### PR TITLE
feat: add interactive map screen with geolocalized shot notes (#58)

### DIFF
--- a/src/components/map/MapFilterBar.tsx
+++ b/src/components/map/MapFilterBar.tsx
@@ -1,6 +1,7 @@
-import { X } from "lucide-react";
+import { Crosshair, X } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
 import type { Film, FilmType } from "@/types";
 import { filmName } from "@/utils/film-helpers";
@@ -13,6 +14,7 @@ interface MapFilterBarProps {
 	onFilterFilm: (id: string | null) => void;
 	onFilterType: (type: FilmType | null) => void;
 	onClearFilter: () => void;
+	onRecenter: () => void;
 }
 
 const FILM_TYPES: FilmType[] = ["Couleur", "N&B", "Diapo", "ECN-2"];
@@ -24,6 +26,7 @@ export function MapFilterBar({
 	onFilterFilm,
 	onFilterType,
 	onClearFilter,
+	onRecenter,
 }: MapFilterBarProps) {
 	const { t } = useTranslation();
 
@@ -33,23 +36,34 @@ export function MapFilterBar({
 	);
 
 	return (
-		<div className="absolute top-3 left-3 right-3 z-10 flex flex-col gap-2">
-			{/* Film type filter */}
-			<div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide">
-				<Chip active={filterType == null} onClick={() => onFilterType(null)} className="shrink-0 text-xs shadow-md">
-					{t("map.allTypes")}
-				</Chip>
-				{FILM_TYPES.map((type) => (
-					<Chip
-						key={type}
-						active={filterType === type}
-						onClick={() => onFilterType(filterType === type ? null : type)}
-						className="shrink-0 text-xs shadow-md"
-					>
-						<div className="w-2 h-2 rounded-full" style={{ backgroundColor: MARKER_COLORS[type] }} />
-						{t(`filmTypes.${type}`, type)}
+		<div className="absolute top-[max(0.75rem,env(safe-area-inset-top))] left-3 right-3 z-10 flex flex-col gap-2">
+			{/* Film type filter + recenter */}
+			<div className="flex items-center gap-1.5">
+				<div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide flex-1 min-w-0">
+					<Chip active={filterType == null} onClick={() => onFilterType(null)} className="shrink-0 text-xs shadow-md">
+						{t("map.allTypes")}
 					</Chip>
-				))}
+					{FILM_TYPES.map((type) => (
+						<Chip
+							key={type}
+							active={filterType === type}
+							onClick={() => onFilterType(filterType === type ? null : type)}
+							className="shrink-0 text-xs shadow-md"
+						>
+							<div className="w-2 h-2 rounded-full" style={{ backgroundColor: MARKER_COLORS[type] }} />
+							{t(`filmTypes.${type}`, type)}
+						</Chip>
+					))}
+				</div>
+				<Button
+					variant="outline"
+					size="icon"
+					onClick={onRecenter}
+					className="shrink-0 shadow-md bg-card/90 backdrop-blur h-[44px] w-[44px]"
+					aria-label={t("map.recenter")}
+				>
+					<Crosshair size={18} className="text-text-sec" />
+				</Button>
 			</div>
 
 			{/* Film filter */}

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,5 +1,5 @@
 import "maplibre-gl/dist/maplibre-gl.css";
-import { Crosshair, MapPin } from "lucide-react";
+import { MapPin } from "lucide-react";
 import maplibregl from "maplibre-gl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -21,21 +21,6 @@ interface MapScreenProps {
 	setSelectedFilm: (id: string) => void;
 	filterFilmId: string | null;
 	onClearFilter: () => void;
-}
-
-function RecenterButton({ onClick }: { onClick: () => void }) {
-	const { t } = useTranslation();
-	return (
-		<Button
-			variant="outline"
-			size="icon"
-			onClick={onClick}
-			className="absolute bottom-20 right-3 z-10 shadow-lg bg-card/90 backdrop-blur"
-			aria-label={t("map.recenter")}
-		>
-			<Crosshair size={18} className="text-text-sec" />
-		</Button>
-	);
 }
 
 export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onClearFilter }: MapScreenProps) {
@@ -149,9 +134,8 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 				onFilterFilm={setLocalFilterFilmId}
 				onFilterType={setFilterType}
 				onClearFilter={onClearFilter}
+				onRecenter={handleRecenter}
 			/>
-
-			<RecenterButton onClick={handleRecenter} />
 
 			{selectedNote && (
 				<NoteSheet geoNote={selectedNote} onClose={() => setSelectedNote(null)} onViewFilm={handleViewFilm} />


### PR DESCRIPTION
## Summary

- Add a new **"Carte"** tab (5th tab) with a full-screen MapLibre GL JS map displaying markers for all geolocalized shot notes
- Markers colored by film type (Couleur=amber, N&B=gray, Diapo=blue, ECN-2=red) with grid-based clustering
- Bottom sheet on marker click showing frame number, film name, aperture/speed, photo, and link to film detail
- Filter chips overlay (by film type + by individual film) with recenter button
- Cross-navigation: "Voir sur la carte" button in ShotNotesSection when notes have GPS data
- Dark tiles (CartoDB Dark Matter) in dark mode, light tiles (Voyager) in light mode
- Lazy-loaded via `React.lazy()` — MapScreen in separate chunk (24KB + 1MB MapLibre on demand)
- Respects safe-area-inset for notched devices

### Files added
- `src/screens/MapScreen.tsx` — screen orchestrator
- `src/components/map/NoteMarker.tsx` — marker component
- `src/components/map/NoteSheet.tsx` — single note bottom sheet
- `src/components/map/ClusterSheet.tsx` — cluster bottom sheet
- `src/components/map/MapFilterBar.tsx` — filter bar + recenter button
- `src/utils/map-helpers.ts` — types, constants, clustering, fitBounds

### Files modified
- `src/types.ts` — add `"map"` to `ScreenName`
- `src/components/TabBar.tsx` — add Map tab
- `src/App.tsx` — lazy routing, full-screen layout, filter state
- `src/screens/FilmDetailScreen.tsx` — pass `onNavigateToMap`
- `src/components/ShotNotesSection.tsx` — "Voir sur la carte" button
- `src/locales/fr.ts` / `en.ts` — map screen i18n keys

## Test plan
- [ ] Map displays with dark tiles in dark mode, light in light mode
- [ ] Markers appear at correct GPS coordinates
- [ ] Markers colored correctly by film type
- [ ] Clustering works when zoomed out, expands on click
- [ ] Bottom sheet shows note details on marker click
- [ ] "Voir la pellicule" navigates to FilmDetailScreen
- [ ] Filter chips filter markers by type and by film
- [ ] Recenter button fits all markers in view
- [ ] "Voir sur la carte" from FilmDetail opens map filtered on that film
- [ ] Navigating to map via TabBar shows unfiltered view
- [ ] EmptyState shown when no geolocalized notes exist
- [ ] Safe area respected on notched devices
- [ ] 5 tabs display correctly on mobile and desktop

https://claude.ai/code/session_017iPe8DGrKHZxgUoWotEQmL