### PR TITLE
feat: add photo viewer modal on all photo thumbnails

### DIFF
--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -1,6 +1,7 @@
 import { Camera, Plus, X } from "lucide-react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { PhotoViewer } from "@/components/PhotoViewer";
 import { useToast } from "@/components/Toast";
 import { Button } from "@/components/ui/button";
 import { compressImage, estimateStorageUsage } from "@/utils/image";
@@ -18,6 +19,7 @@ export function PhotoPicker({ photos, onChange, max = 3, size = 64, placeholderI
 	const { t } = useTranslation();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const { toast } = useToast();
+	const [viewerIndex, setViewerIndex] = useState<number | null>(null);
 
 	const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
@@ -56,7 +58,13 @@ export function PhotoPicker({ photos, onChange, max = 3, size = 64, placeholderI
 			<div className="flex items-center gap-2 flex-wrap">
 				{photos.map((photo, i) => (
 					<div key={photo.slice(-20)} className="relative group" style={{ width: size, height: size }}>
-						<img src={photo} alt="" className="w-full h-full rounded-lg object-cover border border-border" />
+						<img
+							src={photo}
+							alt=""
+							className="w-full h-full rounded-lg object-cover border border-border cursor-pointer"
+							onClick={() => setViewerIndex(i)}
+							onKeyDown={undefined}
+						/>
 						<Button
 							variant="destructive"
 							onClick={() => remove(i)}
@@ -103,6 +111,9 @@ export function PhotoPicker({ photos, onChange, max = 3, size = 64, placeholderI
 				)}
 			</div>
 			<input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={handleFile} />
+			{viewerIndex !== null && (
+				<PhotoViewer photos={photos} initialIndex={viewerIndex} onClose={() => setViewerIndex(null)} />
+			)}
 		</div>
 	);
 }

--- a/src/components/PhotoPicker.tsx
+++ b/src/components/PhotoPicker.tsx
@@ -58,13 +58,19 @@ export function PhotoPicker({ photos, onChange, max = 3, size = 64, placeholderI
 			<div className="flex items-center gap-2 flex-wrap">
 				{photos.map((photo, i) => (
 					<div key={photo.slice(-20)} className="relative group" style={{ width: size, height: size }}>
-						<img
-							src={photo}
-							alt=""
-							className="w-full h-full rounded-lg object-cover border border-border cursor-pointer"
+						<button
+							type="button"
 							onClick={() => setViewerIndex(i)}
-							onKeyDown={undefined}
-						/>
+							aria-label={t("aria.openPhoto", { index: i + 1 })}
+							className="w-full h-full rounded-lg overflow-hidden"
+						>
+							<img
+								src={photo}
+								alt=""
+								aria-hidden="true"
+								className="w-full h-full rounded-lg object-cover border border-border cursor-pointer"
+							/>
+						</button>
 						<Button
 							variant="destructive"
 							onClick={() => remove(i)}

--- a/src/components/equipment/BacksTab.tsx
+++ b/src/components/equipment/BacksTab.tsx
@@ -111,16 +111,22 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 								<div className="flex items-center justify-between">
 									<div className="flex items-center gap-3 flex-1 min-w-0">
 										{b.photo ? (
-											<img
-												src={b.photo}
-												alt=""
-												className="w-10 h-10 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+											<button
+												type="button"
 												onClick={(e) => {
 													e.stopPropagation();
 													setViewerPhoto(b.photo!);
 												}}
-												onKeyDown={undefined}
-											/>
+												aria-label={t("aria.openPhoto", { index: 1 })}
+												className="w-10 h-10 rounded-lg overflow-hidden shrink-0"
+											>
+												<img
+													src={b.photo}
+													alt=""
+													aria-hidden="true"
+													className="w-full h-full object-cover border border-border cursor-pointer"
+												/>
+											</button>
 										) : (
 											<div className="w-10 h-10 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
 												<Camera size={16} className="text-text-muted opacity-40" />

--- a/src/components/equipment/BacksTab.tsx
+++ b/src/components/equipment/BacksTab.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
 import { PhotoPicker } from "@/components/PhotoPicker";
+import { PhotoViewer } from "@/components/PhotoViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -35,6 +36,7 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 		photo: undefined as string | undefined,
 	});
 	const [editBack, setEditBack] = useState<Back | null>(null);
+	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 
 	const interchangeableCameras = data.cameras.filter((c) => c.hasInterchangeableBack);
 
@@ -112,7 +114,12 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 											<img
 												src={b.photo}
 												alt=""
-												className="w-10 h-10 rounded-lg object-cover shrink-0 border border-border"
+												className="w-10 h-10 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+												onClick={(e) => {
+													e.stopPropagation();
+													setViewerPhoto(b.photo!);
+												}}
+												onKeyDown={undefined}
 											/>
 										) : (
 											<div className="w-10 h-10 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
@@ -327,6 +334,8 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 					)}
 				</DialogContent>
 			</Dialog>
+
+			{viewerPhoto && <PhotoViewer photos={[viewerPhoto]} initialIndex={0} onClose={() => setViewerPhoto(null)} />}
 		</>
 	);
 }

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
 import { PhotoPicker } from "@/components/PhotoPicker";
+import { PhotoViewer } from "@/components/PhotoViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -41,6 +42,7 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 		apertureStops: "" as string,
 	});
 	const [editCam, setEditCam] = useState<(CameraType & { mount?: string | null }) | null>(null);
+	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 
 	const addCamera = () => {
 		if (!newCam.brand && !newCam.model) return;
@@ -133,7 +135,12 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 											<img
 												src={cam.photo}
 												alt=""
-												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border"
+												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+												onClick={(e) => {
+													e.stopPropagation();
+													setViewerPhoto(cam.photo!);
+												}}
+												onKeyDown={undefined}
 											/>
 										) : (
 											<div className="w-12 h-12 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
@@ -503,6 +510,8 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 					)}
 				</DialogContent>
 			</Dialog>
+
+			{viewerPhoto && <PhotoViewer photos={[viewerPhoto]} initialIndex={0} onClose={() => setViewerPhoto(null)} />}
 		</>
 	);
 }

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -132,16 +132,22 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 								<div className="flex items-center justify-between">
 									<div className="flex items-center gap-3">
 										{cam.photo ? (
-											<img
-												src={cam.photo}
-												alt=""
-												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+											<button
+												type="button"
 												onClick={(e) => {
 													e.stopPropagation();
 													setViewerPhoto(cam.photo!);
 												}}
-												onKeyDown={undefined}
-											/>
+												aria-label={t("aria.openPhoto", { index: 1 })}
+												className="w-12 h-12 rounded-lg overflow-hidden shrink-0"
+											>
+												<img
+													src={cam.photo}
+													alt=""
+													aria-hidden="true"
+													className="w-full h-full object-cover border border-border cursor-pointer"
+												/>
+											</button>
 										) : (
 											<div className="w-12 h-12 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
 												<Camera size={20} className="text-text-muted opacity-40" />

--- a/src/components/equipment/LensesTab.tsx
+++ b/src/components/equipment/LensesTab.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
 import { PhotoPicker } from "@/components/PhotoPicker";
+import { PhotoViewer } from "@/components/PhotoViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -90,6 +91,7 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 	const [newLens, setNewLens] = useState<LensFormData>(emptyLensForm);
 	const [editLensId, setEditLensId] = useState<string | null>(null);
 	const [editLens, setEditLens] = useState<LensFormData>(emptyLensForm);
+	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 
 	const formToLens = (form: LensFormData, id: string): Lens => {
 		const fMin = Number.parseInt(form.focalLengthMin, 10);
@@ -425,7 +427,12 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 											<img
 												src={lens.photo}
 												alt=""
-												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border"
+												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+												onClick={(e) => {
+													e.stopPropagation();
+													setViewerPhoto(lens.photo!);
+												}}
+												onKeyDown={undefined}
 											/>
 										) : (
 											<div className="w-12 h-12 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
@@ -507,6 +514,8 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 					{renderForm(editLens, setEditLens, saveEditLens, true)}
 				</DialogContent>
 			</Dialog>
+
+			{viewerPhoto && <PhotoViewer photos={[viewerPhoto]} initialIndex={0} onClose={() => setViewerPhoto(null)} />}
 		</>
 	);
 }

--- a/src/components/equipment/LensesTab.tsx
+++ b/src/components/equipment/LensesTab.tsx
@@ -424,16 +424,22 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 								<div className="flex items-center justify-between">
 									<div className="flex items-center gap-3">
 										{lens.photo ? (
-											<img
-												src={lens.photo}
-												alt=""
-												className="w-12 h-12 rounded-lg object-cover shrink-0 border border-border cursor-pointer"
+											<button
+												type="button"
 												onClick={(e) => {
 													e.stopPropagation();
 													setViewerPhoto(lens.photo!);
 												}}
-												onKeyDown={undefined}
-											/>
+												aria-label={t("aria.openPhoto", { index: 1 })}
+												className="w-12 h-12 rounded-lg overflow-hidden shrink-0"
+											>
+												<img
+													src={lens.photo}
+													alt=""
+													aria-hidden="true"
+													className="w-full h-full object-cover border border-border cursor-pointer"
+												/>
+											</button>
 										) : (
 											<div className="w-12 h-12 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
 												<Focus size={20} className="text-text-muted opacity-40" />

--- a/src/components/map/NoteSheet.tsx
+++ b/src/components/map/NoteSheet.tsx
@@ -58,13 +58,14 @@ export function NoteSheet({ geoNote, onClose, onViewFilm }: NoteSheetProps) {
 
 						{note.photo && (
 							<div className="mb-3 rounded-lg overflow-hidden">
-								<img
-									src={note.photo}
-									alt=""
-									className="w-full h-32 object-cover cursor-pointer"
+								<button
+									type="button"
+									className="block w-full"
 									onClick={() => setShowViewer(true)}
-									onKeyDown={undefined}
-								/>
+									aria-label={t("aria.openPhoto", { index: 1 })}
+								>
+									<img src={note.photo} alt="" aria-hidden="true" className="w-full h-32 object-cover cursor-pointer" />
+								</button>
 							</div>
 						)}
 

--- a/src/components/map/NoteSheet.tsx
+++ b/src/components/map/NoteSheet.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { PhotoViewer } from "@/components/PhotoViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { filmName } from "@/utils/film-helpers";
@@ -15,54 +17,67 @@ export function NoteSheet({ geoNote, onClose, onViewFilm }: NoteSheetProps) {
 	const { t } = useTranslation();
 	const { note, film } = geoNote;
 	const name = filmName(film);
+	const [showViewer, setShowViewer] = useState(false);
 
 	return (
-		<div className="absolute bottom-0 left-0 right-0 z-20 animate-slide-up">
-			<div className="bg-card border-t border-border rounded-t-2xl shadow-2xl mx-auto max-w-lg w-full">
-				<div className="flex justify-center pt-2 pb-1">
-					<div className="w-10 h-1 rounded-full bg-border" />
-				</div>
-				<div className="px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
-					<div className="flex items-start justify-between gap-3 mb-3">
-						<div className="min-w-0 flex-1">
-							<div className="flex items-center gap-2 mb-1">
-								{note.frameNumber != null && (
-									<Badge
-										style={{
-											color: "var(--color-text-primary)",
-											background: "var(--color-accent-soft)",
-											fontFamily: "var(--font-mono)",
-										}}
-									>
-										#{note.frameNumber}
-									</Badge>
+		<>
+			<div className="absolute bottom-0 left-0 right-0 z-20 animate-slide-up">
+				<div className="bg-card border-t border-border rounded-t-2xl shadow-2xl mx-auto max-w-lg w-full">
+					<div className="flex justify-center pt-2 pb-1">
+						<div className="w-10 h-1 rounded-full bg-border" />
+					</div>
+					<div className="px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+						<div className="flex items-start justify-between gap-3 mb-3">
+							<div className="min-w-0 flex-1">
+								<div className="flex items-center gap-2 mb-1">
+									{note.frameNumber != null && (
+										<Badge
+											style={{
+												color: "var(--color-text-primary)",
+												background: "var(--color-accent-soft)",
+												fontFamily: "var(--font-mono)",
+											}}
+										>
+											#{note.frameNumber}
+										</Badge>
+									)}
+									<span className="text-sm font-semibold text-text-primary truncate">{name}</span>
+								</div>
+								{(note.aperture || note.shutterSpeed) && (
+									<p className="text-xs text-text-sec">
+										{[note.aperture, note.shutterSpeed].filter(Boolean).join(" · ")}
+									</p>
 								)}
-								<span className="text-sm font-semibold text-text-primary truncate">{name}</span>
+								{note.location && <p className="text-xs text-text-muted mt-0.5 truncate">{note.location}</p>}
+								{note.lens && <p className="text-xs text-text-muted truncate">{note.lens}</p>}
 							</div>
-							{(note.aperture || note.shutterSpeed) && (
-								<p className="text-xs text-text-sec">
-									{[note.aperture, note.shutterSpeed].filter(Boolean).join(" · ")}
-								</p>
-							)}
-							{note.location && <p className="text-xs text-text-muted mt-0.5 truncate">{note.location}</p>}
-							{note.lens && <p className="text-xs text-text-muted truncate">{note.lens}</p>}
+							<Button variant="ghost" size="icon" onClick={onClose} className="shrink-0 -mt-1 -mr-2">
+								<X size={18} className="text-text-muted" />
+							</Button>
 						</div>
-						<Button variant="ghost" size="icon" onClick={onClose} className="shrink-0 -mt-1 -mr-2">
-							<X size={18} className="text-text-muted" />
+
+						{note.photo && (
+							<div className="mb-3 rounded-lg overflow-hidden">
+								<img
+									src={note.photo}
+									alt=""
+									className="w-full h-32 object-cover cursor-pointer"
+									onClick={() => setShowViewer(true)}
+									onKeyDown={undefined}
+								/>
+							</div>
+						)}
+
+						<Button variant="outline" className="w-full justify-center" onClick={onViewFilm}>
+							{t("map.viewFilm")}
 						</Button>
 					</div>
-
-					{note.photo && (
-						<div className="mb-3 rounded-lg overflow-hidden">
-							<img src={note.photo} alt="" className="w-full h-32 object-cover" />
-						</div>
-					)}
-
-					<Button variant="outline" className="w-full justify-center" onClick={onViewFilm}>
-						{t("map.viewFilm")}
-					</Button>
 				</div>
 			</div>
-		</div>
+
+			{showViewer && note.photo && (
+				<PhotoViewer photos={[note.photo]} initialIndex={0} onClose={() => setShowViewer(false)} />
+			)}
+		</>
 	);
 }


### PR DESCRIPTION
Allow clicking on any photo thumbnail to open a full-screen viewer.
Covers PhotoPicker (all dialogs), equipment cards (cameras, lenses,
backs), and map note sheet.

https://claude.ai/code/session_01XUVaxhrRD63SUWeFj4G9fx