### PR TITLE
fix: make "+ Shot" button open add shot note dialog on film detail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ function FilmVaultInner() {
 	const [screen, setScreen] = useState<ScreenName>("home");
 	const [selectedFilm, setSelectedFilm] = useState<string | null>(null);
 	const [mapFilterFilmId, setMapFilterFilmId] = useState<string | null>(null);
+	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
 	const [showAddFilm, setShowAddFilm] = useState(false);
 	const [persistent, setPersistent] = useState(false);
 	const [syncing, setSyncing] = useState(false);
@@ -147,7 +148,13 @@ function FilmVaultInner() {
 		switch (screen) {
 			case "home":
 				return (
-					<DashboardScreen data={data} setScreen={setScreen} setSelectedFilm={setSelectedFilm} onAddFilm={onAddFilm} />
+					<DashboardScreen
+						data={data}
+						setScreen={setScreen}
+						setSelectedFilm={setSelectedFilm}
+						onAddFilm={onAddFilm}
+						setAutoOpenShotNote={setAutoOpenShotNote}
+					/>
 				);
 			case "stock":
 				return (
@@ -162,6 +169,8 @@ function FilmVaultInner() {
 						setSelectedFilm={setSelectedFilm}
 						filmId={selectedFilm}
 						onNavigateToMap={navigateToMap}
+						autoOpenShotNote={autoOpenShotNote}
+						setAutoOpenShotNote={setAutoOpenShotNote}
 					/>
 				);
 			case "map":
@@ -200,7 +209,13 @@ function FilmVaultInner() {
 				);
 			default:
 				return (
-					<DashboardScreen data={data} setScreen={setScreen} setSelectedFilm={setSelectedFilm} onAddFilm={onAddFilm} />
+					<DashboardScreen
+						data={data}
+						setScreen={setScreen}
+						setSelectedFilm={setSelectedFilm}
+						onAddFilm={onAddFilm}
+						setAutoOpenShotNote={setAutoOpenShotNote}
+					/>
 				);
 		}
 	};

--- a/src/components/ShotNotesSection.tsx
+++ b/src/components/ShotNotesSection.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink, ImageIcon, Loader2, LocateFixed, Map as MapIcon, NotebookPen, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PhotoPicker } from "@/components/PhotoPicker";
 import { useToast } from "@/components/Toast";
@@ -24,6 +24,8 @@ interface ShotNotesSectionProps {
 	lenses?: Lens[];
 	onUpdateNotes: (notes: ShotNote[]) => void;
 	onNavigateToMap?: () => void;
+	autoOpenShotNote?: boolean;
+	onAutoOpenConsumed?: () => void;
 }
 
 function formatNoteSummary(note: ShotNote): string {
@@ -124,7 +126,15 @@ function nextFrameNumber(notes: ShotNote[], posesTotal?: number | null): string 
 	return String(next);
 }
 
-function ShotNotesSection({ film, cameras, lenses, onUpdateNotes, onNavigateToMap }: ShotNotesSectionProps) {
+function ShotNotesSection({
+	film,
+	cameras,
+	lenses,
+	onUpdateNotes,
+	onNavigateToMap,
+	autoOpenShotNote,
+	onAutoOpenConsumed,
+}: ShotNotesSectionProps) {
 	const { t } = useTranslation();
 	const { toast } = useToast();
 	const [dialogOpen, setDialogOpen] = useState(false);
@@ -156,7 +166,7 @@ function ShotNotesSection({ film, cameras, lenses, onUpdateNotes, onNavigateToMa
 
 	const [gpsLoading, setGpsLoading] = useState(false);
 
-	const openAdd = () => {
+	const openAdd = useCallback(() => {
 		setEditingId(null);
 		setForm({
 			...emptyForm,
@@ -166,7 +176,14 @@ function ShotNotesSection({ film, cameras, lenses, onUpdateNotes, onNavigateToMa
 			date: nowDateTimeLocal(),
 		});
 		setDialogOpen(true);
-	};
+	}, [film.lens, film.lensId, film.posesTotal, notes]);
+
+	useEffect(() => {
+		if (autoOpenShotNote) {
+			openAdd();
+			onAutoOpenConsumed?.();
+		}
+	}, [autoOpenShotNote, openAdd, onAutoOpenConsumed]);
 
 	const openEdit = (note: ShotNote) => {
 		setEditingId(note.id);

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -15,6 +15,7 @@ interface DashboardScreenProps {
 	setScreen: (screen: ScreenName) => void;
 	setSelectedFilm: (id: string) => void;
 	onAddFilm: () => void;
+	setAutoOpenShotNote?: (open: boolean) => void;
 }
 
 interface EquipmentItem {
@@ -83,7 +84,13 @@ function buildEquipmentItems(cameras: CameraType[], backs: Back[], activeFilms: 
 	return items;
 }
 
-export function DashboardScreen({ data, setScreen, setSelectedFilm, onAddFilm }: DashboardScreenProps) {
+export function DashboardScreen({
+	data,
+	setScreen,
+	setSelectedFilm,
+	onAddFilm,
+	setAutoOpenShotNote,
+}: DashboardScreenProps) {
 	const { t } = useTranslation();
 	const { films, cameras, backs } = data;
 
@@ -170,6 +177,7 @@ export function DashboardScreen({ data, setScreen, setSelectedFilm, onAddFilm }:
 									camera={cam}
 									back={back}
 									onShotClick={() => {
+										setAutoOpenShotNote?.(true);
 										setSelectedFilm(f.id);
 										setScreen("filmDetail");
 									}}

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -90,6 +90,8 @@ interface FilmDetailScreenProps {
 	setSelectedFilm: (id: string) => void;
 	filmId: string | null;
 	onNavigateToMap?: (filmId: string) => void;
+	autoOpenShotNote?: boolean;
+	setAutoOpenShotNote?: (open: boolean) => void;
 }
 
 export function FilmDetailScreen({
@@ -99,6 +101,8 @@ export function FilmDetailScreen({
 	setSelectedFilm,
 	filmId,
 	onNavigateToMap,
+	autoOpenShotNote,
+	setAutoOpenShotNote,
 }: FilmDetailScreenProps) {
 	const { t } = useTranslation();
 	const film = data.films.find((f) => f.id === filmId);
@@ -291,6 +295,8 @@ export function FilmDetailScreen({
 					lenses={data.lenses}
 					onUpdateNotes={(notes) => updateFilm({ shotNotes: notes })}
 					onNavigateToMap={onNavigateToMap ? () => onNavigateToMap(film.id) : undefined}
+					autoOpenShotNote={autoOpenShotNote}
+					onAutoOpenConsumed={() => setAutoOpenShotNote?.(false)}
 				/>
 			)}
 


### PR DESCRIPTION
The "+ Shot" button on ActiveRollCard was doing the same action as clicking
the card itself (just navigating to FilmDetailScreen). Now it sets an
autoOpenShotNote flag that triggers the add shot note dialog to open
automatically when the FilmDetailScreen renders.

https://claude.ai/code/session_014Xe1XHjUiiRm3tk3vfXtKG