### PR TITLE
fix: preserve camera/back info when finishing or partially removing a film

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -31,7 +31,7 @@ function buildEquipmentItems(cameras: CameraType[], backs: Back[], activeFilms: 
 
 	for (const cam of cameras) {
 		if (!cam.hasInterchangeableBack) {
-			const film = activeFilms.find((f) => f.cameraId === cam.id) || null;
+			const film = activeFilms.find((f) => f.state === "loaded" && f.cameraId === cam.id) || null;
 			items.push({
 				key: `cam-${cam.id}`,
 				label: cameraDisplayName(cam),
@@ -42,7 +42,7 @@ function buildEquipmentItems(cameras: CameraType[], backs: Back[], activeFilms: 
 	}
 
 	for (const back of backs) {
-		const film = activeFilms.find((f) => f.backId === back.id) || null;
+		const film = activeFilms.find((f) => f.state === "loaded" && f.backId === back.id) || null;
 		const cam = film?.cameraId ? cameras.find((c) => c.id === film.cameraId) : null;
 		items.push({
 			key: `back-${back.id}`,
@@ -57,7 +57,7 @@ function buildEquipmentItems(cameras: CameraType[], backs: Back[], activeFilms: 
 		if (cam.hasInterchangeableBack) {
 			const compatibleBacks = backs.filter((b) => b.compatibleCameraIds.includes(cam.id));
 			const hasLoadedBack = activeFilms.some(
-				(f) => f.cameraId === cam.id && compatibleBacks.some((b) => b.id === f.backId),
+				(f) => f.state === "loaded" && f.cameraId === cam.id && compatibleBacks.some((b) => b.id === f.backId),
 			);
 			if (!hasLoadedBack) {
 				items.push({

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -648,8 +648,6 @@ export function FilmDetailScreen({
 										state: "exposed",
 										endDate: actionData.endDate || today(),
 										comment: actionData.comment?.trim() || film.comment,
-										cameraId: null,
-										backId: null,
 										history: [...(film.history || []), { date: today(), action: "", actionCode: "exposed", photos }],
 									},
 									t("filmDetail.filmExposed"),
@@ -704,8 +702,6 @@ export function FilmDetailScreen({
 										state: "partial",
 										posesShot: Number.parseInt(actionData.posesShot || "", 10) || 0,
 										comment: actionData.comment?.trim() || film.comment,
-										cameraId: null,
-										backId: null,
 										history: [
 											...(film.history || []),
 											{


### PR DESCRIPTION
The cameraId and backId were explicitly set to null during "exposed" and
"partial" state transitions, losing the device info for stats and editing.
Now the fields are preserved and the dashboard only shows "loaded" films
as currently in a camera, consistent with CamerasTab behavior.

https://claude.ai/code/session_019zKMVp3qgj96CbxqKKkDpJ