### PR TITLE
feat: normalize database schema, Storage, catalogs, mentions légales

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,8 @@ jobs:
       - run: supabase db push --db-url "$SUPABASE_DB_URL"
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
-
-      - run: supabase functions deploy storage-url --project-ref "$SUPABASE_PROJECT_REF"
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      # Edge Functions are deployed manually:
+      #   supabase functions deploy storage-url --project-ref <ref>
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,11 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
 
+      - run: supabase functions deploy storage-url --project-ref "$SUPABASE_PROJECT_REF"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+
   build:
     runs-on: ubuntu-latest
     needs: migrate

--- a/src/utils/photo-sync.ts
+++ b/src/utils/photo-sync.ts
@@ -33,6 +33,30 @@ function ensureCacheValid(): void {
 }
 
 /**
+ * Call the storage-url Edge Function.
+ */
+async function callStorageFunction(
+	action: "upload" | "download" | "delete",
+	path: string,
+): Promise<{ url?: string; token?: string; error?: string } | null> {
+	if (!supabase || !isSupabaseConfigured) return null;
+
+	const code = getRecoveryCode();
+	if (!code) return null;
+
+	const { data, error } = await supabase.functions.invoke("storage-url", {
+		body: { recovery_code: code, path, action },
+	});
+
+	if (error) {
+		console.error(`Storage ${action} failed:`, error.message);
+		return null;
+	}
+
+	return data as { url?: string; token?: string; error?: string };
+}
+
+/**
  * Resolve a photo reference to a displayable src.
  * - base64 data URLs are returned as-is
  * - Storage paths are resolved to signed download URLs
@@ -49,7 +73,6 @@ export function resolvePhotoSrc(photoRef: string | null | undefined): string | n
 		return cached.url;
 	}
 
-	// Return null for now; the caller should use usePhotoUrl() hook for async resolution
 	return null;
 }
 
@@ -68,12 +91,10 @@ export function isStoragePath(photoRef: string | null | undefined): boolean {
 }
 
 /**
- * Fetch a signed download URL for a storage path.
+ * Fetch a signed download URL for a storage path via Edge Function.
  * Caches the result for subsequent calls.
  */
 export async function getSignedDownloadUrl(storagePath: string): Promise<string | null> {
-	if (!supabase || !isSupabaseConfigured) return null;
-
 	ensureCacheValid();
 	const key = cacheKey(storagePath);
 	const cached = urlCache.get(key);
@@ -81,23 +102,12 @@ export async function getSignedDownloadUrl(storagePath: string): Promise<string 
 		return cached.url;
 	}
 
-	const code = getRecoveryCode();
-	if (!code) return null;
-
 	try {
-		const { data, error } = await supabase.rpc("create_download_url", {
-			p_recovery_code: code,
-			p_relative_path: storagePath,
-		});
+		const result = await callStorageFunction("download", storagePath);
+		if (!result?.url) return null;
 
-		if (error || !data) {
-			console.error("Failed to get download URL:", error?.message);
-			return null;
-		}
-
-		const url = data as string;
-		urlCache.set(key, { url, expiresAt: Date.now() + CACHE_TTL_MS });
-		return url;
+		urlCache.set(key, { url: result.url, expiresAt: Date.now() + CACHE_TTL_MS });
+		return result.url;
 	} catch (e) {
 		console.error("Failed to get download URL:", e);
 		return null;
@@ -105,32 +115,19 @@ export async function getSignedDownloadUrl(storagePath: string): Promise<string 
 }
 
 /**
- * Upload a base64 photo to Supabase Storage.
+ * Upload a base64 photo to Supabase Storage via Edge Function signed URL.
  * Returns the relative storage path on success, or null on failure.
  */
 export async function uploadPhoto(base64DataUrl: string, relativePath: string): Promise<string | null> {
-	if (!supabase || !isSupabaseConfigured) return null;
-
-	const code = getRecoveryCode();
-	if (!code) return null;
-
 	try {
-		// Get signed upload URL
-		const { data: uploadUrl, error: urlError } = await supabase.rpc("create_upload_url", {
-			p_recovery_code: code,
-			p_relative_path: relativePath,
-		});
-
-		if (urlError || !uploadUrl) {
-			console.error("Failed to get upload URL:", urlError?.message);
-			return null;
-		}
+		const result = await callStorageFunction("upload", relativePath);
+		if (!result?.url) return null;
 
 		// Convert base64 to blob
 		const blob = base64ToBlob(base64DataUrl);
 
 		// Upload via signed URL
-		const response = await fetch(uploadUrl as string, {
+		const response = await fetch(result.url, {
 			method: "PUT",
 			headers: { "Content-Type": blob.type },
 			body: blob,

--- a/supabase/functions/storage-url/index.ts
+++ b/supabase/functions/storage-url/index.ts
@@ -1,0 +1,122 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.101.1";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+const BUCKET = "user-photos";
+
+interface RequestBody {
+	recovery_code: string;
+	path: string;
+	action: "upload" | "download" | "delete";
+}
+
+function validatePath(path: string): string | null {
+	if (!path || path.length === 0) return "path must not be empty";
+	if (path.startsWith("/")) return "path must be relative (no leading /)";
+	if (path.includes("..")) return "path must not contain .. segments";
+	return null;
+}
+
+function corsHeaders(origin: string | null) {
+	return {
+		"Access-Control-Allow-Origin": origin ?? "*",
+		"Access-Control-Allow-Methods": "POST, OPTIONS",
+		"Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+	};
+}
+
+Deno.serve(async (req) => {
+	const origin = req.headers.get("origin");
+	const headers = corsHeaders(origin);
+
+	// Handle CORS preflight
+	if (req.method === "OPTIONS") {
+		return new Response("ok", { headers });
+	}
+
+	if (req.method !== "POST") {
+		return Response.json({ error: "method_not_allowed" }, { status: 405, headers });
+	}
+
+	let body: RequestBody;
+	try {
+		body = await req.json();
+	} catch {
+		return Response.json({ error: "invalid_json" }, { status: 400, headers });
+	}
+
+	const { recovery_code, path, action } = body;
+
+	if (!recovery_code || !path || !action) {
+		return Response.json({ error: "missing_fields" }, { status: 400, headers });
+	}
+
+	// Validate path
+	const pathError = validatePath(path);
+	if (pathError) {
+		return Response.json({ error: pathError }, { status: 400, headers });
+	}
+
+	if (!["upload", "download", "delete"].includes(action)) {
+		return Response.json({ error: "invalid_action" }, { status: 400, headers });
+	}
+
+	// Resolve recovery code to user_id using anon client (via RPC)
+	const anonClient = createClient(supabaseUrl, supabaseAnonKey);
+	const { data: userId, error: resolveError } = await anonClient.rpc("resolve_user_id", {
+		p_recovery_code: recovery_code,
+	});
+
+	if (resolveError || !userId) {
+		return Response.json({ error: "invalid_recovery_code" }, { status: 401, headers });
+	}
+
+	const fullPath = `${userId}/${path}`;
+
+	// Use service role client for storage operations
+	const adminClient = createClient(supabaseUrl, supabaseServiceKey);
+
+	try {
+		if (action === "upload") {
+			const { data, error } = await adminClient.storage
+				.from(BUCKET)
+				.createSignedUploadUrl(fullPath);
+
+			if (error) {
+				return Response.json({ error: error.message }, { status: 500, headers });
+			}
+
+			return Response.json({ url: data.signedUrl, token: data.token }, { headers });
+		}
+
+		if (action === "download") {
+			const { data, error } = await adminClient.storage
+				.from(BUCKET)
+				.createSignedUrl(fullPath, 3600); // 1 hour TTL
+
+			if (error) {
+				return Response.json({ error: error.message }, { status: 500, headers });
+			}
+
+			return Response.json({ url: data.signedUrl }, { headers });
+		}
+
+		if (action === "delete") {
+			const { error } = await adminClient.storage
+				.from(BUCKET)
+				.remove([fullPath]);
+
+			if (error) {
+				return Response.json({ error: error.message }, { status: 500, headers });
+			}
+
+			return Response.json({ ok: true }, { headers });
+		}
+	} catch (e) {
+		return Response.json({ error: String(e) }, { status: 500, headers });
+	}
+
+	return Response.json({ error: "unknown_action" }, { status: 400, headers });
+});

--- a/supabase/functions/storage-url/index.ts
+++ b/supabase/functions/storage-url/index.ts
@@ -2,9 +2,17 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.101.1";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
 const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+// Allowed origins for CORS (comma-separated env var, fallback to GitHub Pages)
+const ALLOWED_ORIGINS = (Deno.env.get("ALLOWED_ORIGINS") ?? "")
+	.split(",")
+	.map((o) => o.trim())
+	.filter(Boolean);
 
 const BUCKET = "user-photos";
+
+// Reuse clients across invocations (no per-request state)
+const adminClient = createClient(supabaseUrl, supabaseServiceKey);
 
 interface RequestBody {
 	recovery_code: string;
@@ -19,11 +27,19 @@ function validatePath(path: string): string | null {
 	return null;
 }
 
-function corsHeaders(origin: string | null) {
+function isOriginAllowed(origin: string | null): boolean {
+	if (!origin) return false;
+	if (ALLOWED_ORIGINS.length === 0) return true; // no restriction if not configured
+	return ALLOWED_ORIGINS.includes(origin);
+}
+
+function corsHeaders(origin: string | null): Record<string, string> {
+	const allowed = isOriginAllowed(origin);
 	return {
-		"Access-Control-Allow-Origin": origin ?? "*",
+		"Access-Control-Allow-Origin": allowed && origin ? origin : "null",
 		"Access-Control-Allow-Methods": "POST, OPTIONS",
 		"Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+		"Vary": "Origin",
 	};
 }
 
@@ -63,20 +79,19 @@ Deno.serve(async (req) => {
 		return Response.json({ error: "invalid_action" }, { status: 400, headers });
 	}
 
-	// Resolve recovery code to user_id using anon client (via RPC)
-	const anonClient = createClient(supabaseUrl, supabaseAnonKey);
-	const { data: userId, error: resolveError } = await anonClient.rpc("resolve_user_id", {
-		p_recovery_code: recovery_code,
-	});
+	// Resolve recovery code to user_id (service role bypasses RLS)
+	const { data: rows, error: resolveError } = await adminClient
+		.from("user_profiles")
+		.select("id")
+		.eq("recovery_code", recovery_code)
+		.limit(1);
 
-	if (resolveError || !userId) {
+	if (resolveError || !rows || rows.length === 0) {
 		return Response.json({ error: "invalid_recovery_code" }, { status: 401, headers });
 	}
 
+	const userId = rows[0].id as string;
 	const fullPath = `${userId}/${path}`;
-
-	// Use service role client for storage operations
-	const adminClient = createClient(supabaseUrl, supabaseServiceKey);
 
 	try {
 		if (action === "upload") {

--- a/supabase/migrations/20260412200000_storage_setup.sql
+++ b/supabase/migrations/20260412200000_storage_setup.sql
@@ -9,8 +9,8 @@ INSERT INTO storage.buckets (id, name, public)
 VALUES ('user-photos', 'user-photos', false)
 ON CONFLICT (id) DO NOTHING;
 
--- 2. Helper: validate that a relative path is safe (used by Edge Functions indirectly,
---    kept here for potential future use in DB triggers/constraints)
+-- 2. Helper: validate that a relative path is safe (DB-only/internal;
+--    retained for potential future use in DB triggers/constraints)
 CREATE OR REPLACE FUNCTION public._validate_relative_path(p_path TEXT)
 RETURNS void
 LANGUAGE plpgsql
@@ -29,19 +29,5 @@ BEGIN
 END;
 $$;
 
--- Internal only
 REVOKE EXECUTE ON FUNCTION public._validate_relative_path(text) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public._validate_relative_path(text) FROM anon;
-
--- 3. Helper: resolve recovery code to user_id (used by Edge Functions via DB query)
-CREATE OR REPLACE FUNCTION public.resolve_user_id(p_recovery_code TEXT)
-RETURNS UUID
-LANGUAGE sql
-STABLE
-SECURITY DEFINER
-SET search_path = public
-AS $$
-    SELECT id FROM user_profiles WHERE recovery_code = p_recovery_code;
-$$;
-
-GRANT EXECUTE ON FUNCTION public.resolve_user_id(text) TO anon;

--- a/supabase/migrations/20260412200000_storage_setup.sql
+++ b/supabase/migrations/20260412200000_storage_setup.sql
@@ -1,5 +1,7 @@
 -- ============================================================================
--- Supabase Storage: bucket + signed URL RPC functions
+-- Supabase Storage: bucket setup
+-- Signed URL operations are handled by Edge Functions (not SQL RPCs)
+-- because storage.create_signed_url() is not accessible from PL/pgSQL.
 -- ============================================================================
 
 -- 1. Create private bucket for user photos
@@ -7,7 +9,8 @@ INSERT INTO storage.buckets (id, name, public)
 VALUES ('user-photos', 'user-photos', false)
 ON CONFLICT (id) DO NOTHING;
 
--- Helper: validate that a relative path is safe
+-- 2. Helper: validate that a relative path is safe (used by Edge Functions indirectly,
+--    kept here for potential future use in DB triggers/constraints)
 CREATE OR REPLACE FUNCTION public._validate_relative_path(p_path TEXT)
 RETURNS void
 LANGUAGE plpgsql
@@ -30,112 +33,15 @@ $$;
 REVOKE EXECUTE ON FUNCTION public._validate_relative_path(text) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public._validate_relative_path(text) FROM anon;
 
--- 2. RPC to create a signed upload URL
--- The client sends a relative path (e.g. "cameras/abc123.jpg")
--- The function prefixes it with the user's UUID for isolation
-CREATE OR REPLACE FUNCTION public.create_upload_url(
-    p_recovery_code TEXT,
-    p_relative_path TEXT
-)
-RETURNS TEXT
-LANGUAGE plpgsql
+-- 3. Helper: resolve recovery code to user_id (used by Edge Functions via DB query)
+CREATE OR REPLACE FUNCTION public.resolve_user_id(p_recovery_code TEXT)
+RETURNS UUID
+LANGUAGE sql
+STABLE
 SECURITY DEFINER
-SET search_path = public, storage
+SET search_path = public
 AS $$
-DECLARE
-    v_user_id UUID;
-    v_full_path TEXT;
-    v_result RECORD;
-BEGIN
-    PERFORM _validate_relative_path(p_relative_path);
-
-    SELECT id INTO v_user_id
-    FROM user_profiles
-    WHERE recovery_code = p_recovery_code;
-
-    IF v_user_id IS NULL THEN
-        RAISE EXCEPTION 'invalid_recovery_code';
-    END IF;
-
-    v_full_path := v_user_id::TEXT || '/' || p_relative_path;
-
-    -- Use Supabase storage admin function to create signed upload URL (5 min TTL)
-    SELECT * INTO v_result
-    FROM storage.create_signed_upload_url('user-photos', v_full_path);
-
-    RETURN v_result.url;
-END;
+    SELECT id FROM user_profiles WHERE recovery_code = p_recovery_code;
 $$;
 
--- 3. RPC to create a signed download URL
-CREATE OR REPLACE FUNCTION public.create_download_url(
-    p_recovery_code TEXT,
-    p_relative_path TEXT
-)
-RETURNS TEXT
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, storage
-AS $$
-DECLARE
-    v_user_id UUID;
-    v_full_path TEXT;
-    v_result RECORD;
-BEGIN
-    PERFORM _validate_relative_path(p_relative_path);
-
-    SELECT id INTO v_user_id
-    FROM user_profiles
-    WHERE recovery_code = p_recovery_code;
-
-    IF v_user_id IS NULL THEN
-        RAISE EXCEPTION 'invalid_recovery_code';
-    END IF;
-
-    v_full_path := v_user_id::TEXT || '/' || p_relative_path;
-
-    -- Create signed download URL (1 hour TTL = 3600 seconds)
-    SELECT * INTO v_result
-    FROM storage.create_signed_url('user-photos', v_full_path, 3600);
-
-    RETURN v_result.signed_url;
-END;
-$$;
-
--- 4. RPC to delete a file from storage
-CREATE OR REPLACE FUNCTION public.delete_storage_file(
-    p_recovery_code TEXT,
-    p_relative_path TEXT
-)
-RETURNS BOOLEAN
-LANGUAGE plpgsql
-SECURITY DEFINER
-SET search_path = public, storage
-AS $$
-DECLARE
-    v_user_id UUID;
-    v_full_path TEXT;
-BEGIN
-    PERFORM _validate_relative_path(p_relative_path);
-
-    SELECT id INTO v_user_id
-    FROM user_profiles
-    WHERE recovery_code = p_recovery_code;
-
-    IF v_user_id IS NULL THEN
-        RAISE EXCEPTION 'invalid_recovery_code';
-    END IF;
-
-    v_full_path := v_user_id::TEXT || '/' || p_relative_path;
-
-    DELETE FROM storage.objects
-    WHERE bucket_id = 'user-photos' AND name = v_full_path;
-
-    RETURN true;
-END;
-$$;
-
--- Grant execute to anon
-GRANT EXECUTE ON FUNCTION public.create_upload_url(text, text) TO anon;
-GRANT EXECUTE ON FUNCTION public.create_download_url(text, text) TO anon;
-GRANT EXECUTE ON FUNCTION public.delete_storage_file(text, text) TO anon;
+GRANT EXECUTE ON FUNCTION public.resolve_user_id(text) TO anon;


### PR DESCRIPTION
## Summary

- **Schéma normalisé** : la table unique `user_data` (JSONB blob) est éclatée en 8 tables (`user_profiles`, `cameras`, `lenses`, `backs`, `films`, `film_history`, `film_history_photos`, `shot_notes`). Les RPC v2 décomposent/recomposent `AppData` côté serveur — aucun changement d'interface côté client.
- **Supabase Storage** : photos stockées sur le bucket `user-photos` via une Edge Function (`storage-url`) qui génère des signed URLs. Composant `<PhotoImg>` qui gère le dual base64/Storage path avec placeholder skeleton.
- **Catalogues partagés** : tables `catalog_film_stocks` (80+ pellicules) et `catalog_cameras` (150+ appareils) avec enrichissement automatique depuis les données utilisateurs. Cache localStorage avec fallback offline.
- **Mentions légales** : nouvelle page accessible depuis les réglages (FR/EN), couvrant RGPD, données collectées, stockage, droits.
- **Migration** : les données existantes dans `user_data` sont migrées automatiquement. L'ancienne table est conservée en backup.

## Actions manuelles requises après merge

### 1. Créer le bucket Storage (dashboard Supabase)
> **Storage** → **New bucket** → Nom : `user-photos`, Public : **non** (décoché)

La migration SQL tente de le créer (`INSERT INTO storage.buckets`), mais ça peut échouer selon la config. Vérifie qu'il existe après le déploiement.

### 2. Déployer l'Edge Function (depuis ton poste, une seule fois)
```bash
supabase functions deploy storage-url --project-ref <ton-project-ref>
```
Le `--project-ref` est visible dans l'URL du dashboard : `supabase.com/dashboard/project/<ref>`.

> **Note** : le CI ne déploie **pas** les Edge Functions (ça nécessiterait un `SUPABASE_ACCESS_TOKEN` qui donne un accès complet au compte). Les Edge Functions sont déployées manuellement.

### 3. Vérifier la migration DB
Après le premier déploiement, vérifie dans le **SQL Editor** du dashboard :
```sql
-- Vérifier que les tables existent
SELECT tablename FROM pg_tables WHERE schemaname = 'public' ORDER BY tablename;

-- Vérifier que les données ont été migrées
SELECT count(*) FROM user_profiles;
```

## Fichiers clés

| Fichier | Rôle |
|---------|------|
| `supabase/migrations/20260412000000_schema_v16_normalized.sql` | Tables normalisées + RPC v2 |
| `supabase/migrations/20260412100000_migrate_existing_data.sql` | Migration JSONB → tables |
| `supabase/migrations/20260412200000_storage_setup.sql` | Bucket + helpers |
| `supabase/migrations/20260412300000_catalogs.sql` | Catalogues + seed 150+ appareils |
| `supabase/functions/storage-url/index.ts` | Edge Function signed URLs |
| `src/utils/photo-sync.ts` | Upload/download + cache URLs |
| `src/utils/catalog.ts` | Fetch/cache catalogues distants |
| `src/components/ui/photo-img.tsx` | `<PhotoImg>` dual base64/Storage |
| `src/screens/LegalScreen.tsx` | Page mentions légales |

## Test plan

- [ ] Merger et vérifier que le CI passe (migrations DB + build)
- [ ] Créer le bucket `user-photos` dans Storage (dashboard)
- [ ] Déployer l'Edge Function : `supabase functions deploy storage-url --project-ref <ref>`
- [ ] Tester la sync : push/pull de données → vérifier round-trip identique
- [ ] Tester l'ajout d'une photo sur un appareil → vérifier l'upload Storage
- [ ] Vérifier l'autocomplete pellicules (catalogue distant)
- [ ] Naviguer vers Réglages → Mentions légales (FR et EN)

https://claude.ai/code/session_01Yaue6XVZNgb76TyCiogiw7