### PR TITLE
fix: auto-migrate existing base64 photos to Storage on sync

### DIFF
--- a/src/utils/photo-sync.ts
+++ b/src/utils/photo-sync.ts
@@ -63,6 +63,28 @@ export function isStoragePath(photoRef: string | null | undefined): boolean {
 }
 
 /**
+ * Check if AppData contains any base64 photos that should be migrated to Storage.
+ */
+export function hasBase64Photos(data: AppData): boolean {
+	for (const cam of data.cameras) {
+		if (isBase64Photo(cam.photo)) return true;
+	}
+	for (const lens of data.lenses) {
+		if (isBase64Photo(lens.photo)) return true;
+	}
+	for (const back of data.backs) {
+		if (isBase64Photo(back.photo)) return true;
+	}
+	for (const film of data.films) {
+		for (const entry of film.history) {
+			if (entry.photos?.some(isBase64Photo)) return true;
+		}
+		if (film.shotNotes?.some((n) => isBase64Photo(n.photo))) return true;
+	}
+	return false;
+}
+
+/**
  * Fetch a signed download URL for a storage path via Supabase Storage SDK.
  * Caches the result for subsequent calls.
  */

--- a/src/utils/photo-sync.ts
+++ b/src/utils/photo-sync.ts
@@ -63,23 +63,50 @@ export function isStoragePath(photoRef: string | null | undefined): boolean {
 }
 
 /**
+ * Iterate all photo references in AppData.
+ * Shared by hasBase64Photos and extractAndUploadPhotos to stay in sync.
+ */
+interface PhotoRef {
+	value: string;
+	kind: "camera" | "lens" | "back" | "history" | "shot";
+	entityId: string;
+	/** For history photos: "filmId/historyIndex_photoIndex" */
+	subKey?: string;
+}
+
+function* iteratePhotoRefs(data: AppData): Generator<PhotoRef> {
+	for (const cam of data.cameras) {
+		if (cam.photo) yield { value: cam.photo, kind: "camera", entityId: cam.id };
+	}
+	for (const lens of data.lenses) {
+		if (lens.photo) yield { value: lens.photo, kind: "lens", entityId: lens.id };
+	}
+	for (const back of data.backs) {
+		if (back.photo) yield { value: back.photo, kind: "back", entityId: back.id };
+	}
+	for (const film of data.films) {
+		for (let hi = 0; hi < film.history.length; hi++) {
+			const entry = film.history[hi];
+			if (!entry?.photos) continue;
+			for (let pi = 0; pi < entry.photos.length; pi++) {
+				const photo = entry.photos[pi];
+				if (photo) yield { value: photo, kind: "history", entityId: film.id, subKey: `${hi}_${pi}` };
+			}
+		}
+		if (film.shotNotes) {
+			for (const note of film.shotNotes) {
+				if (note.photo) yield { value: note.photo, kind: "shot", entityId: film.id, subKey: note.id };
+			}
+		}
+	}
+}
+
+/**
  * Check if AppData contains any base64 photos that should be migrated to Storage.
  */
 export function hasBase64Photos(data: AppData): boolean {
-	for (const cam of data.cameras) {
-		if (isBase64Photo(cam.photo)) return true;
-	}
-	for (const lens of data.lenses) {
-		if (isBase64Photo(lens.photo)) return true;
-	}
-	for (const back of data.backs) {
-		if (isBase64Photo(back.photo)) return true;
-	}
-	for (const film of data.films) {
-		for (const entry of film.history) {
-			if (entry.photos?.some(isBase64Photo)) return true;
-		}
-		if (film.shotNotes?.some((n) => isBase64Photo(n.photo))) return true;
+	for (const ref of iteratePhotoRefs(data)) {
+		if (isBase64Photo(ref.value)) return true;
 	}
 	return false;
 }

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -1,6 +1,6 @@
 import type { AppData } from "@/types";
 import { applyMigrations, CURRENT_VERSION, validateAppData } from "@/utils/migrations";
-import { clearUrlCache, extractAndUploadPhotos } from "@/utils/photo-sync";
+import { clearUrlCache, extractAndUploadPhotos, hasBase64Photos } from "@/utils/photo-sync";
 import { isSupabaseConfigured, supabase } from "@/utils/supabase";
 
 const RECOVERY_CODE_KEY = "filmvault-recovery-code";
@@ -220,6 +220,10 @@ export async function syncData(
 						? applyMigrations(cloudData as unknown as Record<string, unknown>)
 						: cloudData;
 				setLastSync();
+				// If cloud data has base64 photos, push to migrate them to Storage
+				if (hasBase64Photos(migrated)) {
+					pushToCloud(code, migrated).catch(() => {});
+				}
 				return { data: migrated, source: "cloud" };
 			}
 		}

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -222,7 +222,7 @@ export async function syncData(
 				setLastSync();
 				// If cloud data has base64 photos, push to migrate them to Storage
 				if (hasBase64Photos(migrated)) {
-					pushToCloud(code, migrated).catch(() => {});
+					void pushToCloud(code, migrated);
 				}
 				return { data: migrated, source: "cloud" };
 			}


### PR DESCRIPTION
## Summary

- When cloud data is pulled and contains base64 photos, automatically trigger a background push to upload them to Supabase Storage and replace with relative paths in the DB
- Add `hasBase64Photos()` utility that scans all photo fields in AppData (cameras, lenses, backs, history photos, shot notes)
- Existing users' photos are migrated transparently on next sync without requiring a manual data change

## Test plan

- [ ] Verify that existing base64 photos in the DB get uploaded to Supabase Storage after a sync
- [ ] Verify that photo_path columns in DB contain relative paths (not base64) after migration
- [ ] Verify that photos still display correctly via signed URLs after migration
- [ ] Verify that the migration only triggers when base64 photos are detected (no unnecessary pushes)

https://claude.ai/code/session_016jSjPuSditfNPd7rWwpkRS