### PR TITLE
fix: render PhotoViewer via portal and respect safe area insets

### DIFF
--- a/src/components/PhotoViewer.tsx
+++ b/src/components/PhotoViewer.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { PhotoImg } from "@/components/ui/photo-img";
@@ -45,7 +46,7 @@ export function PhotoViewer({ photos, initialIndex, onClose }: PhotoViewerProps)
 		touchRef.current = null;
 	};
 
-	return (
+	return createPortal(
 		<div
 			className="fixed inset-0 z-[1100] flex flex-col items-center justify-center bg-black/90 backdrop-blur-sm animate-backdrop-fade-in"
 			onClick={onClose}
@@ -58,7 +59,7 @@ export function PhotoViewer({ photos, initialIndex, onClose }: PhotoViewerProps)
 					e.stopPropagation();
 					onClose();
 				}}
-				className="absolute top-4 right-4 z-10 bg-surface-alt/80 rounded-full"
+				className="absolute top-[max(1rem,env(safe-area-inset-top))] right-[max(1rem,env(safe-area-inset-right))] z-10 bg-surface-alt/80 rounded-full"
 				aria-label={t("aria.close")}
 			>
 				<X size={18} className="text-text-primary" />
@@ -122,6 +123,7 @@ export function PhotoViewer({ photos, initialIndex, onClose }: PhotoViewerProps)
 					))}
 				</div>
 			)}
-		</div>
+		</div>,
+		document.body,
 	);
 }


### PR DESCRIPTION
Use createPortal to render the fullscreen photo overlay into document.body,
escaping the CSS transform context of parent DialogContent which was causing
fixed positioning to resolve relative to the modal instead of the viewport.

Also update the close button positioning from fixed top-4/right-4 to use
max(1rem, env(safe-area-inset-*)) so it stays within the safe zone on
devices with a notch or Dynamic Island.

https://claude.ai/code/session_01PtPWEBwSjHeMbgxhHDFSK9