### PR TITLE
Show app header on map screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,9 +245,7 @@ function FilmVaultInner() {
 			<TabBar screen={screen} setScreen={handleSetScreen} variant="sidebar" className="hidden md:flex" />
 
 			<main className="flex-1 flex flex-col min-h-0 min-w-0">
-				{screen !== "map" && (
-					<AppHeader screen={screen} setScreen={handleSetScreen} filmTitle={filmTitle} className="md:hidden" />
-				)}
+				<AppHeader screen={screen} setScreen={handleSetScreen} filmTitle={filmTitle} className="md:hidden" />
 				{screen === "map" ? (
 					<div className="flex-1 min-h-0">{renderScreen()}</div>
 				) : (


### PR DESCRIPTION
The AppHeader was conditionally hidden when the map was displayed.
Remove that condition so the header remains visible on all screens.

https://claude.ai/code/session_016BnRsYAUD9s2xxYzTXM7Xx