### PR TITLE
Afficher le header sur l'écran carte

### DIFF
--- a/src/components/map/ClusterSheet.tsx
+++ b/src/components/map/ClusterSheet.tsx
@@ -19,7 +19,7 @@ export function ClusterSheet({ cluster, onClose, onSelectNote }: ClusterSheetPro
 				<div className="flex justify-center pt-2 pb-1">
 					<div className="w-10 h-1 rounded-full bg-border" />
 				</div>
-				<div className="px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+				<div className="px-4 pb-4">
 					<div className="flex items-center justify-between mb-3">
 						<span className="text-sm font-semibold text-text-primary">
 							{t("map.noteCount", { count: cluster.notes.length })}

--- a/src/components/map/MapFilterBar.tsx
+++ b/src/components/map/MapFilterBar.tsx
@@ -33,7 +33,7 @@ export function MapFilterBar({
 	);
 
 	return (
-		<div className="absolute top-[max(0.75rem,env(safe-area-inset-top))] left-3 right-3 z-10 flex flex-col gap-2">
+		<div className="absolute top-3 left-3 right-3 z-10 flex flex-col gap-2">
 			{/* Film type filter */}
 			<div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide">
 				<Chip active={filterType == null} onClick={() => onFilterType(null)} className="shrink-0 text-xs shadow-md">

--- a/src/components/map/NoteSheet.tsx
+++ b/src/components/map/NoteSheet.tsx
@@ -27,7 +27,7 @@ export function NoteSheet({ geoNote, onClose, onViewFilm }: NoteSheetProps) {
 					<div className="flex justify-center pt-2 pb-1">
 						<div className="w-10 h-1 rounded-full bg-border" />
 					</div>
-					<div className="px-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+					<div className="px-4 pb-4">
 						<div className="flex items-start justify-between gap-3 mb-3">
 							<div className="min-w-0 flex-1">
 								<div className="flex items-center gap-2 mb-1">

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -154,7 +154,7 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 				size="icon"
 				onClick={handleLocateMe}
 				disabled={locating}
-				className="absolute bottom-[max(5rem,calc(4rem+env(safe-area-inset-bottom)))] right-3 z-10 shadow-lg bg-card/90 backdrop-blur"
+				className="absolute bottom-16 right-3 z-10 shadow-lg bg-card/90 backdrop-blur"
 				aria-label={t("map.locateMe")}
 			>
 				{locating ? (


### PR DESCRIPTION
## Summary
- Affiche le `AppHeader` (titre, toggle thème, réglages) sur l'écran carte, qui était auparavant masqué
- Supprime les compensations `safe-area-inset` devenues inutiles sur les overlays de la carte (filtre, bouton localisation, bottom sheets) puisque le header et le TabBar sont maintenant en dehors du conteneur de la carte

## Test plan
- [ ] Ouvrir l'écran Carte sur mobile : le header "My Film Vault" doit être visible en haut
- [ ] Vérifier que les filtres (types de film) sont bien collés au bord supérieur de la carte
- [ ] Vérifier que le bouton de localisation est bien positionné au-dessus du TabBar
- [ ] Ouvrir un marker pour afficher la NoteSheet / ClusterSheet : pas d'espace excessif en bas
- [ ] Vérifier le rendu sur desktop (sidebar visible, pas de header mobile)

https://claude.ai/code/session_016BnRsYAUD9s2xxYzTXM7Xx