### PR TITLE
fix: scroll tour target into view only when off-screen

### DIFF
--- a/src/tour/use-tour-anchor.ts
+++ b/src/tour/use-tour-anchor.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+function isInViewport(el: Element): boolean {
+	const r = el.getBoundingClientRect();
+	return r.top >= 0 && r.bottom <= window.innerHeight;
+}
+
 export function useTourAnchor(selector: string | null, delay = 0): DOMRect | null {
 	const [rect, setRect] = useState<DOMRect | null>(null);
 	const observerRef = useRef<ResizeObserver | null>(null);
@@ -7,6 +12,7 @@ export function useTourAnchor(selector: string | null, delay = 0): DOMRect | nul
 	const retryRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const handlersRef = useRef<{ scroll: () => void; resize: () => void } | null>(null);
 	const rafRef = useRef<number | null>(null);
+	const scrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	const measure = useCallback(() => {
 		if (!selector) {
@@ -14,18 +20,31 @@ export function useTourAnchor(selector: string | null, delay = 0): DOMRect | nul
 			return;
 		}
 		const el = document.querySelector(selector);
-		if (el) {
-			elementRef.current = el;
-			setRect(el.getBoundingClientRect());
-		} else {
+		if (!el) {
 			elementRef.current = null;
 			setRect(null);
+			return;
+		}
+
+		elementRef.current = el;
+
+		if (isInViewport(el)) {
+			// Element already visible — measure immediately
+			setRect(el.getBoundingClientRect());
+		} else {
+			// Element off-screen — scroll into view, then re-measure after scroll settles
+			el.scrollIntoView({ behavior: "smooth", block: "center" });
+			if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
+			scrollTimerRef.current = setTimeout(() => {
+				setRect(el.getBoundingClientRect());
+			}, 400);
 		}
 	}, [selector]);
 
 	useEffect(() => {
 		const cleanup = () => {
 			if (retryRef.current) clearInterval(retryRef.current);
+			if (scrollTimerRef.current) clearTimeout(scrollTimerRef.current);
 			observerRef.current?.disconnect();
 			if (rafRef.current) cancelAnimationFrame(rafRef.current);
 			if (handlersRef.current) {


### PR DESCRIPTION
## Summary
- L'étape 6 du guide (timeline du film detail) rendait le tooltip hors écran car l'élément cible n'était pas visible
- Ajout de `scrollIntoView({ behavior: "smooth", block: "center" })` uniquement pour les éléments hors viewport
- Les éléments déjà visibles sont mesurés immédiatement (pas de délai inutile de 400ms)

## Test plan
- [ ] Lancer le guide depuis un premier lancement (localStorage vide)
- [ ] Vérifier que les étapes 1-4 (dashboard, stock) affichent le cutout immédiatement sans lag
- [ ] Vérifier que l'étape 6 (film detail / timeline) scrolle vers l'élément avant d'afficher le tooltip
- [ ] Vérifier que le tooltip reste dans l'écran à chaque étape
- [ ] Tester sur mobile (viewport petit) pour vérifier le scroll sur les étapes avec contenu long

Fixes #62

https://claude.ai/code/session_01Vf8vRadRNn6hv4VwH4wBcA