### PR TITLE
fix: improve tour tooltip positioning and scroll behavior

### DIFF
--- a/src/tour/TourTooltip.tsx
+++ b/src/tour/TourTooltip.tsx
@@ -36,11 +36,24 @@ export function TourTooltip({
 
 	const isCentered = placement === "center" || !anchorRect;
 
-	const positionStyle = isCentered
-		? {}
-		: placement === "bottom"
-			? { top: Math.min(anchorRect.bottom + 12, window.innerHeight - 220), left: 16, right: 16 }
-			: { bottom: window.innerHeight - anchorRect.top + 12, left: 16, right: 16 };
+	// When the target element is taller than 60% of viewport, the tooltip
+	// can't reasonably sit above/below it — center it on screen instead.
+	const targetTooTall = !isCentered && anchorRect.height > window.innerHeight * 0.6;
+
+	let positionStyle: React.CSSProperties = {};
+	if (!isCentered) {
+		if (targetTooTall) {
+			positionStyle = { top: Math.round(window.innerHeight * 0.35), left: 16, right: 16 };
+		} else if (placement === "bottom") {
+			positionStyle = { top: Math.min(anchorRect.bottom + 12, window.innerHeight - 220), left: 16, right: 16 };
+		} else {
+			positionStyle = {
+				bottom: Math.min(window.innerHeight - anchorRect.top + 12, window.innerHeight - 80),
+				left: 16,
+				right: 16,
+			};
+		}
+	}
 
 	// Move focus into tooltip when step changes
 	const stepKey = currentStep;


### PR DESCRIPTION
## Summary
- Scroll l'élément cible dans la vue uniquement quand il est hors écran (évite le délai de 400ms sur les éléments déjà visibles)
- Quand l'élément cible est plus grand que 60% du viewport (stock list, equipment), le tooltip se centre à l'écran au lieu de sortir par le haut
- Clamp sur le placement "top" pour que le tooltip reste toujours visible

Corrige les étapes 5 (stock), 6 (film detail timeline) et 7 (equipment) du guide interactif.

## Test plan
- [ ] Étapes 1-4 (dashboard) : tooltip apparaît immédiatement sans lag
- [ ] Étape 5 (stock list) : tooltip centré sur l'écran (la liste prend tout l'écran)
- [ ] Étape 6 (film detail / timeline) : scroll smooth vers la timeline, tooltip visible
- [ ] Étape 7 (equipment) : tooltip centré sur l'écran
- [ ] Étape 8 (stats) : tooltip sous les stat cards
- [ ] Tester sur mobile (petit viewport)

https://claude.ai/code/session_01Vf8vRadRNn6hv4VwH4wBcA