### PR TITLE
fix: dock tour tooltip at bottom for full-screen targets

### DIFF
--- a/src/tour/TourTooltip.tsx
+++ b/src/tour/TourTooltip.tsx
@@ -37,13 +37,13 @@ export function TourTooltip({
 	const isCentered = placement === "center" || !anchorRect;
 
 	// When the target element is taller than 60% of viewport, the tooltip
-	// can't reasonably sit above/below it — center it on screen instead.
+	// can't reasonably sit above/below it — dock it to the bottom of the screen.
 	const targetTooTall = !isCentered && anchorRect.height > window.innerHeight * 0.6;
 
 	let positionStyle: React.CSSProperties = {};
 	if (!isCentered) {
 		if (targetTooTall) {
-			positionStyle = { top: Math.round(window.innerHeight * 0.35), left: 16, right: 16 };
+			positionStyle = { bottom: 80, left: 16, right: 16 };
 		} else if (placement === "bottom") {
 			positionStyle = { top: Math.min(anchorRect.bottom + 12, window.innerHeight - 220), left: 16, right: 16 };
 		} else {


### PR DESCRIPTION
## Summary
- Dock le tooltip en bas de l'écran (`bottom: 80px`) quand l'élément cible occupe plus de 60% du viewport (stock list, equipment)
- Le tooltip reste au-dessus de la tab bar, toujours visible et accessible

Corrige le positionnement hors écran sur les étapes 5 (stock) et 7 (equipment) du guide.

## Test plan
- [ ] Étape 5 (stock) : tooltip docké en bas, visible au-dessus de la tab bar
- [ ] Étape 7 (equipment) : idem
- [ ] Les autres étapes ne sont pas impactées

https://claude.ai/code/session_01Vf8vRadRNn6hv4VwH4wBcA