### PR TITLE
fix: dock tour tooltip at bottom when not enough room above target

### DIFF
--- a/src/tour/TourTooltip.tsx
+++ b/src/tour/TourTooltip.tsx
@@ -36,13 +36,15 @@ export function TourTooltip({
 
 	const isCentered = placement === "center" || !anchorRect;
 
-	// When the target element is taller than 60% of viewport, the tooltip
-	// can't reasonably sit above/below it — dock it to the bottom of the screen.
-	const targetTooTall = !isCentered && anchorRect.height > window.innerHeight * 0.6;
+	// When the target element is taller than 40% of viewport, or when there
+	// isn't enough room above/below, dock the tooltip to the bottom of the screen.
+	const targetTooTall = !isCentered && anchorRect.height > window.innerHeight * 0.4;
+	const noRoomAbove = !isCentered && placement === "top" && anchorRect.top < 200;
+	const noRoomBelow = !isCentered && placement === "bottom" && window.innerHeight - anchorRect.bottom < 200;
 
 	let positionStyle: React.CSSProperties = {};
 	if (!isCentered) {
-		if (targetTooTall) {
+		if (targetTooTall || noRoomAbove || noRoomBelow) {
 			positionStyle = { bottom: 80, left: 16, right: 16 };
 		} else if (placement === "bottom") {
 			positionStyle = { top: Math.min(anchorRect.bottom + 12, window.innerHeight - 220), left: 16, right: 16 };


### PR DESCRIPTION
## Summary
- Tooltip docké en bas de l'écran (`bottom: 80px`) quand il n'y a pas assez de place pour le positionner normalement
- 3 conditions de fallback : élément > 40% du viewport, moins de 200px au-dessus (placement "top"), moins de 200px en dessous (placement "bottom")
- Corrige l'étape 7 (equipment) où le tooltip sortait par le haut de l'écran

## Test plan
- [ ] Étape 5 (stock) : tooltip en bas de l'écran
- [ ] Étape 7 (equipment) : tooltip en bas de l'écran, au-dessus de la tab bar
- [ ] Étapes 1-4, 6, 8 : comportement inchangé

https://claude.ai/code/session_01Vf8vRadRNn6hv4VwH4wBcA