### PR TITLE
feat: dashboard chips navigate to filtered stock list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ function FilmVaultInner() {
 	const [screen, setScreen] = useState<ScreenName>("home");
 	const [selectedFilm, setSelectedFilm] = useState<string | null>(null);
 	const [mapFilterFilmId, setMapFilterFilmId] = useState<string | null>(null);
+	const [stockStateFilter, setStockStateFilter] = useState<string | null>(null);
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
 	const [showAddFilm, setShowAddFilm] = useState(false);
 	const [persistent, setPersistent] = useState(false);
@@ -140,12 +141,18 @@ function FilmVaultInner() {
 
 	const handleSetScreen = useCallback((s: ScreenName) => {
 		if (s === "map") setMapFilterFilmId(null);
+		if (s === "stock") setStockStateFilter(null);
 		setScreen(s);
 	}, []);
 
 	const navigateToMap = useCallback((filmId?: string) => {
 		setMapFilterFilmId(filmId ?? null);
 		setScreen("map");
+	}, []);
+
+	const navigateToStock = useCallback((stateFilter: string) => {
+		setStockStateFilter(stateFilter);
+		setScreen("stock");
 	}, []);
 
 	if (loading || !data) {
@@ -169,6 +176,7 @@ function FilmVaultInner() {
 				setSelectedFilm={setSelectedFilm}
 				mapFilterFilmId={mapFilterFilmId}
 				setMapFilterFilmId={setMapFilterFilmId}
+				stockStateFilter={stockStateFilter}
 				autoOpenShotNote={autoOpenShotNote}
 				setAutoOpenShotNote={setAutoOpenShotNote}
 				showAddFilm={showAddFilm}
@@ -179,6 +187,7 @@ function FilmVaultInner() {
 				triggerSync={triggerSync}
 				persistent={persistent}
 				navigateToMap={navigateToMap}
+				navigateToStock={navigateToStock}
 			/>
 		</TourProvider>
 	);
@@ -194,6 +203,7 @@ interface AppContentProps {
 	setSelectedFilm: (id: string | null) => void;
 	mapFilterFilmId: string | null;
 	setMapFilterFilmId: (id: string | null) => void;
+	stockStateFilter: string | null;
 	autoOpenShotNote: boolean;
 	setAutoOpenShotNote: (open: boolean) => void;
 	showAddFilm: boolean;
@@ -204,6 +214,7 @@ interface AppContentProps {
 	triggerSync: () => Promise<void>;
 	persistent: boolean;
 	navigateToMap: (filmId?: string) => void;
+	navigateToStock: (stateFilter: string) => void;
 }
 
 function AppContent({
@@ -216,6 +227,7 @@ function AppContent({
 	setSelectedFilm,
 	mapFilterFilmId,
 	setMapFilterFilmId,
+	stockStateFilter,
 	autoOpenShotNote,
 	setAutoOpenShotNote,
 	showAddFilm,
@@ -226,6 +238,7 @@ function AppContent({
 	triggerSync,
 	persistent,
 	navigateToMap,
+	navigateToStock,
 }: AppContentProps) {
 	const { isTourActive, tourData, startTour } = useTour();
 	const autoTourTriggered = useRef(false);
@@ -271,6 +284,7 @@ function AppContent({
 						setSelectedFilm={setSelectedFilm}
 						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
+						onNavigateToStock={navigateToStock}
 					/>
 				);
 			case "stock":
@@ -280,6 +294,7 @@ function AppContent({
 						setScreen={setScreen}
 						setSelectedFilm={setSelectedFilm}
 						onAddFilm={onAddFilm}
+						initialStateFilter={stockStateFilter}
 					/>
 				);
 			case "filmDetail":
@@ -340,6 +355,7 @@ function AppContent({
 						setSelectedFilm={setSelectedFilm}
 						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
+						onNavigateToStock={navigateToStock}
 					/>
 				);
 		}

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -17,6 +17,7 @@ interface DashboardScreenProps {
 	setSelectedFilm: (id: string) => void;
 	onAddFilm: () => void;
 	setAutoOpenShotNote?: (open: boolean) => void;
+	onNavigateToStock: (stateFilter: string) => void;
 }
 
 interface EquipmentItem {
@@ -91,6 +92,7 @@ export function DashboardScreen({
 	setSelectedFilm,
 	onAddFilm,
 	setAutoOpenShotNote,
+	onNavigateToStock,
 }: DashboardScreenProps) {
 	const { t } = useTranslation();
 	const { films, cameras, backs } = data;
@@ -121,12 +123,42 @@ export function DashboardScreen({
 		<div className="flex flex-col gap-6">
 			{/* Barre de stats compacte */}
 			<div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1" data-tour="stat-cards">
-				<StatChip icon={Snowflake} label={t("dashboard.inStock")} value={stockCount} color={T.blue} />
-				<StatChip icon={Camera} label={t("dashboard.loaded")} value={loadedCount} color={T.green} />
-				<StatChip icon={Eye} label={t("dashboard.exposed")} value={exposedCount} color={T.accent} />
-				<StatChip icon={Archive} label={t("dashboard.developed")} value={developedCount} color={T.textSec} />
+				<StatChip
+					icon={Snowflake}
+					label={t("dashboard.inStock")}
+					value={stockCount}
+					color={T.blue}
+					onClick={() => onNavigateToStock("stock")}
+				/>
+				<StatChip
+					icon={Camera}
+					label={t("dashboard.loaded")}
+					value={loadedCount}
+					color={T.green}
+					onClick={() => onNavigateToStock("loaded")}
+				/>
+				<StatChip
+					icon={Eye}
+					label={t("dashboard.exposed")}
+					value={exposedCount}
+					color={T.accent}
+					onClick={() => onNavigateToStock("exposed")}
+				/>
+				<StatChip
+					icon={Archive}
+					label={t("dashboard.developed")}
+					value={developedCount}
+					color={T.textSec}
+					onClick={() => onNavigateToStock("developed")}
+				/>
 				{scannedCount > 0 && (
-					<StatChip icon={ScanLine} label={t("dashboard.scanned")} value={scannedCount} color={T.orange} />
+					<StatChip
+						icon={ScanLine}
+						label={t("dashboard.scanned")}
+						value={scannedCount}
+						color={T.orange}
+						onClick={() => onNavigateToStock("scanned")}
+					/>
 				)}
 			</div>
 

--- a/src/screens/StockScreen.tsx
+++ b/src/screens/StockScreen.tsx
@@ -77,14 +77,15 @@ interface StockScreenProps {
 	setScreen: (screen: ScreenName) => void;
 	setSelectedFilm: (id: string) => void;
 	onAddFilm: () => void;
+	initialStateFilter?: string | null;
 }
 
-export function StockScreen({ data, setScreen, setSelectedFilm, onAddFilm }: StockScreenProps) {
+export function StockScreen({ data, setScreen, setSelectedFilm, onAddFilm, initialStateFilter }: StockScreenProps) {
 	const { t } = useTranslation();
 	const [filterDialogOpen, setFilterDialogOpen] = useState(false);
 	const { films, cameras, backs } = data;
 
-	const stockFilters = useStockFilters(films);
+	const stockFilters = useStockFilters(films, initialStateFilter);
 	const groups = groupFilms(stockFilters.filteredFilms, t("dateLocale"));
 
 	const stateCounts: Record<string, number> = {};

--- a/src/utils/use-stock-filters.ts
+++ b/src/utils/use-stock-filters.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Film } from "@/types";
 import { filmName, normalizeBrand } from "@/utils/film-helpers";
 
@@ -84,9 +84,9 @@ function getSortComparator(option: SortOption): (a: Film, b: Film) => number {
 	}
 }
 
-export function useStockFilters(films: Film[]) {
+export function useStockFilters(films: Film[], initialStateFilter?: string | null) {
 	const [search, setSearch] = useState("");
-	const [stateFilter, setStateFilter] = useState("all");
+	const [stateFilter, setStateFilter] = useState(initialStateFilter || "all");
 	const [filters, setFilters] = useState<StockFilters>({
 		format: "all",
 		type: "all",
@@ -94,6 +94,12 @@ export function useStockFilters(films: Film[]) {
 		isoValues: [],
 	});
 	const [sortOption, setSortOption] = useState<SortOption>("name-asc");
+
+	useEffect(() => {
+		if (initialStateFilter) {
+			setStateFilter(initialStateFilter);
+		}
+	}, [initialStateFilter]);
 
 	const availableFormats = useMemo(() => {
 		const formats = new Set<string>();


### PR DESCRIPTION
Clicking a stat chip (Stock, Loaded, Exposed, Developed, Scanned) on
the dashboard now navigates to the Stock screen with the corresponding
state filter pre-applied.

https://claude.ai/code/session_015dPsG3ebdD9j3WJAeK9fDt