### PR TITLE
feat(cameras): add camera detail screen and restrict archiving

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ function FilmVaultInner() {
 	const [screen, setScreen] = useState<ScreenName>("home");
 	const [selectedFilm, setSelectedFilm] = useState<string | null>(null);
 	const [selectedCamera, setSelectedCamera] = useState<string | null>(null);
+	const [filmBackTarget, setFilmBackTarget] = useState<ScreenName | null>(null);
 	const [mapFilterFilmId, setMapFilterFilmId] = useState<string | null>(null);
 	const [stockStateFilter, setStockStateFilter] = useState<string | null>(null);
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
@@ -144,6 +145,7 @@ function FilmVaultInner() {
 	const handleSetScreen = useCallback((s: ScreenName) => {
 		if (s === "map") setMapFilterFilmId(null);
 		if (s === "stock") setStockStateFilter(null);
+		if (s !== "filmDetail") setFilmBackTarget(null);
 		setScreen(s);
 	}, []);
 
@@ -164,6 +166,7 @@ function FilmVaultInner() {
 
 	const navigateToFilm = useCallback((filmId: string) => {
 		setSelectedFilm(filmId);
+		setFilmBackTarget("cameraDetail");
 		setScreen("filmDetail");
 	}, []);
 
@@ -203,6 +206,7 @@ function FilmVaultInner() {
 				navigateToCamera={navigateToCamera}
 				navigateToFilm={navigateToFilm}
 				selectedCamera={selectedCamera}
+				filmBackTarget={filmBackTarget}
 			/>
 		</TourProvider>
 	);
@@ -233,6 +237,7 @@ interface AppContentProps {
 	navigateToCamera: (camId: string) => void;
 	navigateToFilm: (filmId: string) => void;
 	selectedCamera: string | null;
+	filmBackTarget: ScreenName | null;
 }
 
 function AppContent({
@@ -260,6 +265,7 @@ function AppContent({
 	navigateToCamera,
 	navigateToFilm,
 	selectedCamera,
+	filmBackTarget,
 }: AppContentProps) {
 	const { isTourActive, tourData, startTour } = useTour();
 	const autoTourTriggered = useRef(false);
@@ -396,7 +402,12 @@ function AppContent({
 	const cameraTitle = selectedCamera
 		? (() => {
 				const cam = effectiveData.cameras.find((c) => c.id === selectedCamera);
-				return cam ? cam.nickname || `${cam.brand} ${cam.model}` : undefined;
+				if (!cam) return undefined;
+				const fallbackTitle = [cam.brand, cam.model]
+					.map((part) => part?.trim())
+					.filter(Boolean)
+					.join(" ");
+				return cam.nickname || fallbackTitle || undefined;
 			})()
 		: undefined;
 	const showTabBar = !["filmDetail", "cameraDetail", "settings", "legal"].includes(screen);
@@ -412,6 +423,7 @@ function AppContent({
 					setScreen={handleSetScreen}
 					filmTitle={filmTitle}
 					cameraTitle={cameraTitle}
+					filmBackTarget={filmBackTarget}
 					className="md:hidden"
 				/>
 				{screen === "map" ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { PwaUpdateBanner } from "@/components/PwaUpdateBanner";
 import { TabBar } from "@/components/TabBar";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ToastProvider, useToast } from "@/components/Toast";
+import { CameraDetailScreen } from "@/screens/CameraDetailScreen";
 import { DashboardScreen } from "@/screens/DashboardScreen";
 import { EquipmentScreen } from "@/screens/EquipmentScreen";
 import { FilmDetailScreen } from "@/screens/FilmDetailScreen";
@@ -30,6 +31,7 @@ function FilmVaultInner() {
 	const [loading, setLoading] = useState(true);
 	const [screen, setScreen] = useState<ScreenName>("home");
 	const [selectedFilm, setSelectedFilm] = useState<string | null>(null);
+	const [selectedCamera, setSelectedCamera] = useState<string | null>(null);
 	const [mapFilterFilmId, setMapFilterFilmId] = useState<string | null>(null);
 	const [stockStateFilter, setStockStateFilter] = useState<string | null>(null);
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
@@ -155,6 +157,16 @@ function FilmVaultInner() {
 		setScreen("stock");
 	}, []);
 
+	const navigateToCamera = useCallback((camId: string) => {
+		setSelectedCamera(camId);
+		setScreen("cameraDetail");
+	}, []);
+
+	const navigateToFilm = useCallback((filmId: string) => {
+		setSelectedFilm(filmId);
+		setScreen("filmDetail");
+	}, []);
+
 	if (loading || !data) {
 		return (
 			<div className="min-h-screen bg-bg flex flex-col items-center justify-center gap-3">
@@ -188,6 +200,9 @@ function FilmVaultInner() {
 				persistent={persistent}
 				navigateToMap={navigateToMap}
 				navigateToStock={navigateToStock}
+				navigateToCamera={navigateToCamera}
+				navigateToFilm={navigateToFilm}
+				selectedCamera={selectedCamera}
 			/>
 		</TourProvider>
 	);
@@ -215,6 +230,9 @@ interface AppContentProps {
 	persistent: boolean;
 	navigateToMap: (filmId?: string) => void;
 	navigateToStock: (stateFilter: string) => void;
+	navigateToCamera: (camId: string) => void;
+	navigateToFilm: (filmId: string) => void;
+	selectedCamera: string | null;
 }
 
 function AppContent({
@@ -239,6 +257,9 @@ function AppContent({
 	persistent,
 	navigateToMap,
 	navigateToStock,
+	navigateToCamera,
+	navigateToFilm,
+	selectedCamera,
 }: AppContentProps) {
 	const { isTourActive, tourData, startTour } = useTour();
 	const autoTourTriggered = useRef(false);
@@ -251,7 +272,7 @@ function AppContent({
 
 	// Track navigation direction
 	useEffect(() => {
-		const detailScreens: ScreenName[] = ["filmDetail", "settings", "legal"];
+		const detailScreens: ScreenName[] = ["filmDetail", "cameraDetail", "settings", "legal"];
 		const prev = prevScreen.current;
 		if (detailScreens.includes(screen) && !detailScreens.includes(prev)) {
 			navDirection.current = "forward";
@@ -306,8 +327,18 @@ function AppContent({
 						setSelectedFilm={setSelectedFilm}
 						filmId={selectedFilm}
 						onNavigateToMap={navigateToMap}
+						onNavigateToCamera={navigateToCamera}
 						autoOpenShotNote={autoOpenShotNote}
 						setAutoOpenShotNote={setAutoOpenShotNote}
+					/>
+				);
+			case "cameraDetail":
+				return (
+					<CameraDetailScreen
+						data={effectiveData}
+						cameraId={selectedCamera}
+						setScreen={setScreen}
+						onFilmClick={navigateToFilm}
 					/>
 				);
 			case "map":
@@ -329,7 +360,7 @@ function AppContent({
 					</Suspense>
 				);
 			case "cameras":
-				return <EquipmentScreen data={effectiveData} setData={effectiveUpdateData} />;
+				return <EquipmentScreen data={effectiveData} setData={effectiveUpdateData} onCameraClick={navigateToCamera} />;
 			case "stats":
 				return <StatsScreen data={effectiveData} />;
 			case "settings":
@@ -362,7 +393,13 @@ function AppContent({
 	};
 
 	const filmTitle = selectedFilm ? effectiveData.films.find((f) => f.id === selectedFilm)?.model : undefined;
-	const showTabBar = !["filmDetail", "settings", "legal"].includes(screen);
+	const cameraTitle = selectedCamera
+		? (() => {
+				const cam = effectiveData.cameras.find((c) => c.id === selectedCamera);
+				return cam ? cam.nickname || `${cam.brand} ${cam.model}` : undefined;
+			})()
+		: undefined;
+	const showTabBar = !["filmDetail", "cameraDetail", "settings", "legal"].includes(screen);
 
 	return (
 		<div className="h-[100dvh] bg-bg text-text-primary font-body flex flex-col md:flex-row relative">
@@ -370,7 +407,13 @@ function AppContent({
 			<TabBar screen={screen} setScreen={handleSetScreen} variant="sidebar" className="hidden md:flex" />
 
 			<main className="flex-1 flex flex-col min-h-0 min-w-0">
-				<AppHeader screen={screen} setScreen={handleSetScreen} filmTitle={filmTitle} className="md:hidden" />
+				<AppHeader
+					screen={screen}
+					setScreen={handleSetScreen}
+					filmTitle={filmTitle}
+					cameraTitle={cameraTitle}
+					className="md:hidden"
+				/>
 				{screen === "map" ? (
 					<div className="flex-1 min-h-0">{renderScreen()}</div>
 				) : (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -10,6 +10,7 @@ interface AppHeaderProps {
 	setScreen: (screen: ScreenName) => void;
 	filmTitle?: string;
 	cameraTitle?: string;
+	filmBackTarget?: ScreenName | null;
 	className?: string;
 }
 
@@ -19,10 +20,10 @@ const backTargets: Partial<Record<ScreenName, ScreenName>> = {
 	settings: "home",
 };
 
-export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, className }: AppHeaderProps) {
+export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, filmBackTarget, className }: AppHeaderProps) {
 	const { t } = useTranslation();
 	const { theme, setTheme } = useTheme();
-	const backTarget = backTargets[screen];
+	const backTarget = screen === "filmDetail" && filmBackTarget ? filmBackTarget : backTargets[screen];
 	const isSubScreen = !!backTarget;
 
 	const subScreenTitles: Partial<Record<ScreenName, string>> = {

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -9,15 +9,17 @@ interface AppHeaderProps {
 	screen: ScreenName;
 	setScreen: (screen: ScreenName) => void;
 	filmTitle?: string;
+	cameraTitle?: string;
 	className?: string;
 }
 
 const backTargets: Partial<Record<ScreenName, ScreenName>> = {
 	filmDetail: "stock",
+	cameraDetail: "cameras",
 	settings: "home",
 };
 
-export function AppHeader({ screen, setScreen, filmTitle, className }: AppHeaderProps) {
+export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, className }: AppHeaderProps) {
 	const { t } = useTranslation();
 	const { theme, setTheme } = useTheme();
 	const backTarget = backTargets[screen];
@@ -25,6 +27,7 @@ export function AppHeader({ screen, setScreen, filmTitle, className }: AppHeader
 
 	const subScreenTitles: Partial<Record<ScreenName, string>> = {
 		filmDetail: filmTitle || t("filmDetail.back"),
+		cameraDetail: cameraTitle || t("cameraDetail.title"),
 		settings: t("nav.settings"),
 	};
 

--- a/src/components/CameraMiniCard.tsx
+++ b/src/components/CameraMiniCard.tsx
@@ -1,0 +1,59 @@
+import { Camera as CameraIcon, ChevronRight } from "lucide-react";
+import { PhotoImg } from "@/components/ui/photo-img";
+import { cn } from "@/lib/utils";
+import type { Back, Camera } from "@/types";
+import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
+
+interface CameraMiniCardProps {
+	camera: Camera;
+	back?: Back | null;
+	onClick?: () => void;
+	className?: string;
+}
+
+export function CameraMiniCard({ camera, back, onClick, className }: CameraMiniCardProps) {
+	const subtitleParts = [camera.format, camera.mount || null, back ? backDisplayName(back) : null].filter(
+		Boolean,
+	) as string[];
+
+	const content = (
+		<>
+			{camera.photo ? (
+				<PhotoImg
+					src={camera.photo}
+					alt=""
+					aria-hidden="true"
+					className="w-14 h-14 rounded-lg object-cover border border-border shrink-0"
+				/>
+			) : (
+				<div className="w-14 h-14 rounded-lg bg-surface-alt flex items-center justify-center shrink-0">
+					<CameraIcon size={22} className="text-text-muted opacity-40" />
+				</div>
+			)}
+			<div className="flex-1 min-w-0">
+				<div className="text-[14px] font-semibold text-text-primary font-body truncate">
+					{cameraDisplayName(camera)}
+				</div>
+				{subtitleParts.length > 0 && (
+					<div className="text-[12px] font-mono truncate text-text-muted">{subtitleParts.join(" · ")}</div>
+				)}
+			</div>
+			{onClick && <ChevronRight size={16} className="text-text-muted shrink-0" />}
+		</>
+	);
+
+	const baseClass = cn(
+		"flex items-center gap-3 w-full rounded-[12px] border border-border bg-card p-3 text-left",
+		onClick && "transition-colors hover:bg-card-hover cursor-pointer",
+		className,
+	);
+
+	if (onClick) {
+		return (
+			<button type="button" onClick={onClick} className={baseClass}>
+				{content}
+			</button>
+		);
+	}
+	return <div className={baseClass}>{content}</div>;
+}

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -2,42 +2,14 @@ import { Archive, Camera, Clock, Eye, Package, Plus, RotateCcw, ScanLine, Send }
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { PhotoImg } from "@/components/ui/photo-img";
-import type { HistoryAction, HistoryEntry, LucideIcon } from "@/types";
+import type { HistoryEntry, LucideIcon } from "@/types";
 import { fmtDate } from "@/utils/helpers";
+import { HISTORY_ACTION_ICONS, HISTORY_ACTION_KEYS } from "@/utils/history-action";
 
 interface TimelineProps {
 	entries: HistoryEntry[];
 	onPhotoClick?: (photos: string[], index: number) => void;
 }
-
-const ACTION_ICONS: Record<HistoryAction, LucideIcon> = {
-	added: Plus,
-	loaded: Camera,
-	reloaded: RotateCcw,
-	removed_partial: Clock,
-	exposed: Eye,
-	sent_dev: Send,
-	developed: Archive,
-	scanned: ScanLine,
-	modified: Plus,
-	duplicated: Plus,
-};
-
-const ACTION_TRANSLATION_KEYS: Record<
-	HistoryAction,
-	string | ((params?: Record<string, string | number | null | undefined>) => string)
-> = {
-	added: "filmDetail.historyAdded",
-	loaded: "filmDetail.historyLoaded",
-	reloaded: "filmDetail.historyReloaded",
-	removed_partial: "filmDetail.historyPartial",
-	exposed: "filmDetail.historyExposed",
-	sent_dev: "filmDetail.historySentDev",
-	developed: (params) => (params?.lab ? "filmDetail.historyDevelopedAt" : "filmDetail.historyDeveloped"),
-	scanned: (params) => (params?.ref ? "filmDetail.historyScannedRef" : "filmDetail.historyScanned"),
-	modified: "filmDetail.historyModified",
-	duplicated: "filmDetail.historyDuplicated",
-};
 
 /** Fallback icon detection for legacy entries that only have a free-text action field */
 function getLegacyIcon(action: string): LucideIcon {
@@ -57,8 +29,8 @@ export function Timeline({ entries, onPhotoClick }: TimelineProps) {
 
 	const renderAction = (entry: HistoryEntry): { icon: LucideIcon; text: string } => {
 		if (entry.actionCode) {
-			const icon = ACTION_ICONS[entry.actionCode];
-			const keyOrFn = ACTION_TRANSLATION_KEYS[entry.actionCode];
+			const icon = HISTORY_ACTION_ICONS[entry.actionCode];
+			const keyOrFn = HISTORY_ACTION_KEYS[entry.actionCode];
 			const key = typeof keyOrFn === "function" ? keyOrFn(entry.params) : keyOrFn;
 			const text = t(key, entry.params ?? {});
 			return { icon, text };

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -1,4 +1,4 @@
-import { Camera, Check, Edit3, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Camera, Check, Edit3, Eye, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
@@ -25,9 +25,10 @@ import { uid } from "@/utils/helpers";
 interface CamerasTabProps {
 	data: AppData;
 	setData: (data: AppData) => void;
+	onCameraClick?: (camId: string) => void;
 }
 
-export function CamerasTab({ data, setData }: CamerasTabProps) {
+export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	const { t } = useTranslation();
 	const [showAdd, setShowAdd] = useState(false);
 	const [newCam, setNewCam] = useState({
@@ -144,8 +145,26 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 					{activeCameras.map((cam) => {
 						const loadedFilms = data.films.filter((f) => f.state === "loaded" && f.cameraId === cam.id);
 						const camBacks = data.backs.filter((b) => !b.soldAt && b.compatibleCameraIds.includes(cam.id));
+						const handleCardClick = () => onCameraClick?.(cam.id);
+						const canArchive = loadedFilms.length === 0;
 						return (
-							<Card key={cam.id}>
+							<Card
+								key={cam.id}
+								onClick={onCameraClick ? handleCardClick : undefined}
+								role={onCameraClick ? "button" : undefined}
+								tabIndex={onCameraClick ? 0 : undefined}
+								onKeyDown={
+									onCameraClick
+										? (e) => {
+												if (e.key === "Enter" || e.key === " ") {
+													e.preventDefault();
+													handleCardClick();
+												}
+											}
+										: undefined
+								}
+								className={onCameraClick ? "cursor-pointer hover:bg-card-hover" : undefined}
+							>
 								<div className="flex items-center justify-between">
 									<div className="flex items-center gap-3">
 										{cam.photo ? (
@@ -190,24 +209,46 @@ export function CamerasTab({ data, setData }: CamerasTabProps) {
 										</div>
 									</div>
 									<div className="flex gap-1.5">
+										{onCameraClick && (
+											<Button
+												variant="outline"
+												size="icon"
+												onClick={(e) => {
+													e.stopPropagation();
+													onCameraClick(cam.id);
+												}}
+												className="w-11 h-11 rounded-lg"
+												aria-label={t("aria.viewCamera")}
+											>
+												<Eye size={14} className="text-text-sec" />
+											</Button>
+										)}
 										<Button
 											variant="outline"
 											size="icon"
-											onClick={() => setEditCam({ ...cam })}
+											onClick={(e) => {
+												e.stopPropagation();
+												setEditCam({ ...cam });
+											}}
 											className="w-11 h-11 rounded-lg"
 											aria-label={t("aria.editCamera")}
 										>
 											<Edit3 size={14} className="text-text-sec" />
 										</Button>
-										<Button
-											variant="destructive"
-											size="icon"
-											onClick={() => sellCamera(cam.id)}
-											className="w-11 h-11 rounded-lg"
-											aria-label={t("aria.sellCamera")}
-										>
-											<PackageX size={14} className="text-accent" />
-										</Button>
+										{canArchive && (
+											<Button
+												variant="destructive"
+												size="icon"
+												onClick={(e) => {
+													e.stopPropagation();
+													sellCamera(cam.id);
+												}}
+												className="w-11 h-11 rounded-lg"
+												aria-label={t("aria.sellCamera")}
+											>
+												<PackageX size={14} className="text-accent" />
+											</Button>
+										)}
 									</div>
 								</div>
 								{loadedFilms.length > 0 && (

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -113,6 +113,8 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	};
 
 	const sellCamera = (camId: string) => {
+		const hasLoaded = data.films.some((f) => f.state === "loaded" && f.cameraId === camId);
+		if (hasLoaded) return;
 		const newCams = data.cameras.map((c) => (c.id === camId ? { ...c, soldAt: new Date().toISOString() } : c));
 		setData({ ...data, cameras: newCams });
 	};

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -331,6 +331,8 @@ export const en = {
 		noFilms: "No films",
 		noFilmsSubtitle: "No film has been used with this camera yet",
 		noHistory: "No events for this camera",
+		partial_one: "{{count}} partial",
+		partial_other: "{{count}} partial",
 	},
 
 	// Equipment screen

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -3,6 +3,8 @@ export const en = {
 	common: {
 		cancel: "Cancel",
 		confirm: "Confirm",
+		yes: "Yes",
+		no: "No",
 	},
 
 	// Navigation
@@ -317,6 +319,20 @@ export const en = {
 		othersInStock: "{{count}} other identical films in stock",
 	},
 
+	// Camera detail screen
+	cameraDetail: {
+		title: "Camera",
+		notFound: "Camera not found",
+		sectionInfo: "Information",
+		sectionFilms: "Films",
+		sectionHistory: "History",
+		shutterRange: "Shutter range",
+		archivedOn: "Archived on",
+		noFilms: "No films",
+		noFilmsSubtitle: "No film has been used with this camera yet",
+		noHistory: "No events for this camera",
+	},
+
 	// Equipment screen
 	equipment: {
 		title: "Equipment",
@@ -551,6 +567,7 @@ export const en = {
 		previousPhoto: "Previous photo",
 		nextPhoto: "Next photo",
 		editFilm: "Edit film",
+		viewCamera: "View camera details",
 		editCamera: "Edit camera",
 		editBack: "Edit back",
 		editLens: "Edit lens",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -3,6 +3,8 @@ export const fr = {
 	common: {
 		cancel: "Annuler",
 		confirm: "Confirmer",
+		yes: "Oui",
+		no: "Non",
 	},
 
 	// Navigation
@@ -317,6 +319,20 @@ export const fr = {
 		othersInStock: "{{count}} autres pellicules identiques en stock",
 	},
 
+	// Camera detail screen
+	cameraDetail: {
+		title: "Appareil",
+		notFound: "Appareil introuvable",
+		sectionInfo: "Informations",
+		sectionFilms: "Pellicules",
+		sectionHistory: "Historique",
+		shutterRange: "Plage vitesses",
+		archivedOn: "Archivé le",
+		noFilms: "Aucune pellicule",
+		noFilmsSubtitle: "Aucune pellicule n'a encore été utilisée avec cet appareil",
+		noHistory: "Aucun événement pour cet appareil",
+	},
+
 	// Equipment screen
 	equipment: {
 		title: "Équipement",
@@ -551,6 +567,7 @@ export const fr = {
 		previousPhoto: "Photo précédente",
 		nextPhoto: "Photo suivante",
 		editFilm: "Modifier la pellicule",
+		viewCamera: "Voir le détail de l'appareil",
 		editCamera: "Modifier l'appareil",
 		editBack: "Modifier le dos",
 		editLens: "Modifier l'objectif",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -331,6 +331,8 @@ export const fr = {
 		noFilms: "Aucune pellicule",
 		noFilmsSubtitle: "Aucune pellicule n'a encore été utilisée avec cet appareil",
 		noHistory: "Aucun événement pour cet appareil",
+		partial_one: "{{count}} partielle",
+		partial_other: "{{count}} partielles",
 	},
 
 	// Equipment screen

--- a/src/screens/CameraDetailScreen.tsx
+++ b/src/screens/CameraDetailScreen.tsx
@@ -1,0 +1,113 @@
+import { Camera as CameraIcon, Film as FilmIcon, History, Info } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { EmptyState } from "@/components/EmptyState";
+import { PhotoViewer } from "@/components/PhotoViewer";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
+import { PhotoImg } from "@/components/ui/photo-img";
+import { alpha, T } from "@/constants/theme";
+import type { AppData, ScreenName } from "@/types";
+import { cameraDisplayName } from "@/utils/camera-helpers";
+import { CameraFilmsList } from "./camera-detail/CameraFilmsList";
+import { CameraHistoryTimeline } from "./camera-detail/CameraHistoryTimeline";
+import { CameraInfoSection } from "./camera-detail/CameraInfoSection";
+
+interface CameraDetailScreenProps {
+	data: AppData;
+	cameraId: string | null;
+	setScreen: (screen: ScreenName) => void;
+	onFilmClick: (filmId: string) => void;
+}
+
+export function CameraDetailScreen({ data, cameraId, setScreen, onFilmClick }: CameraDetailScreenProps) {
+	const { t } = useTranslation();
+	const camera = cameraId ? data.cameras.find((c) => c.id === cameraId) : null;
+	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
+	const [viewerPhotos, setViewerPhotos] = useState<string[] | null>(null);
+	const [viewerIndex, setViewerIndex] = useState(0);
+
+	if (!camera) {
+		return (
+			<EmptyState
+				icon={CameraIcon}
+				title={t("cameraDetail.notFound")}
+				action={<Button onClick={() => setScreen("cameras")}>{t("filmDetail.back")}</Button>}
+			/>
+		);
+	}
+
+	const cameraFilms = data.films.filter((f) => f.cameraId === camera.id);
+	const loadedCount = cameraFilms.filter((f) => f.state === "loaded").length;
+	const totalCount = cameraFilms.length;
+
+	return (
+		<div className="flex flex-col gap-5 pb-10">
+			{/* Header */}
+			<div>
+				<h2 className="font-display text-[22px] text-text-primary m-0 italic">{cameraDisplayName(camera)}</h2>
+				<div className="flex gap-2 flex-wrap mt-2">
+					<Badge style={{ color: T.textMuted, background: alpha(T.textMuted, 0.09) }}>{camera.format}</Badge>
+					{camera.mount && (
+						<Badge style={{ color: T.textMuted, background: alpha(T.textMuted, 0.09) }}>{camera.mount}</Badge>
+					)}
+					{loadedCount > 0 && (
+						<Badge style={{ color: T.green, background: alpha(T.green, 0.09) }}>
+							{t("cameras.loaded", { count: loadedCount })}
+						</Badge>
+					)}
+					{totalCount > 0 && (
+						<Badge style={{ color: T.blue, background: alpha(T.blue, 0.09) }}>
+							{t("equipment.associatedFilms", { count: totalCount })}
+						</Badge>
+					)}
+				</div>
+			</div>
+
+			{/* Camera photo */}
+			{camera.photo && (
+				<button
+					type="button"
+					onClick={() => setViewerPhoto(camera.photo!)}
+					aria-label={t("aria.openPhoto", { index: 1 })}
+					className="w-full rounded-[14px] overflow-hidden border border-border bg-surface-alt cursor-pointer"
+				>
+					<PhotoImg
+						src={camera.photo}
+						alt=""
+						aria-hidden="true"
+						className={`w-full max-h-80 object-cover ${camera.soldAt ? "grayscale" : ""}`}
+					/>
+				</button>
+			)}
+
+			{/* Info */}
+			<CollapsibleSection icon={Info} title={t("cameraDetail.sectionInfo")} defaultOpen>
+				<CameraInfoSection camera={camera} />
+			</CollapsibleSection>
+
+			{/* Films */}
+			<CollapsibleSection icon={FilmIcon} title={t("cameraDetail.sectionFilms")} count={cameraFilms.length} defaultOpen>
+				<CameraFilmsList films={cameraFilms} onFilmClick={onFilmClick} />
+			</CollapsibleSection>
+
+			{/* History */}
+			<CollapsibleSection icon={History} title={t("cameraDetail.sectionHistory")} defaultOpen={false}>
+				<CameraHistoryTimeline
+					films={cameraFilms}
+					onFilmClick={onFilmClick}
+					onPhotoClick={(photos, index) => {
+						setViewerPhotos(photos);
+						setViewerIndex(index);
+					}}
+				/>
+			</CollapsibleSection>
+
+			{viewerPhoto && <PhotoViewer photos={[viewerPhoto]} initialIndex={0} onClose={() => setViewerPhoto(null)} />}
+			{viewerPhotos && (
+				<PhotoViewer photos={viewerPhotos} initialIndex={viewerIndex} onClose={() => setViewerPhotos(null)} />
+			)}
+		</div>
+	);
+}

--- a/src/screens/CameraDetailScreen.tsx
+++ b/src/screens/CameraDetailScreen.tsx
@@ -40,6 +40,7 @@ export function CameraDetailScreen({ data, cameraId, setScreen, onFilmClick }: C
 
 	const cameraFilms = data.films.filter((f) => f.cameraId === camera.id);
 	const loadedCount = cameraFilms.filter((f) => f.state === "loaded").length;
+	const partialCount = cameraFilms.filter((f) => f.state === "partial").length;
 	const totalCount = cameraFilms.length;
 
 	return (
@@ -55,6 +56,11 @@ export function CameraDetailScreen({ data, cameraId, setScreen, onFilmClick }: C
 					{loadedCount > 0 && (
 						<Badge style={{ color: T.green, background: alpha(T.green, 0.09) }}>
 							{t("cameras.loaded", { count: loadedCount })}
+						</Badge>
+					)}
+					{partialCount > 0 && (
+						<Badge style={{ color: T.amber, background: alpha(T.amber, 0.09) }}>
+							{t("cameraDetail.partial", { count: partialCount })}
 						</Badge>
 					)}
 					{totalCount > 0 && (

--- a/src/screens/EquipmentScreen.tsx
+++ b/src/screens/EquipmentScreen.tsx
@@ -12,9 +12,10 @@ type EquipmentTab = "cameras" | "lenses" | "backs";
 interface EquipmentScreenProps {
 	data: AppData;
 	setData: (data: AppData) => void;
+	onCameraClick?: (camId: string) => void;
 }
 
-export function EquipmentScreen({ data, setData }: EquipmentScreenProps) {
+export function EquipmentScreen({ data, setData, onCameraClick }: EquipmentScreenProps) {
 	const { t } = useTranslation();
 	const [activeTab, setActiveTab] = useState<EquipmentTab>("cameras");
 
@@ -43,7 +44,7 @@ export function EquipmentScreen({ data, setData }: EquipmentScreenProps) {
 				))}
 			</div>
 
-			{activeTab === "cameras" && <CamerasTab data={data} setData={setData} />}
+			{activeTab === "cameras" && <CamerasTab data={data} setData={setData} onCameraClick={onCameraClick} />}
 			{activeTab === "lenses" && <LensesTab data={data} setData={setData} />}
 			{activeTab === "backs" && <BacksTab data={data} setData={setData} />}
 		</div>

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -31,6 +31,7 @@ interface FilmDetailScreenProps {
 	setSelectedFilm: (id: string) => void;
 	filmId: string | null;
 	onNavigateToMap?: (filmId: string) => void;
+	onNavigateToCamera?: (camId: string) => void;
 	autoOpenShotNote?: boolean;
 	setAutoOpenShotNote?: (open: boolean) => void;
 }
@@ -42,6 +43,7 @@ export function FilmDetailScreen({
 	setSelectedFilm,
 	filmId,
 	onNavigateToMap,
+	onNavigateToCamera,
 	autoOpenShotNote,
 	setAutoOpenShotNote,
 }: FilmDetailScreenProps) {
@@ -241,7 +243,7 @@ export function FilmDetailScreen({
 
 			{/* Collapsible: Informations */}
 			<CollapsibleSection icon={Info} title={t("filmDetail.sectionInfo")} defaultOpen>
-				<FilmInfoSection film={film} data={data} />
+				<FilmInfoSection film={film} data={data} onCameraClick={onNavigateToCamera} />
 			</CollapsibleSection>
 
 			{/* Collapsible: Shot notes */}

--- a/src/screens/camera-detail/CameraFilmsList.tsx
+++ b/src/screens/camera-detail/CameraFilmsList.tsx
@@ -1,0 +1,73 @@
+import { ChevronRight, Film as FilmIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { EmptyState } from "@/components/EmptyState";
+import { Badge } from "@/components/ui/badge";
+import { getStates } from "@/constants/films";
+import { alpha } from "@/constants/theme";
+import type { Film, FilmState } from "@/types";
+import { filmName } from "@/utils/film-helpers";
+import { fmtDate } from "@/utils/helpers";
+
+interface CameraFilmsListProps {
+	films: Film[];
+	onFilmClick: (filmId: string) => void;
+}
+
+const STATE_ORDER: FilmState[] = ["loaded", "partial", "exposed", "developed", "scanned", "stock"];
+
+export function CameraFilmsList({ films, onFilmClick }: CameraFilmsListProps) {
+	const { t } = useTranslation();
+	const states = getStates(t);
+
+	if (films.length === 0) {
+		return (
+			<EmptyState icon={FilmIcon} title={t("cameraDetail.noFilms")} subtitle={t("cameraDetail.noFilmsSubtitle")} />
+		);
+	}
+
+	const groups = STATE_ORDER.map((state) => ({
+		state,
+		items: films.filter((f) => f.state === state),
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<div className="flex flex-col gap-4">
+			{groups.map(({ state, items }) => {
+				const config = states[state];
+				const Icon = config.icon;
+				return (
+					<div key={state} className="flex flex-col gap-2">
+						<div className="flex items-center gap-2">
+							<Icon size={14} color={config.color} />
+							<span className="text-[11px] font-bold font-body uppercase tracking-wide" style={{ color: config.color }}>
+								{config.label}
+							</span>
+							<Badge style={{ color: config.color, background: alpha(config.color, 0.09) }}>{items.length}</Badge>
+						</div>
+						{items.map((f) => {
+							const dateLabel = f.endDate || f.startDate || f.addedDate;
+							return (
+								<button
+									key={f.id}
+									type="button"
+									onClick={() => onFilmClick(f.id)}
+									className="flex items-center gap-3 w-full rounded-[12px] border border-border bg-card hover:bg-card-hover transition-colors p-3 text-left cursor-pointer"
+								>
+									<div className="flex-1 min-w-0">
+										<div className="text-[13px] font-semibold text-text-primary font-body truncate">{filmName(f)}</div>
+										<div className="text-[11px] font-mono text-text-muted truncate">
+											{f.shootIso != null ? `ISO ${f.shootIso} · ` : ""}
+											{fmtDate(dateLabel)}
+											{f.posesShot != null && f.posesTotal != null ? ` · ${f.posesShot}/${f.posesTotal}` : ""}
+										</div>
+									</div>
+									<ChevronRight size={14} className="text-text-muted shrink-0" />
+								</button>
+							);
+						})}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/screens/camera-detail/CameraHistoryTimeline.tsx
+++ b/src/screens/camera-detail/CameraHistoryTimeline.tsx
@@ -1,0 +1,139 @@
+import { Archive, Camera, ChevronRight, Clock, Eye, Plus, RotateCcw, ScanLine, Send } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { PhotoImg } from "@/components/ui/photo-img";
+import type { Film, HistoryAction, HistoryEntry, LucideIcon } from "@/types";
+import { filmName } from "@/utils/film-helpers";
+import { fmtDate } from "@/utils/helpers";
+
+interface CameraHistoryTimelineProps {
+	films: Film[];
+	onFilmClick: (filmId: string) => void;
+	onPhotoClick?: (photos: string[], index: number) => void;
+}
+
+interface EnrichedEntry extends HistoryEntry {
+	filmId: string;
+	filmLabel: string;
+	sourceIndex: number;
+}
+
+const ACTION_ICONS: Record<HistoryAction, LucideIcon> = {
+	added: Plus,
+	loaded: Camera,
+	reloaded: RotateCcw,
+	removed_partial: Clock,
+	exposed: Eye,
+	sent_dev: Send,
+	developed: Archive,
+	scanned: ScanLine,
+	modified: Plus,
+	duplicated: Plus,
+};
+
+const ACTION_KEYS: Record<
+	HistoryAction,
+	string | ((params?: Record<string, string | number | null | undefined>) => string)
+> = {
+	added: "filmDetail.historyAdded",
+	loaded: "filmDetail.historyLoaded",
+	reloaded: "filmDetail.historyReloaded",
+	removed_partial: "filmDetail.historyPartial",
+	exposed: "filmDetail.historyExposed",
+	sent_dev: "filmDetail.historySentDev",
+	developed: (params) => (params?.lab ? "filmDetail.historyDevelopedAt" : "filmDetail.historyDeveloped"),
+	scanned: (params) => (params?.ref ? "filmDetail.historyScannedRef" : "filmDetail.historyScanned"),
+	modified: "filmDetail.historyModified",
+	duplicated: "filmDetail.historyDuplicated",
+};
+
+// Actions directly involving the camera (kept in aggregated history)
+const CAMERA_ACTIONS = new Set<HistoryAction>(["loaded", "reloaded", "removed_partial", "exposed"]);
+
+export function CameraHistoryTimeline({ films, onFilmClick, onPhotoClick }: CameraHistoryTimelineProps) {
+	const { t } = useTranslation();
+
+	const entries: EnrichedEntry[] = films
+		.flatMap((f) =>
+			(f.history || [])
+				.map((h, idx): EnrichedEntry | null =>
+					!h.actionCode || CAMERA_ACTIONS.has(h.actionCode)
+						? { ...h, filmId: f.id, filmLabel: filmName(f), sourceIndex: idx }
+						: null,
+				)
+				.filter((e): e is EnrichedEntry => e !== null),
+		)
+		.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+	if (entries.length === 0) {
+		return <span className="text-[12px] text-text-muted font-body italic">{t("cameraDetail.noHistory")}</span>;
+	}
+
+	return (
+		<div>
+			<span className="text-[11px] font-bold text-text-muted font-body uppercase tracking-wide">
+				{t("timeline.history")}
+			</span>
+			<div className="mt-3 flex flex-col">
+				{entries.map((h, i) => {
+					const isFirst = i === 0;
+					const isLast = i === entries.length - 1;
+					let Icon: LucideIcon = Plus;
+					let text = h.action;
+					if (h.actionCode) {
+						Icon = ACTION_ICONS[h.actionCode];
+						const keyOrFn = ACTION_KEYS[h.actionCode];
+						const key = typeof keyOrFn === "function" ? keyOrFn(h.params) : keyOrFn;
+						text = t(key, h.params ?? {});
+					}
+
+					return (
+						<div key={`${h.filmId}-${h.sourceIndex}`} className="flex gap-3">
+							<div className="flex flex-col items-center">
+								<div
+									className={`w-3 h-3 rounded-full shrink-0 mt-0.5 ${
+										isFirst
+											? "bg-accent border-2 border-accent animate-timeline-pulse"
+											: "bg-bg border-2 border-border-light"
+									}`}
+								/>
+								{!isLast && <div className="w-[2px] flex-1 bg-border min-h-4" />}
+							</div>
+							<div className={`flex flex-col gap-0.5 ${isLast ? "pb-0" : "pb-3"} flex-1 min-w-0`}>
+								<div className="flex items-center gap-1.5">
+									<Icon size={12} className={isFirst ? "text-accent" : "text-text-muted"} />
+									<span className="text-[11px] text-text-muted font-mono">{fmtDate(h.date)}</span>
+								</div>
+								<span className={`text-xs font-body ${isFirst ? "text-text-primary" : "text-text-sec"}`}>{text}</span>
+								<button
+									type="button"
+									onClick={() => onFilmClick(h.filmId)}
+									className="flex items-center gap-1 text-[11px] font-body text-accent hover:underline self-start cursor-pointer"
+								>
+									<span className="truncate max-w-[220px]">{h.filmLabel}</span>
+									<ChevronRight size={11} />
+								</button>
+								{h.photos && h.photos.length > 0 && (
+									<div className="flex gap-1.5 mt-1.5">
+										{h.photos.map((photo, pi) => (
+											<Button
+												key={photo.slice(-20)}
+												variant="ghost"
+												size="icon"
+												onClick={() => onPhotoClick?.(h.photos!, pi)}
+												className="rounded-md overflow-hidden border border-border bg-surface-alt !p-0"
+												aria-label={t("aria.openPhoto", { index: pi + 1 })}
+											>
+												<PhotoImg src={photo} className="w-full h-full object-cover" alt="" />
+											</Button>
+										))}
+									</div>
+								)}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/src/screens/camera-detail/CameraHistoryTimeline.tsx
+++ b/src/screens/camera-detail/CameraHistoryTimeline.tsx
@@ -1,10 +1,11 @@
-import { Archive, Camera, ChevronRight, Clock, Eye, Plus, RotateCcw, ScanLine, Send } from "lucide-react";
+import { ChevronRight, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { PhotoImg } from "@/components/ui/photo-img";
-import type { Film, HistoryAction, HistoryEntry, LucideIcon } from "@/types";
+import type { Film, HistoryEntry, LucideIcon } from "@/types";
 import { filmName } from "@/utils/film-helpers";
 import { fmtDate } from "@/utils/helpers";
+import { CAMERA_HISTORY_ACTIONS, HISTORY_ACTION_ICONS, HISTORY_ACTION_KEYS } from "@/utils/history-action";
 
 interface CameraHistoryTimelineProps {
 	films: Film[];
@@ -18,46 +19,17 @@ interface EnrichedEntry extends HistoryEntry {
 	sourceIndex: number;
 }
 
-const ACTION_ICONS: Record<HistoryAction, LucideIcon> = {
-	added: Plus,
-	loaded: Camera,
-	reloaded: RotateCcw,
-	removed_partial: Clock,
-	exposed: Eye,
-	sent_dev: Send,
-	developed: Archive,
-	scanned: ScanLine,
-	modified: Plus,
-	duplicated: Plus,
-};
-
-const ACTION_KEYS: Record<
-	HistoryAction,
-	string | ((params?: Record<string, string | number | null | undefined>) => string)
-> = {
-	added: "filmDetail.historyAdded",
-	loaded: "filmDetail.historyLoaded",
-	reloaded: "filmDetail.historyReloaded",
-	removed_partial: "filmDetail.historyPartial",
-	exposed: "filmDetail.historyExposed",
-	sent_dev: "filmDetail.historySentDev",
-	developed: (params) => (params?.lab ? "filmDetail.historyDevelopedAt" : "filmDetail.historyDeveloped"),
-	scanned: (params) => (params?.ref ? "filmDetail.historyScannedRef" : "filmDetail.historyScanned"),
-	modified: "filmDetail.historyModified",
-	duplicated: "filmDetail.historyDuplicated",
-};
-
-// Actions directly involving the camera (kept in aggregated history)
-const CAMERA_ACTIONS = new Set<HistoryAction>(["loaded", "reloaded", "removed_partial", "exposed"]);
-
 export function CameraHistoryTimeline({ films, onFilmClick, onPhotoClick }: CameraHistoryTimelineProps) {
 	const { t } = useTranslation();
 
+	// Keep actions that physically involve the camera (load/reload/expose/remove).
+	// Legacy entries without an `actionCode` are also kept because they pre-date
+	// the structured codes and would otherwise be invisible for older films.
 	const entries: EnrichedEntry[] = films
 		.flatMap((f) =>
 			(f.history || [])
 				.map((h, idx): EnrichedEntry | null =>
-					!h.actionCode || CAMERA_ACTIONS.has(h.actionCode)
+					!h.actionCode || CAMERA_HISTORY_ACTIONS.has(h.actionCode)
 						? { ...h, filmId: f.id, filmLabel: filmName(f), sourceIndex: idx }
 						: null,
 				)
@@ -81,8 +53,8 @@ export function CameraHistoryTimeline({ films, onFilmClick, onPhotoClick }: Came
 					let Icon: LucideIcon = Plus;
 					let text = h.action;
 					if (h.actionCode) {
-						Icon = ACTION_ICONS[h.actionCode];
-						const keyOrFn = ACTION_KEYS[h.actionCode];
+						Icon = HISTORY_ACTION_ICONS[h.actionCode];
+						const keyOrFn = HISTORY_ACTION_KEYS[h.actionCode];
 						const key = typeof keyOrFn === "function" ? keyOrFn(h.params) : keyOrFn;
 						text = t(key, h.params ?? {});
 					}

--- a/src/screens/camera-detail/CameraInfoSection.tsx
+++ b/src/screens/camera-detail/CameraInfoSection.tsx
@@ -1,0 +1,47 @@
+import { Aperture, Camera as CameraIcon, Gauge, Hash, Layers, PackageX, Puzzle, Tag } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { InfoLine } from "@/components/InfoLine";
+import type { Camera } from "@/types";
+import { fmtDate } from "@/utils/helpers";
+
+interface CameraInfoSectionProps {
+	camera: Camera;
+}
+
+function stopsLabel(value: string | null | undefined, t: (k: string) => string): string | null {
+	if (!value) return null;
+	if (value === "1") return t("cameras.stopsFull");
+	if (value === "1/2") return t("cameras.stopsHalf");
+	if (value === "1/3") return t("cameras.stopsThird");
+	return value;
+}
+
+export function CameraInfoSection({ camera }: CameraInfoSectionProps) {
+	const { t } = useTranslation();
+	const shutterRange =
+		camera.shutterSpeedMin || camera.shutterSpeedMax
+			? `${camera.shutterSpeedMin ?? "—"} → ${camera.shutterSpeedMax ?? "—"}`
+			: null;
+	const shutterStops = stopsLabel(camera.shutterSpeedStops, t);
+	const apertureStops = stopsLabel(camera.apertureStops, t);
+
+	return (
+		<div className="flex flex-col gap-2">
+			{camera.brand && <InfoLine icon={Tag} label={t("cameras.brand")} value={camera.brand} />}
+			{camera.model && <InfoLine icon={CameraIcon} label={t("cameras.model")} value={camera.model} />}
+			{camera.nickname && <InfoLine icon={Hash} label={t("cameras.nickname")} value={camera.nickname} />}
+			{camera.serial && <InfoLine icon={Hash} label={t("cameras.serial")} value={camera.serial} />}
+			{camera.format && <InfoLine icon={Layers} label={t("cameras.format")} value={camera.format} />}
+			{camera.mount && <InfoLine icon={Puzzle} label={t("cameras.mount")} value={camera.mount} />}
+			{camera.hasInterchangeableBack && (
+				<InfoLine icon={Puzzle} label={t("cameras.interchangeableBack")} value={t("common.yes")} />
+			)}
+			{shutterRange && <InfoLine icon={Gauge} label={t("cameraDetail.shutterRange")} value={shutterRange} />}
+			{shutterStops && <InfoLine icon={Gauge} label={t("cameras.shutterSpeedStops")} value={shutterStops} />}
+			{apertureStops && <InfoLine icon={Aperture} label={t("cameras.apertureStops")} value={apertureStops} />}
+			{camera.soldAt && (
+				<InfoLine icon={PackageX} label={t("cameraDetail.archivedOn")} value={fmtDate(camera.soldAt)} />
+			)}
+		</div>
+	);
+}

--- a/src/screens/film-detail/FilmInfoSection.tsx
+++ b/src/screens/film-detail/FilmInfoSection.tsx
@@ -1,7 +1,6 @@
 import {
 	Aperture,
 	Calendar,
-	Camera,
 	CircleDot,
 	Coins,
 	Focus,
@@ -12,9 +11,9 @@ import {
 	Tag,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { CameraMiniCard } from "@/components/CameraMiniCard";
 import { InfoLine } from "@/components/InfoLine";
 import type { AppData, Film } from "@/types";
-import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 import { fmtExpDate, getExpirationStatus } from "@/utils/expiration";
 import { fmtDate, fmtPrice } from "@/utils/helpers";
 import { lensDisplayName } from "@/utils/lens-helpers";
@@ -22,9 +21,10 @@ import { lensDisplayName } from "@/utils/lens-helpers";
 interface FilmInfoSectionProps {
 	film: Film;
 	data: AppData;
+	onCameraClick?: (camId: string) => void;
 }
 
-export function FilmInfoSection({ film, data }: FilmInfoSectionProps) {
+export function FilmInfoSection({ film, data, onCameraClick }: FilmInfoSectionProps) {
 	const { t } = useTranslation();
 	const cam = film.cameraId ? data.cameras.find((c) => c.id === film.cameraId) : null;
 	const back = film.backId ? data.backs.find((b) => b.id === film.backId) : null;
@@ -41,11 +41,10 @@ export function FilmInfoSection({ film, data }: FilmInfoSectionProps) {
 			)}
 			{film.shootIso && <InfoLine icon={Aperture} label={t("filmDetail.shootIso")} value={film.shootIso} />}
 			{cam && (
-				<InfoLine
-					icon={Camera}
-					label={t("filmDetail.camera")}
-					value={`${cameraDisplayName(cam)}${back ? ` · ${backDisplayName(back)}` : ""}`}
-				/>
+				<div className="py-1">
+					<span className="text-xs text-text-muted font-body block mb-1.5">{t("filmDetail.camera")}</span>
+					<CameraMiniCard camera={cam} back={back} onClick={onCameraClick ? () => onCameraClick(cam.id) : undefined} />
+				</div>
 			)}
 			{(film.lensId || film.lens) && (
 				<InfoLine

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,7 +160,16 @@ export interface AppData {
 	version: number;
 }
 
-export type ScreenName = "home" | "stock" | "filmDetail" | "cameras" | "stats" | "settings" | "legal" | "map";
+export type ScreenName =
+	| "home"
+	| "stock"
+	| "filmDetail"
+	| "cameras"
+	| "cameraDetail"
+	| "stats"
+	| "settings"
+	| "legal"
+	| "map";
 
 export interface StateConfig {
 	label: string;

--- a/src/utils/history-action.ts
+++ b/src/utils/history-action.ts
@@ -1,0 +1,33 @@
+import { Archive, Camera, Clock, Eye, Plus, RotateCcw, ScanLine, Send } from "lucide-react";
+import type { HistoryAction, LucideIcon } from "@/types";
+
+export const HISTORY_ACTION_ICONS: Record<HistoryAction, LucideIcon> = {
+	added: Plus,
+	loaded: Camera,
+	reloaded: RotateCcw,
+	removed_partial: Clock,
+	exposed: Eye,
+	sent_dev: Send,
+	developed: Archive,
+	scanned: ScanLine,
+	modified: Plus,
+	duplicated: Plus,
+};
+
+type Params = Record<string, string | number | null | undefined>;
+
+export const HISTORY_ACTION_KEYS: Record<HistoryAction, string | ((params?: Params) => string)> = {
+	added: "filmDetail.historyAdded",
+	loaded: "filmDetail.historyLoaded",
+	reloaded: "filmDetail.historyReloaded",
+	removed_partial: "filmDetail.historyPartial",
+	exposed: "filmDetail.historyExposed",
+	sent_dev: "filmDetail.historySentDev",
+	developed: (params) => (params?.lab ? "filmDetail.historyDevelopedAt" : "filmDetail.historyDeveloped"),
+	scanned: (params) => (params?.ref ? "filmDetail.historyScannedRef" : "filmDetail.historyScanned"),
+	modified: "filmDetail.historyModified",
+	duplicated: "filmDetail.historyDuplicated",
+};
+
+/** Actions where the film physically interacts with the camera. */
+export const CAMERA_HISTORY_ACTIONS = new Set<HistoryAction>(["loaded", "reloaded", "removed_partial", "exposed"]);


### PR DESCRIPTION
Introduces a dedicated camera detail screen accessible from the equipment
tab (clickable card + eye button) and from any film that references the
camera. The screen shows full specs, associated films grouped by state,
and an aggregated timeline of load/reload/expose/remove events.

The film detail view now shows a richer camera mini-card (photo, name,
format, mount, back) that links to the new screen.

The archive (sell) button in the equipment tab is hidden when a film is
currently loaded in the camera, so an in-use body cannot be archived by
accident.