### PR TITLE
docs: add technical documentation under docs/

### DIFF
--- a/.claude/rules/data-model.md
+++ b/.claude/rules/data-model.md
@@ -11,3 +11,5 @@ globs: src/utils/**/*.ts, src/types.ts
 - Les changements de schema doivent passer par une migration dans `src/utils/migrations.ts` et incrementer le numero de version
 - Les films suivent un cycle d'etats : stock -> loaded -> partial -> exposed -> developed
 - Chaque changement d'etat doit etre enregistre dans `film.history`
+
+Reference detaillee : `docs/data-model.md` (types complets, invariants) et `docs/persistence.md` (pipeline de migrations, procedure d'ajout).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,18 @@ src/
 - **Langue** : UI et labels en francais, code (variables, fonctions, types) en anglais
 - **Types** : definir les interfaces props au-dessus du composant, utiliser `type` pour les unions simples
 - **Design tokens** : utiliser les variables Tailwind custom (`text-text-primary`, `bg-surface`, `text-accent`...) definies dans `index.css` et `constants/theme.ts`
+
+## Documentation technique
+
+Documentation detaillee dans `docs/` — a consulter avant toute modification non triviale :
+
+- [`docs/architecture.md`](docs/architecture.md) — flux applicatif, gestion d'etat, cycle de demarrage, routing
+- [`docs/data-model.md`](docs/data-model.md) — types partages, cycle de vie des films, `HistoryEntry`, invariants
+- [`docs/persistence.md`](docs/persistence.md) — localStorage, pipeline de migrations, procedure d'ajout
+- [`docs/cloud-sync.md`](docs/cloud-sync.md) — Supabase, recovery codes, RPCs, strategie de merge, photos
+- [`docs/ui-system.md`](docs/ui-system.md) — design tokens Tailwind 4, `T`, composants UI, conventions
+- [`docs/screens.md`](docs/screens.md) — inventaire des 8 ecrans et de leurs props
+- [`docs/i18n.md`](docs/i18n.md) — namespaces FR/EN, pluralisation, ajout d'une traduction
+- [`docs/recipes.md`](docs/recipes.md) — guides pas-a-pas pour les extensions recurrentes
+
+Les regles courtes dans `.claude/rules/` restent la source pour le style de code au jour le jour ; `docs/` sert de reference detaillee.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,134 @@
+# Architecture
+
+Vue d'ensemble du flux applicatif de FilmVault. Compléter avec `docs/data-model.md` pour les types et `docs/persistence.md` pour la couche de stockage.
+
+## Stack technique
+
+| Couche | Outil | Version |
+| --- | --- | --- |
+| Framework | React | 19.2 |
+| Langage | TypeScript (strict) | 6.0 |
+| Build | Vite | 8.0 |
+| Styling | Tailwind CSS 4 (`@tailwindcss/vite`) | 4.2 |
+| UI primitives | Radix UI (`@radix-ui/react-*`) | 1.x / 2.x |
+| Icônes | Lucide React | 1.7 |
+| i18n | i18next + react-i18next | 26 / 17 |
+| Cartes | `maplibre-gl` + `react-map-gl` | 5 / 8 |
+| Cloud (optionnel) | `@supabase/supabase-js` | 2.101 |
+| PWA | `vite-plugin-pwa` (Workbox) | 1.2 |
+| Lint/Format | Biome | 2.4 |
+| Tests E2E | Playwright | 1.59 |
+
+Scripts NPM : `npm run dev | build | preview | lint | format | test | test:ui`.
+
+## Point d'entrée
+
+- `src/main.tsx` : monte React en `StrictMode`, charge `src/utils/i18n.ts` puis rend `<App />`.
+- `src/App.tsx` : expose `FilmVaultInner` qui concentre tout l'état applicatif, enveloppé par `ThemeProvider`, `ToastProvider` et `TourProvider`.
+
+## Gestion d'état
+
+Le projet n'utilise ni Redux, ni Zustand, ni Context global pour les données. Le composant `FilmVaultInner` (`src/App.tsx`) détient :
+
+- `data: AppData | null` — état principal persisté (`useState`)
+- `dataRef: useRef<AppData | null>` — miroir pour closures stables (listeners `online`)
+- `loading`, `screen`, `selectedFilm`, `stockStateFilter`, `mapFilterFilmId`, `autoOpenShotNote`, `showAddFilm`, `persistent`, `syncing`, `recoveryCode` — UI/session state
+
+La fonction `updateData(newData)` (`src/App.tsx:44`) est l'unique point de mutation :
+
+```ts
+setData(newData);
+dataRef.current = newData;
+if (isStorageAvailable()) await saveData(newData);
+const code = getRecoveryCode();
+if (code && isSupabaseConfigured) pushToCloud(code, newData).catch(() => {});
+```
+
+Conséquence : **toute modification passe par `updateData`** — jamais de `setData` direct, jamais de mutation en place. Voir `docs/persistence.md` pour le pipeline save/sync.
+
+## Propagation du state
+
+`AppContent` (dans `src/App.tsx`) est le relais qui distribue `data`, `updateData` et les setters vers les écrans :
+
+```
+FilmVaultInner
+  └── AppContent (data, updateData, screen, setSelectedFilm, ...)
+        ├── TabBar (navigation)
+        ├── AppHeader
+        └── renderScreen() switch
+              ├── DashboardScreen
+              ├── StockScreen        (data, updateData, setSelectedFilm, ...)
+              ├── FilmDetailScreen   (data, updateData, selectedFilm, ...)
+              ├── EquipmentScreen
+              ├── StatsScreen
+              ├── SettingsScreen
+              ├── MapScreen          (lazy)
+              └── LegalScreen
+```
+
+Le prop drilling est assumé et explicite. Les callbacks (`onAddFilm`, `onUpdateFilm`, `onDeleteFilm`…) remontent jusqu'à `updateData`.
+
+## Routing
+
+Pas de React Router. `screen: ScreenName` (type défini dans `src/types.ts`) est une union :
+
+```
+"home" | "stock" | "filmDetail" | "cameras" | "stats" | "settings" | "legal" | "map"
+```
+
+Un `switch` dans `renderScreen()` (`src/App.tsx`) choisit l'écran. `MapScreen` est chargé en lazy via `React.lazy` + `Suspense` pour isoler la bundle Leaflet/MapLibre.
+
+## Cycle de démarrage
+
+`useEffect` de `FilmVaultInner` (`src/App.tsx:81`) :
+
+1. `ensureAnonSession()` si `isSupabaseConfigured && navigator.onLine`
+2. `checkStorage()` → active `isStorageAvailable`
+3. `loadData()` → lit localStorage, applique migrations si `version < CURRENT_VERSION`, normalise
+4. Si pas de données locales valides → `getInitialData()` (AppData vide, `version = CURRENT_VERSION`)
+5. Si `getRecoveryCode()` et Supabase configuré → `syncData(code, appData)` (compare timestamps local/cloud, conserve le plus récent)
+6. `refreshCatalogs()` en arrière-plan (catalogues films/caméras Supabase)
+7. `setLoading(false)`
+
+Un listener `window.addEventListener("online")` déclenche `triggerSync()` pour resynchroniser dès retour en ligne.
+
+## Providers
+
+- **ThemeProvider** (`src/components/ThemeProvider.tsx`) : ajoute/retire la classe `html.light` selon la préférence stockée.
+- **ToastProvider** (`src/components/Toast.tsx`) : hook `useToast()` qui expose `toast(msg, "success" | "error")`.
+- **TourProvider** (`src/tour/TourProvider.tsx`) : onboarding optionnel piloté par `hasCompletedTour()` et les étapes de `src/tour/tour-steps.ts`.
+
+## Arborescence `src/`
+
+```
+src/
+├── main.tsx, App.tsx, index.css, types.ts
+├── lib/
+│   └── utils.ts                  # cn()
+├── components/
+│   ├── ui/                       # 17 primitives (voir docs/ui-system.md)
+│   ├── equipment/                # CamerasTab, LensesTab, BacksTab
+│   ├── map/                      # MapFilterBar, ClusterSheet, NoteSheet, NoteMarker
+│   └── *.tsx                     # 24 composants métier
+├── screens/                      # 9 écrans (voir docs/screens.md)
+│   └── film-detail/              # Sous-composants de FilmDetailScreen
+├── constants/                    # theme.ts, films.ts, photography.ts, film-catalog.ts
+├── utils/                        # storage, migrations, sync, helpers, hooks
+├── locales/                      # fr.ts, en.ts
+└── tour/                         # Onboarding
+```
+
+## PWA & déploiement
+
+- `vite.config.ts` configure `VitePWA` avec `registerType: "prompt"`, manifest `My Film Vault`, icons 192/512, caching Google Fonts via Workbox `CacheFirst`.
+- `PwaUpdateBanner` (`src/components/PwaUpdateBanner.tsx`) exploite `virtual:pwa-register/react` pour proposer la mise à jour.
+- `base: "./"` dans `vite.config.ts` pour compatibilité GitHub Pages.
+- CI : `.github/workflows/deploy.yml` (jobs `migrate` Supabase → `build` → `deploy` Pages). Env vars `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` injectées au build.
+
+## Conventions transverses
+
+- Alias `@/*` → `src/*` (défini dans `vite.config.ts` et `tsconfig.json`). **Jamais d'imports relatifs `../`**.
+- Named exports uniquement (pas de `export default`, sauf `i18n.ts`).
+- Interfaces props nommées `{ComponentName}Props`, déclarées au-dessus du composant.
+- Tout texte utilisateur passe par `t()` (voir `docs/i18n.md`).
+- Tout changement de schéma `AppData` impose une migration (voir `docs/persistence.md`).

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -1,0 +1,127 @@
+# Cloud sync (Supabase)
+
+Synchronisation optionnelle via Supabase, activée quand les variables d'environnement sont présentes. L'application fonctionne parfaitement sans cloud.
+
+## Configuration
+
+Variables d'environnement requises (build Vite) :
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+
+Injectées en CI par `.github/workflows/deploy.yml` (étape `build`). Le flag `isSupabaseConfigured` (`src/utils/supabase.ts`) est `true` si les deux sont définies. Le client `supabase` est `null` sinon, et toutes les fonctions cloud retournent prématurément.
+
+## Auth anonyme
+
+`ensureAnonSession()` (`src/utils/supabase.ts:15`) appelé au démarrage par `FilmVaultInner` :
+
+- Si une session existe déjà (persistée par `supabase-js` en localStorage), no-op.
+- Sinon, `supabase.auth.signInAnonymously()`.
+
+C'est `auth.uid()` qui identifie l'utilisateur côté Postgres (d'où le suffixe `_v3` des RPCs). Le recovery code est un mécanisme de liaison entre plusieurs sessions anonymes (même utilisateur, plusieurs appareils).
+
+## Recovery codes
+
+Format : `FILM-XXXX-XXXX`. Généré par `generateRecoveryCode()` (`src/utils/sync.ts:12`) à partir d'un alphabet sans ambiguïté (pas de `I`/`O`/`0`/`1`).
+
+API (`src/utils/sync.ts`) :
+
+| Fonction | Rôle |
+| --- | --- |
+| `generateRecoveryCode()` | Génère un nouveau code. |
+| `getRecoveryCode()` | Lit `localStorage["filmvault-recovery-code"]`. |
+| `setRecoveryCode(code)` | Persiste localement. |
+| `clearRecoveryCode()` | Supprime code + `filmvault-last-sync` + cache URL signées. |
+| `activateCloud(code): Promise<string \| null>` | RPC `activate_cloud` : crée un profil lié à la session anon courante. |
+| `linkRecoveryCode(code): Promise<string \| null>` | RPC `link_recovery_code` : rattache un code existant (restauration sur un nouvel appareil). |
+
+Flow UI côté `SettingsScreen` :
+
+1. « Activer la sync » → `generateRecoveryCode()` → `activateCloud(code)` → `setRecoveryCode(code)` → `pushToCloud(code, data)`.
+2. « Restaurer avec un code » → `setRecoveryCode(code)` → `linkRecoveryCode(code)` → `syncData(code, data)`.
+
+## RPCs Supabase utilisés
+
+| Fonction PG | Appelant | Rôle |
+| --- | --- | --- |
+| `activate_cloud(p_recovery_code)` | `activateCloud` | Crée `user_profiles` + lie à `auth.uid()`. |
+| `link_recovery_code(p_recovery_code)` | `linkRecoveryCode` | Lie un code existant à la session anon courante. |
+| `upsert_user_data_v3(p_data, p_version, p_updated_at)` | `pushToCloud` | Upsert `AppData` sérialisé (photos déjà extraites vers Storage). |
+| `get_user_data_v3()` | `pullFromCloud`, `syncData` | Retourne `{ data, version, updated_at }`. |
+| `get_profile_id()` | `getProfileId` | Retourne l'UUID du profil (racine des chemins Storage). |
+| `get_film_catalog()` | `refreshCatalogs` | Catalogue films serveur. |
+| `get_camera_catalog()` | `refreshCatalogs` | Catalogue caméras serveur. |
+
+Les migrations SQL vivent côté Supabase (dossier `supabase/` versionné) et sont poussées par le job `migrate` de `.github/workflows/deploy.yml` via `SUPABASE_DB_URL` en secret.
+
+## Pipeline `updateData` → cloud
+
+Lors de chaque mutation :
+
+1. `setData` / `saveData` (localStorage)
+2. `pushToCloud(code, newData)` en arrière-plan, **fire-and-forget** (`.catch(() => {})`)
+3. Aucun feedback UI sur la réussite : la sync est transparente, `setLastSync()` trace l'horodatage en cas de succès.
+
+## Stratégie de merge : `syncData`
+
+Signature : `syncData(code, localData): Promise<{ data, source: "local" | "cloud" }>` (`src/utils/sync.ts:176`).
+
+1. Appelle `get_user_data_v3`.
+2. Si aucune ligne trouvée, tente `linkRecoveryCode(code)` (cas d'un utilisateur v2 non encore lié à auth) puis retry.
+3. Si toujours rien → `pushToCloud(code, localData)` puis retourne `{ source: "local" }`.
+4. Si ligne trouvée, compare `row.updated_at` (cloud) vs `getLastModified()` (local) :
+   - **Cloud plus récent** : valide le payload (`validateAppData`), applique migrations si besoin, `setLastSync()`, retourne `{ source: "cloud" }`. Si le cloud contient encore des photos base64 héritées, relance `pushToCloud` en arrière-plan pour les migrer vers Storage.
+   - **Local plus récent ou égal** : `pushToCloud(code, localData)`, retourne `{ source: "local" }`.
+5. Toute exception → `{ source: "local" }` (l'app reste utilisable hors ligne).
+
+Le champ `getLastModified()` est remis à jour à chaque `saveData` local ; `setLastSync()` à chaque `pushToCloud`/`syncData` réussi.
+
+## Photos
+
+Deux représentations coexistent pour `Camera.photo`, `Lens.photo`, `Back.photo`, `ShotNote.photo`, `HistoryEntry.photos[]` :
+
+- **Data URL** (`data:image/jpeg;base64,…`) — stockage local, généré via `src/utils/image.ts` (`compressImage`).
+- **Chemin Storage** (`{profileId}/…`) — après upload, référence le bucket Supabase.
+
+### `src/utils/photo-sync.ts`
+
+| Fonction | Rôle |
+| --- | --- |
+| `getProfileId(): Promise<string \| null>` | RPC `get_profile_id`, cache en mémoire. Utilisé comme racine des chemins Storage. |
+| `resolvePhotoSrc(ref): string \| null` | Retourne les data URLs telles quelles ; pour les chemins Storage, renvoie une URL signée depuis le cache (TTL 50 min). |
+| `isBase64Photo(ref)`, `isStoragePath(ref)` | Discriminateurs. |
+| `extractAndUploadPhotos(data): Promise<AppData>` | Itère toutes les photos base64, les upload dans `storage.from("photos")`, remplace les références par des chemins. Appelé par `pushToCloud`. |
+| `hasBase64Photos(data): boolean` | Permet à `syncData` de forcer une migration photo → Storage. |
+| `clearUrlCache()` | Invalide les URLs signées (changement de profil). |
+
+**Signed URLs** : un hook consommateur (ex. composant `PhotoImg`) appelle une fonction d'hydratation pour pré-charger les URLs signées manquantes. Les URLs sont valides 60 min côté Supabase ; le cache expire à 50 min pour une marge de sécurité.
+
+## Catalogues (Supabase)
+
+`src/utils/catalog.ts` fournit des catalogues films/caméras **en lecture** partagés entre utilisateurs :
+
+- `refreshCatalogs()` : RPCs `get_film_catalog` + `get_camera_catalog`, merge incrémental avec horodatages serveur, cache en mémoire + localStorage.
+- `getFilmCatalog()` / `getCameraCatalog()` : lecture synchrone avec fallback sur `FILM_CATALOG` hardcodé (`src/constants/film-catalog.ts`) si le cache est vide.
+
+Utilisés par `useFilmSuggestions` (autocomplete `AddFilmDialog`) et les onglets d'équipement.
+
+## Schéma table `user_data` (résumé)
+
+Colonnes utiles (gérées côté Postgres, pas directement accédées depuis le client) :
+
+| Colonne | Type | Usage |
+| --- | --- | --- |
+| `auth_uid` | UUID | `auth.uid()` de la session. Clé de lookup pour les RPCs v3. |
+| `recovery_code` | TEXT | Clé de liaison multi-device. |
+| `data` | JSONB | `AppData` sérialisé. |
+| `version` | INTEGER | Version schéma au moment du push. |
+| `updated_at` | TIMESTAMPTZ | Comparé à `getLastModified()`. |
+
+Le client ne fait jamais de SELECT direct : tout passe par les RPCs déclarées ci-dessus.
+
+## Points d'attention
+
+- **Ne jamais awaiter `pushToCloud` dans un chemin UI critique** : fire-and-forget obligatoire pour ne pas bloquer le flux `updateData`.
+- **Respecter l'ordre migration** : un `pullFromCloud` sur un `AppData` d'une version inférieure ré-applique les migrations — les migrations doivent donc rester pures et tolérantes aux données partiellement manquantes.
+- **Ne pas stocker de PII** : le schéma est pensé pour des données de collection (films, appareils), pas pour de l'identifiant personnel.
+- **Hors ligne** : `navigator.onLine` est testé avant chaque appel réseau. Le listener `online` relance `triggerSync`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,244 @@
+# Modèle de données
+
+Référence des types partagés. Source de vérité : `src/types.ts`. Tout changement de schéma doit être accompagné d'une migration (voir `docs/persistence.md`).
+
+## Structure racine : `AppData`
+
+```ts
+interface AppData {
+  films: Film[];
+  cameras: Camera[];
+  backs: Back[];
+  lenses: Lens[];
+  version: number;   // CURRENT_VERSION courante = 17
+}
+```
+
+Persisté en localStorage sous la clé `filmvault-data` (voir `docs/persistence.md`).
+
+## Unions et énumérations
+
+### `FilmFormat`
+```
+"35mm" | "120"
+| "Instax Mini" | "Instax Square" | "Instax Wide"
+| "Polaroid SX-70" | "Polaroid 600" | "Polaroid I-Type" | "Polaroid Go"
+```
+
+Helper `isInstantFormat(format)` (`src/types.ts:25`) détecte les formats instantanés via la constante `INSTANT_FORMATS`.
+
+### `FilmType`
+```
+"Couleur" | "N&B" | "Diapo" | "ECN-2"
+```
+
+Couleurs associées dans `FILM_TYPE_COLORS` (`src/constants/theme.ts`).
+
+### `FilmState`
+```
+"stock" | "loaded" | "partial" | "exposed" | "developed" | "scanned"
+```
+
+Configuration (label i18n, couleur, icône Lucide) fournie par `getStates(t)` dans `src/constants/films.ts`.
+
+### `HistoryAction`
+```
+"added" | "loaded" | "reloaded" | "removed_partial"
+| "exposed" | "sent_dev" | "developed" | "scanned"
+| "modified" | "duplicated"
+```
+
+### `StopIncrement`
+```
+"1" | "1/2" | "1/3"
+```
+Incrément des crans de vitesse/ouverture pour une `Camera` ou `Lens`.
+
+## `Film`
+
+Le type central. Champs par catégorie (voir `src/types.ts:67`) :
+
+**Identité**
+- `id: string` — UUID généré par `uid()` (`src/utils/helpers.ts`)
+- `brand?`, `model?`, `customName?`
+- `iso?: number`, `type?: string` (FilmType), `format?: string` (FilmFormat)
+
+**Stock**
+- `state: FilmState` (obligatoire)
+- `quantity?: number`, `price?: number | null`, `expDate?: string | null` (`YYYY-MM`)
+- `comment?`, `storageLocation?`
+- `addedDate: string` (`YYYY-MM-DD`, obligatoire)
+
+**Utilisation**
+- `shootIso?: number | null` — ISO réel d'exposition (peut différer de `iso`)
+- `cameraId?: string | null`, `backId?: string | null`, `lensId?: string | null`
+- `lens?: string | null` — texte libre (legacy avant `lensId`)
+- `startDate?: string | null`, `endDate?: string | null`
+- `posesShot?: number | null`, `posesTotal?: number | null`
+
+**Développement**
+- `lab?: string | null`, `labRef?: string | null`, `devDate?: string | null`
+- `devCost?: number | null`, `scanCost?: number | null`, `devScanPackage?: boolean`
+- `scanRef?: string | null`
+
+**Journalisation**
+- `history: HistoryEntry[]` — obligatoire, démarre avec `{ actionCode: "added" }`
+- `shotNotes?: ShotNote[]` — notes par vue
+
+### Poses par défaut
+
+Créés par `createNewFilm()` (`src/utils/film-factory.ts`) via la table `DEFAULT_POSES` :
+
+| Format | Poses |
+| --- | --- |
+| `35mm` | 36 |
+| `120` | 12 |
+| `Instax Mini/Square/Wide` | 10 |
+| `Polaroid SX-70/600/I-Type/Go` | 8 |
+
+## Cycle de vie des pellicules
+
+```
+stock ──loaded──▶ loaded ──removed_partial──▶ partial ──loaded──▶ loaded …
+                   │                           │
+                   └──exposed──▶ exposed ◀─────┘
+                                   │
+                                   ├──sent_dev──▶ (pas de nouvel état, ajoute entrée history)
+                                   │
+                                   └──developed──▶ developed ──scanned──▶ scanned
+```
+
+**Règle** : chaque transition pousse une entrée dans `film.history` avec l'`actionCode` correspondant. C'est la seule source de vérité pour tracer l'historique.
+
+## `HistoryEntry`
+
+```ts
+interface HistoryEntry {
+  date: string;                    // "YYYY-MM-DD"
+  action: string;                  // Texte libre, deprecated depuis v7 (peut être "")
+  actionCode?: HistoryAction;      // Préféré
+  params?: Record<string, string | number | null | undefined>;
+  photos?: string[];               // Data URL ou chemins Storage Supabase
+}
+```
+
+Paramètres attendus par `actionCode` :
+
+| `actionCode` | `params` |
+| --- | --- |
+| `added` | — |
+| `loaded` | `{ camera: string }` — nom affiché de l'appareil |
+| `reloaded` | `{ camera: string }` |
+| `removed_partial` | `{ posesShot: number, posesTotal: number }` |
+| `exposed` | — |
+| `sent_dev` | — |
+| `developed` | `{ lab: string \| null }` |
+| `scanned` | `{ ref: string \| null }` |
+| `modified` | — |
+| `duplicated` | `{ name: string }` — nom du film source |
+
+Le champ `action` (texte libre) reste présent pour rétrocompatibilité : la migration v6→v7 parse les anciens textes bilingues et renseigne `actionCode` + `params`. Depuis v7, `action` peut rester vide.
+
+## `ShotNote`
+
+Notes par vue, géolocalisées, attachées à `Film.shotNotes` :
+
+```ts
+interface ShotNote {
+  id: string;
+  frameNumber?: number | null;
+  aperture?: string | null;      // Issu de APERTURES (src/constants/photography.ts)
+  shutterSpeed?: string | null;  // Issu de SHUTTER_SPEEDS
+  lens?: string | null;          // Texte libre (fallback si pas de lensId)
+  lensId?: string | null;        // Référence à Lens.id
+  location?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  notes?: string | null;
+  date?: string | null;
+  photo?: string | null;
+}
+```
+
+## `Camera`
+
+```ts
+interface Camera {
+  id: string;
+  brand: string; model: string; nickname: string; serial: string;
+  format: string;                       // FilmFormat
+  hasInterchangeableBack: boolean;
+  photo?: string;                       // Data URL ou path Storage
+  mount?: string | null;                // "M42", "EF", "F", ...
+  shutterSpeedMin?: string | null;
+  shutterSpeedMax?: string | null;
+  shutterSpeedStops?: StopIncrement | null;
+  apertureStops?: StopIncrement | null;
+  soldAt?: string | null;               // Date de revente
+}
+```
+
+Helper d'affichage : `cameraDisplayName(cam)` dans `src/utils/camera-helpers.ts`.
+
+## `Back`
+
+Dos interchangeable (un boîtier de film séparé du corps de la caméra) :
+
+```ts
+interface Back {
+  id: string;
+  name: string;
+  nickname?: string; ref?: string; serial?: string; photo?: string;
+  format: string;
+  compatibleCameraIds: string[];        // IDs de Camera compatibles
+  soldAt?: string | null;
+}
+```
+
+Extrait de `Camera.backs[]` par la migration v9→v10. Helper `backDisplayName(back)` dans `src/utils/camera-helpers.ts`.
+
+## `Lens`
+
+```ts
+interface Lens {
+  id: string;
+  brand: string; model: string; nickname?: string; serial?: string; photo?: string;
+  mount?: string;
+  isZoom?: boolean;                     // Calculé v13→v14
+  focalLengthMin?: number | null;
+  focalLengthMax?: number | null;
+  maxApertureAtMin?: string | null;
+  maxApertureAtMax?: string | null;
+  apertureMin?: string | null;
+  apertureMax?: string | null;
+  apertureStops?: StopIncrement | null;
+  shutterSpeedMin?: string | null;
+  shutterSpeedMax?: string | null;
+  shutterSpeedStops?: StopIncrement | null;
+  soldAt?: string | null;
+}
+```
+
+Helpers : `lensDisplayName()`, `lensFocalLabel()`, `lensApertureLabel()` dans `src/utils/lens-helpers.ts`.
+
+## Types UI
+
+```ts
+type ScreenName = "home" | "stock" | "filmDetail" | "cameras"
+                | "stats" | "settings" | "legal" | "map";
+
+interface StateConfig {
+  label: string;
+  color: string;
+  icon: ComponentType<{ size?; color?; className?; strokeWidth? }>;
+}
+
+type LucideIcon = StateConfig["icon"];
+```
+
+## Invariants
+
+- `film.id`, `camera.id`, `back.id`, `lens.id` sont **stables** : toute référence (`cameraId`, `compatibleCameraIds`, `lensId`) doit rester cohérente lors d'une suppression → nettoyer les références orphelines ou refuser la suppression.
+- `film.state` et `film.history` sont cohérents : la dernière entrée significative doit correspondre à l'état courant.
+- Immutabilité : toute mise à jour crée de nouveaux objets (`{ ...film, state: "exposed" }`), jamais de mutation en place avant `updateData`.
+- `version` doit toujours valoir `CURRENT_VERSION` après `loadData`/`parseImportFile`/`getInitialData`.

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,0 +1,96 @@
+# Internationalisation
+
+Configuration i18next : `src/utils/i18n.ts`. Locales : `src/locales/fr.ts` et `src/locales/en.ts`.
+
+## Setup
+
+- Librairies : `i18next@^26` + `react-i18next@^17`.
+- Langues supportées : `fr` (par défaut et fallback) et `en`.
+- Persistance : `localStorage["filmvault-locale"]` (lu au démarrage, écrit sur `languageChanged`).
+- `document.documentElement.lang` mis à jour automatiquement sur changement.
+
+L'initialisation est faite dès l'import du module (`src/main.tsx` importe `@/utils/i18n`).
+
+## Utilisation dans un composant
+
+```tsx
+import { useTranslation } from "react-i18next";
+
+export function MyComponent() {
+  const { t } = useTranslation();
+  return <h1>{t("dashboard.inStock")}</h1>;
+}
+```
+
+Pour une fonction utilitaire en dehors de React, on accepte `t?: TFunction` en paramètre (voir `getStates(t)` dans `src/constants/films.ts` ou `getExpirationStatus(expDate, t?)` dans `src/utils/expiration.ts`) — et on fournit des fallbacks français en dur si `t` est absent.
+
+## Namespaces
+
+Les deux fichiers `src/locales/{fr,en}.ts` exportent un objet structuré par domaine (un seul namespace `translation` côté i18next, structuré par clés imbriquées).
+
+| Namespace | Contenu |
+| --- | --- |
+| `common` | `cancel`, `confirm`, … |
+| `nav` | Labels de `TabBar` / `AppHeader` |
+| `states` | Labels de `FilmState` |
+| `expiration` | `expired`, `expiringSoon` |
+| `dashboard` | Section accueil (compteurs, TODO, équipement) |
+| `stock` | Recherche, filtres, tri, groupes |
+| `stats` | Titres et légendes de `StatsScreen` |
+| `addFilm` | Dialog d'ajout |
+| `filmTypes` | Libellés de `FilmType` |
+| `filmFormats` | Libellés de `FilmFormat` |
+| `filmDetail` | Écran détail + modals de transition/dev/scan |
+| `equipment` | Gestion caméras/objectifs/dos |
+| `lenses`, `cameras` | Sous-sections spécifiques |
+| `settings` | Réglages, sync, import/export |
+| `timeline` | Entrées d'historique (format par `actionCode`) |
+| `pwa` | Bannières d'installation/update |
+| `app` | Messages système (erreurs save/sync) |
+| `storage` | Messages d'import/export |
+| `aria` | Labels ARIA non-visuels |
+| `map` | Écran carte |
+| `legal` | Mentions légales |
+| `tour` | Onboarding |
+
+## Pluralisation et interpolation
+
+Les clés pluralisées suivent la convention i18next : suffixes `_one`, `_other`, … Exemple :
+
+```ts
+// fr.ts
+dashboard: {
+  partiallyExposed_one: "{{count}} pellicule partiellement exposée",
+  partiallyExposed_other: "{{count}} pellicules partiellement exposées",
+}
+```
+
+Usage :
+
+```tsx
+t("dashboard.partiallyExposed", { count: 3 })
+```
+
+Pour des variables simples, utiliser `{{var}}` :
+
+```ts
+loaded: "Chargée dans {{camera}}"
+```
+
+## Règles
+
+- **Tout texte affiché à l'utilisateur passe par `t()`** — jamais de chaîne française codée en dur dans un composant ou un écran.
+- Exception : les libellés de `FilmType`/`FilmFormat` sont aussi des **valeurs de données** (`"Couleur"`, `"35mm"`…) — ils apparaissent tels quels dans `AppData`. L'affichage passe par `filmTypes.*` / `filmFormats.*` pour la localisation.
+- Les fichiers `src/locales/{fr,en}.ts` doivent rester **symétriques** : toute clé ajoutée à `fr.ts` doit exister dans `en.ts` (et vice-versa). TypeScript ne le vérifie pas automatiquement.
+
+## Ajouter une traduction
+
+1. Ouvrir `src/locales/fr.ts` et `src/locales/en.ts` en parallèle.
+2. Ajouter la clé dans le bon namespace, dans les deux fichiers.
+3. Respecter la pluralisation i18next (`_one`, `_other`) si applicable.
+4. Consommer avec `const { t } = useTranslation(); t("namespace.key")`.
+5. Passer les variables via le deuxième argument : `t("stock.foundCount", { count: list.length })`.
+
+## Accents et caractères spéciaux
+
+Les fichiers de locale utilisent UTF-8 avec accents (« Pellicule », « Périmée », etc.). Biome ne transforme pas ces caractères. Ne pas remplacer par des équivalents ASCII — la version française reste francophone typographiquement correcte.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,124 @@
+# Persistence & migrations
+
+Couche localStorage + pipeline de versioning. Source de vérité : `src/utils/storage.ts` et `src/utils/migrations.ts`.
+
+## localStorage
+
+Clés utilisées :
+
+| Clé | Contenu | Producteur |
+| --- | --- | --- |
+| `filmvault-data` | `AppData` sérialisé JSON | `saveData()` |
+| `filmvault-test` | Sonde d'accès (crée/supprime) | `checkStorage()` |
+| `filmvault-locale` | `"fr"` \| `"en"` | i18next `languageChanged` |
+| `filmvault-recovery-code` | Code de recovery cloud | `src/utils/sync.ts` |
+| `filmvault-last-modified` | ISO timestamp dernière modif locale | `setLastModified()` |
+| `filmvault-last-sync` | ISO timestamp dernier sync cloud réussi | `setLastSync()` |
+
+## API `src/utils/storage.ts`
+
+| Fonction | Rôle |
+| --- | --- |
+| `checkStorage(): Promise<boolean>` | Teste l'accès localStorage, met à jour le flag interne. À appeler une fois au démarrage. |
+| `isStorageAvailable(): boolean` | Lit le flag après `checkStorage`. |
+| `loadData(): Promise<AppData \| null>` | Lit `filmvault-data`, valide, applique migrations si `< CURRENT_VERSION`, normalise, retourne. |
+| `saveData(data): Promise<boolean>` | Écrit `filmvault-data` puis `setLastModified()`. |
+| `getInitialData(): AppData` | `AppData` vide : `{ films:[], cameras:[], backs:[], lenses:[], version: CURRENT_VERSION }`. |
+| `exportData(data)` | Déclenche le téléchargement d'un fichier `filmvault-backup-YYYY-MM-DD.json`. |
+| `parseImportFile(file, t?): Promise<ImportResult \| ImportError>` | Parse un JSON importé, valide, refuse si `version > CURRENT_VERSION`, migre sinon. |
+
+### Pipeline `loadData`
+
+```
+raw = localStorage.getItem("filmvault-data")
+  └─▶ JSON.parse → validateAppData → ❌ null
+                                    └─▶ if version < CURRENT_VERSION:
+                                          applyMigrations → réécriture localStorage → return
+                                        else:
+                                          normalizeAppData → return
+```
+
+`validateAppData` accepte strictement les structures où `films` et `cameras` sont des tableaux, `backs`/`lenses`/`version` optionnels selon la version. Si `version >= 13`, `lenses` doit être un tableau.
+
+`normalizeAppData` comble les valeurs manquantes pour les données plus anciennes : `backs ??= []`, `lenses ??= []`.
+
+## Migrations : `src/utils/migrations.ts`
+
+Constante `CURRENT_VERSION = 17`. L'objet `migrations: Record<number, MigrationFn>` associe chaque version source à une fonction `(data) => newData`.
+
+Fonction publique :
+
+```ts
+applyMigrations(data: Record<string, unknown>): AppData
+```
+
+Applique séquentiellement `migrations[v]` tant que `version < CURRENT_VERSION`, force `current.version = CURRENT_VERSION` en sortie, et cast vers `AppData`. Lève si une version intermédiaire n'a pas de fonction enregistrée.
+
+### Historique
+
+| De → À | Fonction | Objet |
+| --- | --- | --- |
+| 1 → 2 | `migrateV1toV2` | Scinde `camera.name` en `{ brand, model, nickname:"", serial:"" }`. |
+| 2 → 3 | `migrateV2toV3` | Bump sans transformation. |
+| 3 → 4 | `migrateV3toV4` | Tronque `film.expDate` à `YYYY-MM`. |
+| 4 → 5 | `migrateV4toV5` | Initialise `film.scanRef` à `null`. |
+| 5 → 6 | `migrateV5toV6` | Ajoute `nickname` et `serial` par défaut aux `camera.backs[]`. |
+| 6 → 7 | `migrateV6toV7` | Parse les `history[].action` bilingues (FR/EN) pour renseigner `actionCode` + `params`. |
+| 7 → 8 | `migrateV7toV8` | Bump. |
+| 8 → 9 | `migrateV8toV9` | Bump. |
+| 9 → 10 | `migrateV9toV10` | Extrait `camera.backs[]` dans `data.backs[]` racine, propage `format` et `compatibleCameraIds: [cam.id]`. |
+| 10 → 11 | `migrateV10toV11` | Remplace `format`/`type` `"Instant"` par `"Instax Mini"` / `"Couleur"` sur films, caméras et dos. |
+| 11 → 12 | `migrateV11toV12` | Champs optionnels d'exposition sur `Camera`. Pas de transformation. |
+| 12 → 13 | `migrateV12toV13` | Ajoute `lenses: []` racine, `lensId` optionnel sur `Film`/`ShotNote`. |
+| 13 → 14 | `migrateV13toV14` | Calcule `lens.isZoom = fMax > fMin` à partir des focales existantes. |
+| 14 → 15 | `migrateV14toV15` | Champs optionnels `devCost`, `scanCost`, `devScanPackage` sur `Film`. Pas de transformation. |
+| 15 → 16 | `migrateV15toV16` | Bump (schéma cloud normalisé côté Supabase). |
+| 16 → 17 | `migrateV16toV17` | Ajoute `soldAt` optionnel sur `Camera`, `Back`, `Lens`. Pas de transformation. |
+
+## Ajouter une migration
+
+À faire à chaque changement structurel (ajout/suppression de champ obligatoire, renommage, normalisation de valeurs, extraction de tableau…).
+
+1. **Incrémenter** la constante dans `src/utils/migrations.ts` :
+   ```ts
+   export const CURRENT_VERSION = 18;
+   ```
+2. **Écrire** la fonction :
+   ```ts
+   function migrateV17toV18(data: Record<string, unknown>): Record<string, unknown> {
+     // Transformations sur data.films / data.cameras / data.backs / data.lenses
+     return { ...data, version: 18 };
+   }
+   ```
+   - Toujours retourner un nouvel objet avec `version` incrémenté.
+   - Typer les structures intermédiaires via des interfaces locales (`V17Film` ex.) si nécessaire pour documenter le schéma source.
+   - Les champs purement optionnels (présent ou `undefined`) peuvent n'avoir qu'un bump sans transformation.
+3. **Enregistrer** dans l'objet `migrations` :
+   ```ts
+   const migrations: Record<number, MigrationFn> = {
+     …
+     17: migrateV17toV18,
+   };
+   ```
+4. **Mettre à jour** `validateAppData` / `normalizeAppData` si le nouveau champ impose une invariance.
+5. **Adapter** `createNewFilm`/`getInitialData` pour produire directement des objets compatibles v18.
+6. **Mettre à jour** ce fichier (tableau historique).
+
+## Import/export
+
+`exportData(data)` sérialise `AppData` tel quel dans un fichier JSON. `parseImportFile(file)` :
+
+- lit le texte, `JSON.parse`
+- refuse si `validateAppData` échoue (message i18n `storage.invalidData`)
+- refuse si `version > CURRENT_VERSION` (`storage.newerVersion`)
+- applique migrations puis normalise si `version < CURRENT_VERSION`
+- retourne `{ success: true, data }` ou `{ success: false, error }`
+
+L'UI d'import se trouve dans `SettingsScreen`.
+
+## Invariants
+
+- Aucune fonction du projet ne doit lire/écrire `filmvault-data` en dehors de `src/utils/storage.ts`.
+- Toute mutation passe par `updateData` (voir `docs/architecture.md`).
+- Les migrations sont **pures** (aucun accès réseau, localStorage, DOM).
+- Une migration est **idempotente en sortie** : un deuxième appel sur un objet déjà migré produit le même résultat (utile pour `pullFromCloud` qui ré-applique les migrations).

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,162 @@
+# Recipes — modifications courantes
+
+Guides pas-à-pas pour les extensions récurrentes. Toutes ces recettes supposent que les docs voisines (`docs/data-model.md`, `docs/persistence.md`, `docs/ui-system.md`, `docs/i18n.md`) sont familières.
+
+## 1. Ajouter un champ à `Film`
+
+Exemple : ajouter `tags: string[]` pour tagger les pellicules.
+
+1. **Type** — `src/types.ts` :
+   ```ts
+   export interface Film {
+     …
+     tags?: string[];
+   }
+   ```
+2. **Migration** — `src/utils/migrations.ts` :
+   ```ts
+   export const CURRENT_VERSION = 18;   // était 17
+
+   function migrateV17toV18(data: Record<string, unknown>): Record<string, unknown> {
+     // tags est optionnel, aucun traitement nécessaire
+     return { ...data, version: 18 };
+   }
+
+   const migrations: Record<number, MigrationFn> = {
+     …
+     17: migrateV17toV18,
+   };
+   ```
+   Si le champ est **obligatoire**, backfiller explicitement :
+   ```ts
+   const films = (data.films as Record<string, unknown>[]) || [];
+   return { ...data, films: films.map((f) => ({ ...f, tags: f.tags ?? [] })), version: 18 };
+   ```
+3. **Factory** — `src/utils/film-factory.ts` : initialiser le nouveau champ dans `createNewFilm()`.
+4. **UI d'édition** — `AddFilmDialog.tsx` et `src/screens/film-detail/EditModal.tsx` : ajouter le contrôle.
+5. **Affichage** — ajouter dans `FilmInfoSection.tsx` et/ou `FilmRow.tsx` selon visibilité.
+6. **i18n** — ajouter les libellés dans `addFilm.*` et `filmDetail.*` (FR + EN).
+7. **Historique de migrations** — mettre à jour le tableau dans `docs/persistence.md`.
+
+## 2. Ajouter un écran
+
+Exemple : écran `timeline` global.
+
+1. **Fichier** `src/screens/TimelineScreen.tsx` avec interface `TimelineScreenProps` et export named `TimelineScreen`.
+2. **Union** — `src/types.ts` : `type ScreenName = … | "timeline";`.
+3. **Routing** — `src/App.tsx`, fonction `renderScreen()` : ajouter le `case "timeline": return <TimelineScreen …/>;`.
+4. **Navigation** — `src/components/TabBar.tsx` et `AppHeader.tsx` : ajouter l'entrée (icône Lucide, libellé i18n).
+5. **i18n** — `nav.timeline` dans `fr.ts` et `en.ts`, plus les libellés spécifiques à l'écran.
+6. **Lazy loading optionnel** — pour un écran lourd (ex. Map), envelopper avec `React.lazy` + `Suspense` comme `MapScreen` dans `App.tsx:26`.
+7. **Doc** — mettre à jour `docs/screens.md` et `docs/architecture.md` (arborescence).
+
+## 3. Ajouter un composant UI
+
+Exemple : nouvelle primitive `progress-bar` dans `src/components/ui/`.
+
+1. Créer `src/components/ui/progress-bar.tsx` :
+   ```tsx
+   import { cn } from "@/lib/utils";
+
+   interface ProgressBarProps {
+     value: number;            // 0 à 1
+     className?: string;
+   }
+
+   export function ProgressBar({ value, className }: ProgressBarProps) {
+     return (
+       <div className={cn("h-1 w-full bg-border rounded-full overflow-hidden", className)}>
+         <div
+           className="h-full bg-accent transition-[width]"
+           style={{ width: `${Math.round(Math.min(1, Math.max(0, value)) * 100)}%` }}
+         />
+       </div>
+     );
+   }
+   ```
+2. Si plusieurs variantes stylistiques : utiliser `cva` et exporter `progressBarVariants` (cf. `button.tsx`).
+3. Pour un wrapper Radix (select, dialog…), suivre le pattern de `dialog.tsx`/`select.tsx`.
+4. Ne pas exporter un `default`.
+
+## 4. Ajouter une action dans `film.history`
+
+Exemple : action `lost` (pellicule perdue).
+
+1. **Type** — `src/types.ts` : `type HistoryAction = … | "lost";`.
+2. **UI** — écrire la mutation :
+   ```ts
+   const updatedFilm: Film = {
+     ...film,
+     state: "exposed",  // ou autre état terminal si pertinent
+     history: [...film.history, { date: today(), action: "", actionCode: "lost" }],
+   };
+   updateData({ ...data, films: data.films.map((f) => f.id === film.id ? updatedFilm : f) });
+   ```
+3. **Timeline** — `src/components/Timeline.tsx` : ajouter le rendu du nouvel `actionCode` (icône + libellé).
+4. **i18n** — `timeline.lost` dans `fr.ts` et `en.ts`.
+5. **Migration v6→v7 (historique)** : pas nécessaire si la nouvelle action n'existe que pour les nouveaux enregistrements. Si on veut détecter l'action dans des exports historiques texte libre, enrichir `parseHistoryAction` (attention : cela ne s'applique qu'aux imports de données <v7).
+
+## 5. Ajouter une migration
+
+Voir `docs/persistence.md` section « Ajouter une migration ». Résumé :
+
+1. Incrémenter `CURRENT_VERSION`.
+2. Écrire `migrateVXtoVY` (pure, idempotente, retourne `{ ...data, version: Y }`).
+3. Enregistrer dans l'objet `migrations`.
+4. Mettre à jour `validateAppData`/`normalizeAppData` si nécessaire.
+5. Adapter `createNewFilm`/`getInitialData` pour produire du v`Y` directement.
+6. Documenter dans `docs/persistence.md`.
+
+## 6. Ajouter un format ou type de film
+
+Exemple : format `"110"` (sous-miniature).
+
+1. **Type** — `src/types.ts` : ajouter à l'union `FilmFormat`. Ajouter à `INSTANT_FORMATS` si format instantané (sinon ne pas toucher).
+2. **Poses par défaut** — `src/utils/film-factory.ts`, table `DEFAULT_POSES` : ajouter `"110": 24`.
+3. **Catalogue** — `src/constants/film-catalog.ts` : ajouter les entrées `FilmCatalogEntry` correspondantes si un ou plusieurs films de ce format existent commercialement.
+4. **Couleurs** — si nouveau `FilmType`, mettre à jour `FILM_TYPE_COLORS` dans `src/constants/theme.ts` et `getStates(t)` si nécessaire (`src/constants/films.ts`).
+5. **i18n** — `filmFormats.*` dans `fr.ts` et `en.ts`.
+6. **Migration** — si des données existantes doivent être converties (renommage, fusion…), écrire une migration.
+7. Vérifier que les écrans `AddFilmDialog`, `StockFilterDialog` et `StatsScreen` affichent correctement la nouvelle valeur (ils itèrent sur des helpers qui récupèrent la liste depuis `useFilmSuggestions`).
+
+## 7. Ajouter une traduction
+
+Voir `docs/i18n.md`. Résumé :
+
+1. Identifier le namespace approprié.
+2. Ajouter la clé dans `src/locales/fr.ts` **et** `src/locales/en.ts`.
+3. Utiliser les suffixes i18next (`_one`, `_other`) pour la pluralisation, `{{var}}` pour l'interpolation.
+4. Consommer via `t("namespace.key")` ou `t("namespace.key", { count, var })`.
+
+## 8. Ajouter un utilitaire / hook
+
+- **Utilitaire pur** : `src/utils/{nom-kebab}.ts`, named export.
+- **Hook** : préfixer par `use-`, placer dans `src/utils/` (ex : `src/utils/use-stock-filters.ts`). Un hook retourne en général un objet avec les valeurs + setters.
+- **Ne pas dupliquer** un helper existant : vérifier `src/utils/helpers.ts` (`uid`, `today`, `fmtDate`, `fmtPrice`), `src/utils/film-helpers.ts`, `src/utils/camera-helpers.ts`, `src/utils/lens-helpers.ts`, `src/utils/expiration.ts` d'abord.
+
+## 9. Modifier le design system
+
+- **Nouvelle couleur** : ajouter `--color-xxx` et `--color-xxx-soft` dans `src/index.css` (blocs `@theme` + `html.light`). Ajouter la même clé dans l'objet `T` (`src/constants/theme.ts`). Les classes Tailwind `bg-xxx`, `text-xxx`, etc. sont générées automatiquement par Tailwind 4.
+- **Nouvelle typographie** : ajouter `--font-xxx` dans `@theme`, charger la font via `@import` Google Fonts en tête de `src/index.css`, ajouter l'entrée dans `FONT` (`src/constants/theme.ts`).
+- **Nouvelle animation** : définir `@keyframes` + utilitaire `.animate-xxx` dans `src/index.css`.
+
+## 10. Lancer et vérifier
+
+| Commande | Rôle |
+| --- | --- |
+| `npm run dev` | Dev server Vite (localhost:5173) |
+| `npm run build` | `tsc --noEmit` puis `vite build` (doit passer sans erreur) |
+| `npm run lint` | Biome check (code + CSS, avec tailwindDirectives) |
+| `npm run format` | Biome fix (tabs, quotes, semicolons, ordre des imports) |
+| `npm run test` | Playwright E2E (configuré pour Chromium + Pixel 5) |
+| `npm run test:ui` | Playwright en mode UI |
+
+**Avant tout commit** : `npm run format && npm run lint && npm run build`.
+
+## 11. Rappels universels
+
+- Une seule fonction pour muter `AppData` : `updateData` (via `setData` dans les props d'écran).
+- Aucun import relatif (`../`) : toujours `@/…`.
+- Named exports uniquement (exception : `src/utils/i18n.ts` qui exporte l'instance i18next par défaut).
+- Toute valeur utilisateur est internationalisée.
+- Tout changement de forme de `AppData` impose une migration.

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -1,0 +1,128 @@
+# Écrans
+
+Les 8 écrans principaux de FilmVault. Source de vérité : `src/screens/`. Navigation contrôlée par `ScreenName` (`src/types.ts`).
+
+Pour le routing et la propagation du state, voir `docs/architecture.md`.
+
+## `DashboardScreen` — `home`
+
+`src/screens/DashboardScreen.tsx`
+
+Accueil : pellicules actives (chargées/partielles), équipement chargé, stats rapides, section « À faire » (dev/scan).
+
+**Props**
+```ts
+{ data, setScreen, setSelectedFilm, onAddFilm, setAutoOpenShotNote?, onNavigateToStock }
+```
+
+**Composants exploités** : `ActiveRollCard`, `EquipmentCard`, `StatCard`, `StatChip`, `TodoItem`, `EmptyState`.
+
+## `StockScreen` — `stock`
+
+`src/screens/StockScreen.tsx`
+
+Inventaire filtrable/triable. Utilise le hook `useStockFilters(films, initialStateFilter)` (`src/utils/use-stock-filters.ts`) pour gérer recherche, filtres (`format`, `type`, `brands[]`, `isoValues[]`) et tri (`SortOption`). Regroupe par date d'ajout via `groupFilms`.
+
+**Props**
+```ts
+{ data, setScreen, setSelectedFilm, onAddFilm, initialStateFilter? }
+```
+
+**Composants exploités** : `FilmRow`, `StockFilterDialog`, `ActiveFilterChips`, `EmptyState`.
+
+## `FilmDetailScreen` — `filmDetail`
+
+`src/screens/FilmDetailScreen.tsx`
+
+Détail d'une pellicule identifiée par `filmId`. Affiche le cycle de vie (`FilmLifecycleStepper`), les infos, l'historique (`Timeline`), les `ShotNotes` (`ShotNotesSection`).
+
+**Props**
+```ts
+{ data, setData, setScreen, setSelectedFilm, filmId,
+  onNavigateToMap?, autoOpenShotNote?, setAutoOpenShotNote? }
+```
+
+**Sous-composants** (`src/screens/film-detail/`) :
+
+- `FilmInfoSection.tsx` — infos éditables (brand, iso, format, expDate, storage)
+- `FloatingActionBar.tsx` — actions flottantes contextuelles (Load, Expose, Develop, Scan)
+- `TransitionModals.tsx` — modals pour transitions `loaded` → `exposed` / `partial`
+- `DevScanModals.tsx` — modals pour `developed` / `scanned` (lab, ref, coût, dev/scan package)
+- `EditModal.tsx` — édition globale du film
+- `types.ts` — types locaux (`ActionType`, `EditData`…)
+
+Chaque transition d'état pousse une `HistoryEntry` avec le bon `actionCode` et `params` (voir `docs/data-model.md`).
+
+## `EquipmentScreen` — `cameras`
+
+`src/screens/EquipmentScreen.tsx`
+
+Gestion des caméras, objectifs et dos. Trois onglets via un state local `activeTab: EquipmentTab`.
+
+**Props**
+```ts
+{ data, setData }
+```
+
+**Sous-composants** (`src/components/equipment/`) :
+
+- `CamerasTab.tsx` — liste + formulaire add/edit, photo via `PhotoPicker`
+- `LensesTab.tsx` — idem pour `Lens`
+- `BacksTab.tsx` — idem pour `Back`, gère la compatibilité `compatibleCameraIds`
+
+## `StatsScreen` — `stats`
+
+`src/screens/StatsScreen.tsx`
+
+Statistiques agrégées à partir des `films` : répartition par `type`, `brand`, `format`, par caméra, par objectif (via `lensDisplayName`). Utilise `BarChart`.
+
+**Props**
+```ts
+{ data }
+```
+
+## `SettingsScreen` — `settings`
+
+`src/screens/SettingsScreen.tsx`
+
+Réglages : langue (fr/en), thème (dark/light), sync cloud (activation + code de récupération + sync manuelle), import/export (`exportData`, `parseImportFile`), accès aux mentions légales.
+
+**Props**
+```ts
+{ data, setData, syncing, recoveryCode, onRecoveryCodeChange, onSyncNow, persistent, setScreen }
+```
+
+**Points d'intégration** : voir `docs/cloud-sync.md` pour le détail des flows (activation, restauration).
+
+## `MapScreen` — `map`
+
+`src/screens/MapScreen.tsx` (chargé en `React.lazy` dans `App.tsx`)
+
+Carte MapLibre GL centralisant les `ShotNote` avec `latitude`/`longitude`. Clusters par niveau de zoom (`clusterNotes` dans `src/utils/map-helpers.ts`). Filtre par film (`filterFilmId`) et par type (`filterType: FilmType`).
+
+**Props**
+```ts
+{ data, setScreen, setSelectedFilm, filterFilmId, onClearFilter }
+```
+
+**Sous-composants** (`src/components/map/`) : `MapFilterBar`, `ClusterSheet`, `NoteSheet`, `NoteMarker`.
+
+## `LegalScreen` — `legal`
+
+`src/screens/LegalScreen.tsx`
+
+Mentions légales statiques, accessible depuis `SettingsScreen`.
+
+**Props**
+```ts
+{ onBack }
+```
+
+## Conventions
+
+- Un écran vit dans `src/screens/{Name}Screen.tsx`.
+- Suffixe `Screen` **obligatoire** dans le nom de fichier et le nom de composant.
+- Props interface `{Name}ScreenProps` déclarée au-dessus.
+- Pour toute mutation de `data`, appeler `setData(newData)` — c'est la prop héritée de `updateData` (voir `docs/architecture.md`).
+- Utiliser `useTranslation()` pour tout texte UI.
+- Headers/layout communs gérés par `AppHeader` (mobile) et `TabBar` (mobile & desktop). Les écrans ne redéfinissent pas le chrome de navigation.

--- a/docs/ui-system.md
+++ b/docs/ui-system.md
@@ -1,0 +1,197 @@
+# UI system
+
+Design tokens, Tailwind 4, composants UI réutilisables. Source de vérité : `src/index.css`, `src/constants/theme.ts`, `src/components/ui/`.
+
+## Tailwind 4 via `@theme`
+
+Configuration déclarative dans `src/index.css` (il n'y a **pas** de `tailwind.config.js` — tout passe par Vite via `@tailwindcss/vite`).
+
+Les tokens sont définis dans un bloc `@theme { … }` et générés automatiquement par Tailwind en tant qu'utilitaires (`bg-bg`, `text-text-primary`, etc.).
+
+### Couleurs (dark — défaut)
+
+| Variable CSS | Valeur | Usage |
+| --- | --- | --- |
+| `--color-bg` | `#0d0d0d` | Fond principal |
+| `--color-surface` | `#1a1a1a` | Surfaces surélevées |
+| `--color-surface-alt` | `#242424` | Surfaces alternatives |
+| `--color-card` | `#1e1e1e` | Cartes |
+| `--color-card-hover` | `#252525` | Hover carte |
+| `--color-border` | `#2a2a2a` | Bordure standard |
+| `--color-border-light` | `#333333` | Bordure claire |
+| `--color-text-primary` | `#e8e4df` | Texte principal |
+| `--color-text-sec` | `#a09a92` | Texte secondaire |
+| `--color-text-muted` | `#827d75` | Texte discret |
+| `--color-accent` | `#c4392d` | Rouge safelight (CTA) |
+| `--color-accent-hover` | `#d44435` | Hover accent |
+| `--color-accent-soft` | `rgba(196,57,45,0.12)` | Accent translucide |
+| `--color-orange` | `#e07940` | Scanned |
+| `--color-amber` | `#d4a858` | Couleur/Partial |
+| `--color-green` | `#4a8c5c` | Loaded |
+| `--color-blue` | `#5b7fa5` | Stock/Diapo |
+
+Chaque couleur avec variante `-soft` pour badges/backgrounds translucides.
+
+### Thème light (« Chambre claire »)
+
+Activé via `html.light` : un override complet de toutes les variables dans `src/index.css`. Géré par `ThemeProvider` (`src/components/ThemeProvider.tsx`).
+
+### Typographies
+
+| Variable | Famille |
+| --- | --- |
+| `--font-display` | `Instrument Serif`, italique pour titres |
+| `--font-body` | `DM Sans`, corps UI |
+| `--font-mono` | `DM Mono`, chiffres et stats |
+
+Utilitaires Tailwind : `font-display`, `font-body`, `font-mono`. Les fonts sont chargées depuis Google Fonts via `@import` en tête de `index.css` et cachées par Workbox.
+
+### Rayon et spacing
+
+- `--radius: 14px` (utilisé via `rounded-[14px]` — le thème shadcn/ui expose aussi `rounded-md/lg`).
+- Classes utilisées régulièrement : `rounded-[10px]`, `rounded-[14px]`, `min-h-[44px]` (cibles tactiles), `px-4.5`, `py-2.5`.
+
+### Animations
+
+Keyframes et utilitaires custom définis dans `src/index.css` :
+
+- `animate-fade-in`, `animate-spin`
+- `animate-screen-enter`, `animate-screen-forward`, `animate-screen-back`
+- `animate-stagger-item`, `animate-slide-up`
+- `animate-backdrop-fade-in`
+- `animate-toast-enter`, `animate-toast-exit`
+- `animate-timeline-pulse`
+- `animate-tour-tooltip-enter`, `animate-banner-enter`
+
+## Objet `T` : design tokens côté JS
+
+Pour les styles dynamiques où Tailwind ne peut pas être utilisé (ex. `style={{ color: T.accent }}`), `src/constants/theme.ts` expose :
+
+```ts
+export const T = {
+  bg, surface, surfaceAlt, card, cardHover,
+  border, borderLight,
+  text, textSec, textMuted,
+  accent, accentHover, accentSoft,
+  orange, orangeSoft, amber, amberSoft, green, greenSoft, blue, blueSoft,
+} as const;
+```
+
+Chaque valeur est `"var(--color-…)"`. Helpers :
+
+- `alpha(cssVar, opacity)` — retourne `color-mix(in srgb, ${cssVar} ${opacity*100}%, transparent)` pour moduler la transparence d'une variable CSS dynamiquement.
+- `FILM_TYPE_COLORS: Record<FilmType, string>` — mapping Couleur→amber, N&B→textSec, Diapo→blue, ECN-2→accent.
+- `FONT = { display, body, mono }` — pour `style={{ fontFamily: FONT.display }}`.
+
+**Règle** : privilégier les classes Tailwind (`bg-accent`, `text-text-primary`) ; réserver `T` aux cas où la valeur est interpolée en JS (props de lib tierce, animations avec Motion, SVG…).
+
+## Utilitaire `cn()`
+
+`src/lib/utils.ts` :
+
+```ts
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}
+```
+
+Combine `clsx` (gestion conditionnelle) et `tailwind-merge` (déduplication/écrasement des classes Tailwind conflictuelles).
+
+**À utiliser systématiquement** dans chaque composant pour merger `className` (passé par le parent) avec les classes internes :
+
+```tsx
+<div className={cn("p-4 bg-card", className)}>…</div>
+```
+
+## Composants UI (`src/components/ui/`)
+
+17 primitives. Tous acceptent `className` et exportent en named export.
+
+| Fichier | Rôle | Particularité |
+| --- | --- | --- |
+| `button.tsx` | Bouton standard | CVA variants `default` \| `outline` \| `ghost` \| `destructive`, tailles `default` \| `sm` \| `icon` \| `icon-sm`, `asChild` via Radix `Slot` |
+| `dialog.tsx` | Dialog modal | Wrap `@radix-ui/react-dialog` : `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, `DialogCloseButton` |
+| `select.tsx` | Select | Wrap `@radix-ui/react-select` : `Select`, `SelectTrigger`, `SelectContent`, `SelectItem` |
+| `switch.tsx` | Toggle | Wrap `@radix-ui/react-switch` |
+| `input.tsx`, `textarea.tsx` | Champs | Wrappers stylisés des éléments natifs |
+| `badge.tsx` | Badge | Variantes via CVA |
+| `chip.tsx` | Chip sélectionnable | Bouton avec state `active` |
+| `card.tsx` | Carte | `Card`, `CardHeader`, `CardTitle`, `CardContent`, `CardFooter` |
+| `alert.tsx` | Alerte | Variante `default` / `destructive` |
+| `form-field.tsx` | Wrapper label + champ | Layout flex, gère l'id d'association |
+| `list-button.tsx` | Item de liste cliquable | Gère state `selected` |
+| `autocomplete-input.tsx` | Input + suggestions | Couple avec `useFilmSuggestions` |
+| `month-year-picker.tsx` | Picker `YYYY-MM` | Pour `Film.expDate` |
+| `collapsible-section.tsx` | Section repliable | Avec icône, titre, compteur |
+| `confirm-dialog.tsx` | Confirmation | Wrap `Dialog`, variante `destructive` |
+| `photo-img.tsx` | `<img>` résolvant les chemins Storage | Utilise `resolvePhotoSrc` |
+
+### Conventions de composant
+
+1. **Interface props nommée** `{ComponentName}Props`, déclarée au-dessus du composant.
+2. **Named export** uniquement (pas de `export default`).
+3. **`className` toujours accepté** et mergé via `cn()`.
+4. **CVA** pour les variants stylistiques (cf. `button.tsx`).
+5. **Radix** pour toute primitive nécessitant de l'accessibilité (dialog, select, switch, popover, slot).
+6. **Tailwind tokens custom prioritaires** sur les couleurs hex. Pour un style dynamique, `T` depuis `@/constants/theme`.
+
+Exemple minimal (règle `.claude/rules/components.md`) :
+
+```tsx
+import { cn } from "@/lib/utils";
+
+interface MyComponentProps {
+  className?: string;
+  label: string;
+  active?: boolean;
+}
+
+export function MyComponent({ className, label, active }: MyComponentProps) {
+  return (
+    <div className={cn("p-3 rounded-[14px] bg-card text-text-primary", active && "bg-accent-soft", className)}>
+      {label}
+    </div>
+  );
+}
+```
+
+## Composants métier (`src/components/`)
+
+24 composants au premier niveau, plus trois sous-dossiers (`equipment/`, `map/`, pas `ui/`). Liste complète :
+
+```
+ActiveFilterChips, ActiveRollCard, AddFilmDialog, AppHeader, BarChart,
+EmptyState, EquipmentCard, FilmLifecycleStepper, FilmRow, FilmTypeFormatFields,
+InfoLine, PhotoPicker, PhotoViewer, PwaInstallBanner, PwaUpdateBanner,
+ShotNotesSection, StatCard, StatChip, StockFilterDialog, TabBar,
+ThemeProvider, Timeline, Toast, TodoItem
+```
+
+- `equipment/` : `CamerasTab`, `LensesTab`, `BacksTab` — onglets d'`EquipmentScreen`.
+- `map/` : `MapFilterBar`, `ClusterSheet`, `NoteSheet`, `NoteMarker` — helpers pour `MapScreen`.
+
+## Icônes
+
+`lucide-react` — import nominatif (`import { Camera, Film } from "lucide-react"`). Props usuelles : `size`, `color`, `className`, `strokeWidth`. Le type `LucideIcon` est exporté depuis `src/types.ts`.
+
+## Toasts
+
+`useToast()` depuis `@/components/Toast` (`src/components/Toast.tsx`) :
+
+```tsx
+const { toast } = useToast();
+toast("Film ajouté", "success"); // "success" | "error"
+```
+
+## Haptiques
+
+`src/utils/haptics.ts` expose `hapticLight()`, `hapticSuccess()`, `hapticWarning()` (utilisent `navigator.vibrate` avec fallback silencieux). À appeler pour feedbacks tactiles sur actions importantes.
+
+## Ce qu'il **ne faut pas** faire
+
+- Pas d'imports `../../…` — toujours `@/…`.
+- Pas de couleurs hex en dur dans les composants — utiliser les classes Tailwind ou `T`.
+- Pas de `export default`.
+- Pas de texte français codé en dur dans un composant — passer par `t()` (voir `docs/i18n.md`).
+- Pas de mutations de props/state (utiliser le spread immuable).
+- Pas de `style={{ color: "#c4392d" }}` — préférer `className="text-accent"` ou `style={{ color: T.accent }}`.


### PR DESCRIPTION
Add detailed technical references in docs/ (architecture, data model,
persistence, cloud sync, UI system, screens, i18n, recipes) and link
them from CLAUDE.md and .claude/rules/ for quick lookup.

https://claude.ai/code/session_01PDvDoUkcAmQu7wqaymWKZE