### PR TITLE
fix(dashboard): filter Stock by status from "À faire" buttons

### DIFF
--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -220,7 +220,7 @@ export function DashboardScreen({
 								icon={Eye}
 								label={t("dashboard.awaitingDev", { count: exposedCount })}
 								color={T.accent}
-								onClick={() => setScreen("stock")}
+								onClick={() => onNavigateToStock("exposed")}
 							/>
 						)}
 						{developedCount > 0 && (
@@ -228,7 +228,7 @@ export function DashboardScreen({
 								icon={Archive}
 								label={t("dashboard.awaitingScan", { count: developedCount })}
 								color={T.textSec}
-								onClick={() => setScreen("stock")}
+								onClick={() => onNavigateToStock("developed")}
 							/>
 						)}
 					</div>


### PR DESCRIPTION
Les boutons "En attente de développement" et "En attente de scan"
naviguaient vers Stock sans filtre. Ils utilisent maintenant
onNavigateToStock avec le statut correspondant (exposed / developed)
pour afficher directement les pellicules concernées.