### PR TITLE
feat(tags): add tags/projects to group films (#113)

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -85,6 +85,9 @@ Le type central. Champs par catégorie (voir `src/types.ts:67`) :
 - `history: HistoryEntry[]` — obligatoire, démarre avec `{ actionCode: "added" }`
 - `shotNotes?: ShotNote[]` — notes par vue
 
+**Organisation**
+- `tags?: string[]` — libellés libres saisis par l'utilisateur pour regrouper les pellicules (projet, voyage, série). Dédupliqués par film (case-insensitive), triés via `collectAllTags(films)` pour l'autocomplete.
+
 ### Poses par défaut
 
 Créés par `createNewFilm()` (`src/utils/film-factory.ts`) via la table `DEFAULT_POSES` :

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -44,7 +44,7 @@ raw = localStorage.getItem("filmvault-data")
 
 ## Migrations : `src/utils/migrations.ts`
 
-Constante `CURRENT_VERSION = 17`. L'objet `migrations: Record<number, MigrationFn>` associe chaque version source à une fonction `(data) => newData`.
+Constante `CURRENT_VERSION = 18`. L'objet `migrations: Record<number, MigrationFn>` associe chaque version source à une fonction `(data) => newData`.
 
 Fonction publique :
 
@@ -74,6 +74,7 @@ Applique séquentiellement `migrations[v]` tant que `version < CURRENT_VERSION`,
 | 14 → 15 | `migrateV14toV15` | Champs optionnels `devCost`, `scanCost`, `devScanPackage` sur `Film`. Pas de transformation. |
 | 15 → 16 | `migrateV15toV16` | Bump (schéma cloud normalisé côté Supabase). |
 | 16 → 17 | `migrateV16toV17` | Ajoute `soldAt` optionnel sur `Camera`, `Back`, `Lens`. Pas de transformation. |
+| 17 → 18 | `migrateV17toV18` | Ajoute `tags` optionnel sur `Film`. Pas de transformation. |
 
 ## Ajouter une migration
 
@@ -81,23 +82,23 @@ Applique séquentiellement `migrations[v]` tant que `version < CURRENT_VERSION`,
 
 1. **Incrémenter** la constante dans `src/utils/migrations.ts` :
    ```ts
-   export const CURRENT_VERSION = 18;
+   export const CURRENT_VERSION = 19;
    ```
 2. **Écrire** la fonction :
    ```ts
-   function migrateV17toV18(data: Record<string, unknown>): Record<string, unknown> {
+   function migrateV18toV19(data: Record<string, unknown>): Record<string, unknown> {
      // Transformations sur data.films / data.cameras / data.backs / data.lenses
-     return { ...data, version: 18 };
+     return { ...data, version: 19 };
    }
    ```
    - Toujours retourner un nouvel objet avec `version` incrémenté.
-   - Typer les structures intermédiaires via des interfaces locales (`V17Film` ex.) si nécessaire pour documenter le schéma source.
+   - Typer les structures intermédiaires via des interfaces locales (`V18Film` ex.) si nécessaire pour documenter le schéma source.
    - Les champs purement optionnels (présent ou `undefined`) peuvent n'avoir qu'un bump sans transformation.
 3. **Enregistrer** dans l'objet `migrations` :
    ```ts
    const migrations: Record<number, MigrationFn> = {
      …
-     17: migrateV17toV18,
+     18: migrateV18toV19,
    };
    ```
 4. **Mettre à jour** `validateAppData` / `normalizeAppData` si le nouveau champ impose une invariance.

--- a/src/components/AddFilmDialog.tsx
+++ b/src/components/AddFilmDialog.tsx
@@ -9,8 +9,10 @@ import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } f
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { MonthYearPicker } from "@/components/ui/month-year-picker";
+import { TagInput } from "@/components/ui/tag-input";
 import { type AppData, isInstantFormat } from "@/types";
 import { createNewFilm } from "@/utils/film-factory";
+import { collectAllTags } from "@/utils/film-helpers";
 import { currentMonthYear } from "@/utils/helpers";
 import { useFilmSuggestions } from "@/utils/use-film-suggestions";
 
@@ -35,6 +37,7 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 	const [storageLocation, setStorageLocation] = useState("");
 	const [price, setPrice] = useState("");
 	const [comment, setComment] = useState("");
+	const [tags, setTags] = useState<string[]>([]);
 
 	useEffect(() => {
 		if (!open) {
@@ -48,6 +51,7 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 			setPrice("");
 			setStorageLocation("");
 			setComment("");
+			setTags([]);
 		}
 	}, [open]);
 
@@ -72,6 +76,7 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 			comment: comment.trim() || null,
 			price: price.trim() ? Number.parseFloat(price) : null,
 			storageLocation: storageLocation.trim() || null,
+			tags: tags.length > 0 ? tags : undefined,
 		};
 		const newFilms = Array.from({ length: qty }, () => createNewFilm(params));
 		const updated = { ...data, films: [...data.films, ...newFilms] };
@@ -167,6 +172,14 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 							placeholder={t("addFilm.notesPlaceholder")}
 						/>
 					</FormField>
+
+					<TagInput
+						label={t("addFilm.tags")}
+						value={tags}
+						onChange={setTags}
+						suggestions={collectAllTags(data.films)}
+						placeholder={t("addFilm.tagsPlaceholder")}
+					/>
 
 					<Button onClick={handleSave} disabled={!brand || !model} className="w-full justify-center py-3.5 px-5">
 						<Plus size={16} /> {t("addFilm.addButton", { count: qty })}

--- a/src/components/FilmRow.tsx
+++ b/src/components/FilmRow.tsx
@@ -69,6 +69,11 @@ export function FilmRow({ film, onClick, cameras, backs, groupCount }: FilmRowPr
 					{expInfo && expInfo.status !== "ok" && (
 						<Badge style={{ color: expInfo.color, background: expInfo.bgColor }}>{expInfo.label}</Badge>
 					)}
+					{film.tags?.map((tag) => (
+						<Badge key={tag} style={{ color: T.accent, background: alpha(T.accent, 0.12) }}>
+							{tag}
+						</Badge>
+					))}
 				</div>
 			</div>
 			<ChevronRight size={16} className="text-text-muted" />

--- a/src/components/StockFilterDialog.tsx
+++ b/src/components/StockFilterDialog.tsx
@@ -13,10 +13,12 @@ interface StockFilterDialogProps {
 	availableTypes: string[];
 	availableBrands: string[];
 	availableIsoValues: number[];
+	availableTags: string[];
 	onSetFormat: (v: string) => void;
 	onSetType: (v: string) => void;
 	onToggleBrand: (brand: string) => void;
 	onToggleIso: (iso: number) => void;
+	onToggleTag: (tag: string) => void;
 	onReset: () => void;
 }
 
@@ -28,10 +30,12 @@ export function StockFilterDialog({
 	availableTypes,
 	availableBrands,
 	availableIsoValues,
+	availableTags,
 	onSetFormat,
 	onSetType,
 	onToggleBrand,
 	onToggleIso,
+	onToggleTag,
 	onReset,
 }: StockFilterDialogProps) {
 	const { t } = useTranslation();
@@ -93,6 +97,18 @@ export function StockFilterDialog({
 								{availableIsoValues.map((iso) => (
 									<Chip key={iso} active={filters.isoValues.includes(iso)} onClick={() => onToggleIso(iso)}>
 										{iso}
+									</Chip>
+								))}
+							</div>
+						</FormField>
+					)}
+
+					{availableTags.length > 0 && (
+						<FormField label={t("stock.tags")}>
+							<div className="flex flex-wrap gap-1.5">
+								{availableTags.map((tag) => (
+									<Chip key={tag} active={filters.tags.includes(tag)} onClick={() => onToggleTag(tag)}>
+										{tag}
 									</Chip>
 								))}
 							</div>

--- a/src/components/map/MapFilterBar.tsx
+++ b/src/components/map/MapFilterBar.tsx
@@ -10,8 +10,11 @@ interface MapFilterBarProps {
 	films: Film[];
 	filterFilmId: string | null;
 	filterType: FilmType | null;
+	filterTag: string | null;
+	availableTags: string[];
 	onFilterFilm: (id: string | null) => void;
 	onFilterType: (type: FilmType | null) => void;
+	onFilterTag: (tag: string | null) => void;
 	onClearFilter: () => void;
 }
 
@@ -21,8 +24,11 @@ export function MapFilterBar({
 	films,
 	filterFilmId,
 	filterType,
+	filterTag,
+	availableTags,
 	onFilterFilm,
 	onFilterType,
+	onFilterTag,
 	onClearFilter,
 }: MapFilterBarProps) {
 	const { t } = useTranslation();
@@ -51,6 +57,25 @@ export function MapFilterBar({
 					</Chip>
 				))}
 			</div>
+
+			{/* Tag filter */}
+			{availableTags.length > 0 && (
+				<div className="flex gap-1.5 overflow-x-auto pb-1 scrollbar-hide">
+					<Chip active={filterTag == null} onClick={() => onFilterTag(null)} className="shrink-0 text-xs shadow-md">
+						{t("map.allTags")}
+					</Chip>
+					{availableTags.map((tag) => (
+						<Chip
+							key={tag}
+							active={filterTag === tag}
+							onClick={() => onFilterTag(filterTag === tag ? null : tag)}
+							className="shrink-0 text-xs shadow-md"
+						>
+							{tag}
+						</Chip>
+					))}
+				</div>
+			)}
 
 			{/* Film filter */}
 			{filmsWithGeo.length > 1 && (

--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -1,0 +1,152 @@
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { Plus, X } from "lucide-react";
+import { type KeyboardEvent, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+
+interface TagInputProps {
+	label?: string;
+	value: string[];
+	onChange: (tags: string[]) => void;
+	suggestions: string[];
+	placeholder?: string;
+	className?: string;
+}
+
+function TagInput({ label, value, onChange, suggestions, placeholder, className }: TagInputProps) {
+	const { t } = useTranslation();
+	const [input, setInput] = useState("");
+	const [isOpen, setIsOpen] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const trimmed = input.trim();
+	const lower = trimmed.toLowerCase();
+	const selectedLower = new Set(value.map((v) => v.toLowerCase()));
+	const filteredSuggestions = suggestions
+		.filter((s) => !selectedLower.has(s.toLowerCase()) && s.toLowerCase().includes(lower))
+		.slice(0, 12);
+	const canCreate =
+		trimmed.length > 0 && !suggestions.some((s) => s.toLowerCase() === lower) && !selectedLower.has(lower);
+
+	const addTag = (tag: string) => {
+		const normalized = tag.trim();
+		if (!normalized) return;
+		if (value.some((v) => v.toLowerCase() === normalized.toLowerCase())) return;
+		onChange([...value, normalized]);
+		setInput("");
+		setIsOpen(false);
+		inputRef.current?.focus();
+	};
+
+	const removeTag = (tag: string) => {
+		onChange(value.filter((v) => v !== tag));
+	};
+
+	const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter" || e.key === ",") {
+			e.preventDefault();
+			if (trimmed) addTag(trimmed);
+		} else if (e.key === "Backspace" && input === "" && value.length > 0) {
+			e.preventDefault();
+			removeTag(value[value.length - 1]!);
+		}
+	};
+
+	const popoverOpen = isOpen && (filteredSuggestions.length > 0 || canCreate);
+
+	return (
+		<div className={cn("flex flex-col gap-1.5", className)}>
+			{label && (
+				<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">{label}</label>
+			)}
+			<PopoverPrimitive.Root open={popoverOpen} onOpenChange={setIsOpen}>
+				<PopoverPrimitive.Anchor asChild>
+					{/* biome-ignore lint/a11y/useKeyWithClickEvents: inner input handles keyboard interaction */}
+					<div
+						className={cn(
+							"bg-surface-alt border border-border rounded-[10px] px-2 py-1.5",
+							"focus-within:border-accent transition-colors flex flex-wrap items-center gap-1.5",
+						)}
+						onClick={() => inputRef.current?.focus()}
+					>
+						{value.map((tag) => (
+							<span
+								key={tag}
+								className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold font-body bg-accent/15 text-accent"
+							>
+								{tag}
+								<button
+									type="button"
+									onClick={(e) => {
+										e.stopPropagation();
+										removeTag(tag);
+									}}
+									aria-label={t("common.removeTag")}
+									className="flex items-center justify-center hover:opacity-70 cursor-pointer"
+								>
+									<X size={11} />
+								</button>
+							</span>
+						))}
+						<input
+							ref={inputRef}
+							type="text"
+							value={input}
+							onChange={(e) => {
+								setInput(e.target.value);
+								setIsOpen(true);
+							}}
+							onFocus={() => setIsOpen(true)}
+							onKeyDown={handleKeyDown}
+							placeholder={value.length === 0 ? placeholder : ""}
+							autoComplete="off"
+							className="flex-1 min-w-[80px] bg-transparent outline-none text-text-primary text-sm font-body placeholder:text-text-muted py-1"
+						/>
+					</div>
+				</PopoverPrimitive.Anchor>
+				<PopoverPrimitive.Portal>
+					<PopoverPrimitive.Content
+						className="z-[1001] w-[var(--radix-popover-trigger-width)] bg-surface-alt border border-border rounded-[10px] overflow-hidden shadow-lg max-h-[220px] overflow-y-auto"
+						sideOffset={4}
+						onOpenAutoFocus={(e) => e.preventDefault()}
+						onInteractOutside={() => setIsOpen(false)}
+					>
+						<ul>
+							{filteredSuggestions.map((item) => (
+								<li key={item}>
+									<button
+										type="button"
+										className="w-full text-left px-3.5 py-2.5 text-sm text-text-primary font-body hover:bg-surface cursor-pointer border-none bg-transparent"
+										onMouseDown={(e) => {
+											e.preventDefault();
+											addTag(item);
+										}}
+									>
+										{item}
+									</button>
+								</li>
+							))}
+							{canCreate && (
+								<li>
+									<button
+										type="button"
+										className="w-full text-left px-3.5 py-2.5 text-sm text-accent font-body hover:bg-surface cursor-pointer border-none bg-transparent flex items-center gap-1.5"
+										onMouseDown={(e) => {
+											e.preventDefault();
+											addTag(trimmed);
+										}}
+									>
+										<Plus size={14} />
+										{t("addFilm.createTag", { value: trimmed })}
+									</button>
+								</li>
+							)}
+						</ul>
+					</PopoverPrimitive.Content>
+				</PopoverPrimitive.Portal>
+			</PopoverPrimitive.Root>
+		</div>
+	);
+}
+
+export { TagInput };

--- a/src/components/ui/tag-input.tsx
+++ b/src/components/ui/tag-input.tsx
@@ -31,8 +31,9 @@ function TagInput({ label, value, onChange, suggestions, placeholder, className 
 	const addTag = (tag: string) => {
 		const normalized = tag.trim();
 		if (!normalized) return;
-		if (value.some((v) => v.toLowerCase() === normalized.toLowerCase())) return;
-		onChange([...value, normalized]);
+		const canonical = suggestions.find((s) => s.toLowerCase() === normalized.toLowerCase()) ?? normalized;
+		if (value.some((v) => v.toLowerCase() === canonical.toLowerCase())) return;
+		onChange([...value, canonical]);
 		setInput("");
 		setIsOpen(false);
 		inputRef.current?.focus();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -5,6 +5,7 @@ export const en = {
 		confirm: "Confirm",
 		yes: "Yes",
 		no: "No",
+		removeTag: "Remove tag",
 	},
 
 	// Navigation
@@ -93,6 +94,7 @@ export const en = {
 		reset: "Reset",
 		apply: "Apply",
 		clearAll: "Clear all",
+		tags: "Tags",
 		resultCount_one: "{{count}} film",
 		resultCount_other: "{{count}} films",
 	},
@@ -113,6 +115,7 @@ export const en = {
 		byFormat: "By format",
 		byCamera: "By camera",
 		byLens: "By lens",
+		byTag: "By project / tag",
 		favoriteFilms: "Favorite films",
 		unknown: "Unknown",
 		expenses: "Expenses",
@@ -149,6 +152,9 @@ export const en = {
 		addButton_one: "Add film",
 		addButton_other: "Add {{count}} films",
 		addedToStock: "Added to stock",
+		tags: "Tags",
+		tagsPlaceholder: "E.g. Japan trip 2025, Portrait…",
+		createTag: 'Create "{{value}}"',
 	},
 
 	// Film types (display labels)
@@ -601,6 +607,7 @@ export const en = {
 		viewFilm: "View film",
 		allFilms: "All",
 		allTypes: "All types",
+		allTags: "All tags",
 		filterByFilm: "By film",
 		filterByType: "By type",
 		recenter: "Recenter",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -5,6 +5,7 @@ export const fr = {
 		confirm: "Confirmer",
 		yes: "Oui",
 		no: "Non",
+		removeTag: "Retirer le tag",
 	},
 
 	// Navigation
@@ -93,6 +94,7 @@ export const fr = {
 		reset: "Réinitialiser",
 		apply: "Appliquer",
 		clearAll: "Tout effacer",
+		tags: "Tags",
 		resultCount_one: "{{count}} pellicule",
 		resultCount_other: "{{count}} pellicules",
 	},
@@ -113,6 +115,7 @@ export const fr = {
 		byFormat: "Par format",
 		byCamera: "Par appareil",
 		byLens: "Par objectif",
+		byTag: "Par projet / tag",
 		favoriteFilms: "Films favoris",
 		unknown: "Inconnu",
 		expenses: "Dépenses",
@@ -149,6 +152,9 @@ export const fr = {
 		addButton_one: "Ajouter la pellicule",
 		addButton_other: "Ajouter {{count}} pellicules",
 		addedToStock: "Ajoutée au stock",
+		tags: "Tags",
+		tagsPlaceholder: "Ex : Voyage Japon 2025, Portrait…",
+		createTag: 'Créer "{{value}}"',
 	},
 
 	// Film types (display labels)
@@ -601,6 +607,7 @@ export const fr = {
 		viewFilm: "Voir la pellicule",
 		allFilms: "Toutes",
 		allTypes: "Tous les types",
+		allTags: "Tous les tags",
 		filterByFilm: "Par pellicule",
 		filterByType: "Par type",
 		recenter: "Recentrer",

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -153,6 +153,7 @@ export function FilmDetailScreen({
 			price: film.price ?? null,
 			posesTotal: film.posesTotal ?? undefined,
 			storageLocation: film.storageLocation ?? null,
+			tags: film.tags,
 		});
 		newFilm.history = [{ date: today(), action: "", actionCode: "duplicated", params: { name: filmName(film) } }];
 		setData({ ...data, films: [...data.films, newFilm] });

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -61,6 +61,7 @@ export function FilmDetailScreen({
 		storageLocation: "",
 		comment: "",
 		price: "",
+		tags: [],
 		shootIso: "",
 		cameraId: "",
 		backId: "",
@@ -103,6 +104,7 @@ export function FilmDetailScreen({
 			storageLocation: film.storageLocation || "",
 			comment: film.comment || "",
 			price: film.price != null ? String(film.price) : "",
+			tags: film.tags ?? [],
 			shootIso: film.shootIso != null ? String(film.shootIso) : "",
 			cameraId: film.cameraId || "",
 			backId: film.backId || "",
@@ -215,6 +217,11 @@ export function FilmDetailScreen({
 					<Badge style={{ color: T.textMuted, background: alpha(T.textMuted, 0.09) }}>{film.format}</Badge>
 					<Badge style={{ color: T.textMuted, background: alpha(T.textMuted, 0.09) }}>{filmType(film)}</Badge>
 					<Badge style={{ color: T.textMuted, background: alpha(T.textMuted, 0.09) }}>ISO {fIso}</Badge>
+					{film.tags?.map((tag) => (
+						<Badge key={tag} style={{ color: T.accent, background: alpha(T.accent, 0.12) }}>
+							{tag}
+						</Badge>
+					))}
 				</div>
 			</div>
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -12,6 +12,7 @@ import { NoteSheet } from "@/components/map/NoteSheet";
 import { useTheme } from "@/components/ThemeProvider";
 import { Button } from "@/components/ui/button";
 import type { AppData, FilmType, ScreenName } from "@/types";
+import { collectAllTags } from "@/utils/film-helpers";
 import type { Cluster, GeoNote } from "@/utils/map-helpers";
 import { clusterNotes, collectGeoNotes, DARK_STYLE, fitMapToBounds, LIGHT_STYLE } from "@/utils/map-helpers";
 
@@ -31,6 +32,7 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 	const [zoom, setZoom] = useState(3);
 	const [localFilterFilmId, setLocalFilterFilmId] = useState<string | null>(filterFilmId);
 	const [filterType, setFilterType] = useState<FilmType | null>(null);
+	const [filterTag, setFilterTag] = useState<string | null>(null);
 	const [selectedCluster, setSelectedCluster] = useState<Cluster | null>(null);
 	const [selectedNote, setSelectedNote] = useState<GeoNote | null>(null);
 	const [locating, setLocating] = useState(false);
@@ -40,6 +42,10 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 	}, [filterFilmId]);
 
 	const allGeoNotes = useMemo(() => collectGeoNotes(data.films), [data.films]);
+	const availableTags = useMemo(() => {
+		const filmIds = new Set(allGeoNotes.map((n) => n.film.id));
+		return collectAllTags(data.films.filter((f) => filmIds.has(f.id)));
+	}, [data.films, allGeoNotes]);
 
 	const filteredNotes = useMemo(() => {
 		let notes = allGeoNotes;
@@ -49,8 +55,11 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 		if (filterType) {
 			notes = notes.filter((n) => n.film.type === filterType);
 		}
+		if (filterTag) {
+			notes = notes.filter((n) => n.film.tags?.includes(filterTag));
+		}
 		return notes;
-	}, [allGeoNotes, localFilterFilmId, filterType]);
+	}, [allGeoNotes, localFilterFilmId, filterType, filterTag]);
 
 	const clusters = useMemo(() => clusterNotes(filteredNotes, zoom), [filteredNotes, zoom]);
 
@@ -144,8 +153,11 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 				films={data.films}
 				filterFilmId={localFilterFilmId}
 				filterType={filterType}
+				filterTag={filterTag}
+				availableTags={availableTags}
 				onFilterFilm={setLocalFilterFilmId}
 				onFilterType={setFilterType}
+				onFilterTag={setFilterTag}
 				onClearFilter={onClearFilter}
 			/>
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -56,7 +56,8 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 			notes = notes.filter((n) => n.film.type === filterType);
 		}
 		if (filterTag) {
-			notes = notes.filter((n) => n.film.tags?.includes(filterTag));
+			const target = filterTag.toLowerCase();
+			notes = notes.filter((n) => n.film.tags?.some((t) => t.toLowerCase() === target));
 		}
 		return notes;
 	}, [allGeoNotes, localFilterFilmId, filterType, filterTag]);

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -28,6 +28,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 	const byFormat: Record<string, number> = {};
 	const byCamera: Record<string, number> = {};
 	const byLens: Record<string, number> = {};
+	const byTag: Record<string, number> = {};
 	const topFilms: Record<string, number> = {};
 	const byYearMonth: Record<string, number> = {};
 	let shotCount = 0;
@@ -62,6 +63,12 @@ export function StatsScreen({ data }: StatsScreenProps) {
 		if (f.endDate && consumedStates.has(f.state)) {
 			const ym = f.endDate.slice(0, 7);
 			byYearMonth[ym] = (byYearMonth[ym] || 0) + 1;
+		}
+
+		if (f.tags) {
+			for (const tag of f.tags) {
+				byTag[tag] = (byTag[tag] || 0) + 1;
+			}
 		}
 	}
 
@@ -160,6 +167,13 @@ export function StatsScreen({ data }: StatsScreenProps) {
 				<Card>
 					<span className="text-sm font-bold text-text-primary font-body mb-3 block">{t("stats.byLens")}</span>
 					<BarChart data={byLens} color={T.blue} />
+				</Card>
+			)}
+
+			{Object.keys(byTag).length > 0 && (
+				<Card>
+					<span className="text-sm font-bold text-text-primary font-body mb-3 block">{t("stats.byTag")}</span>
+					<BarChart data={byTag} color={T.accent} />
 				</Card>
 			)}
 

--- a/src/screens/StockScreen.tsx
+++ b/src/screens/StockScreen.tsx
@@ -200,10 +200,12 @@ export function StockScreen({ data, setScreen, setSelectedFilm, onAddFilm, initi
 				availableTypes={stockFilters.availableTypes}
 				availableBrands={stockFilters.availableBrands}
 				availableIsoValues={stockFilters.availableIsoValues}
+				availableTags={stockFilters.availableTags}
 				onSetFormat={stockFilters.setFormat}
 				onSetType={stockFilters.setType}
 				onToggleBrand={stockFilters.toggleBrand}
 				onToggleIso={stockFilters.toggleIso}
+				onToggleTag={stockFilters.toggleTag}
 				onReset={stockFilters.resetFilters}
 			/>
 		</div>

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -10,9 +10,11 @@ import { Input } from "@/components/ui/input";
 import { MonthYearPicker } from "@/components/ui/month-year-picker";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { TagInput } from "@/components/ui/tag-input";
 import { alpha, T } from "@/constants/theme";
 import { type AppData, type Back, type Camera, type Film, isInstantFormat } from "@/types";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
+import { collectAllTags } from "@/utils/film-helpers";
 import { today } from "@/utils/helpers";
 import { lensDisplayName } from "@/utils/lens-helpers";
 import type { ActionType, EditData } from "./types";
@@ -152,6 +154,13 @@ export function EditModal({
 							placeholder={t("addFilm.notesPlaceholder")}
 						/>
 					</FormField>
+					<TagInput
+						label={t("addFilm.tags")}
+						value={editData.tags}
+						onChange={(tags) => setEditData({ ...editData, tags })}
+						suggestions={collectAllTags(data.films)}
+						placeholder={t("addFilm.tagsPlaceholder")}
+					/>
 
 					{/* === Loading section === */}
 					{showLoading && (
@@ -433,6 +442,7 @@ export function EditModal({
 								storageLocation: editData.storageLocation.trim() || null,
 								price: editData.price.trim() ? safeFloat(editData.price) : null,
 								comment: editData.comment.trim() || null,
+								tags: editData.tags.length > 0 ? editData.tags : undefined,
 								history: [...(film.history || []), { date: today(), action: "", actionCode: "modified" }],
 							};
 							if (showLoading) {

--- a/src/screens/film-detail/types.ts
+++ b/src/screens/film-detail/types.ts
@@ -33,6 +33,7 @@ export interface EditData {
 	storageLocation: string;
 	comment: string;
 	price: string;
+	tags: string[];
 	// Loading
 	shootIso: string;
 	cameraId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export interface Film {
 	storageLocation?: string | null;
 	history: HistoryEntry[];
 	shotNotes?: ShotNote[];
+	tags?: string[];
 }
 
 export interface Back {

--- a/src/utils/film-factory.ts
+++ b/src/utils/film-factory.ts
@@ -24,6 +24,7 @@ interface NewFilmParams {
 	price?: number | null;
 	posesTotal?: number;
 	storageLocation?: string | null;
+	tags?: string[];
 }
 
 export function createNewFilm(params: NewFilmParams): Film {
@@ -52,5 +53,6 @@ export function createNewFilm(params: NewFilmParams): Film {
 		devDate: null,
 		storageLocation: params.storageLocation ?? null,
 		history: [{ date: today(), action: "", actionCode: "added" }],
+		tags: params.tags && params.tags.length > 0 ? params.tags : undefined,
 	};
 }

--- a/src/utils/film-factory.ts
+++ b/src/utils/film-factory.ts
@@ -53,6 +53,6 @@ export function createNewFilm(params: NewFilmParams): Film {
 		devDate: null,
 		storageLocation: params.storageLocation ?? null,
 		history: [{ date: today(), action: "", actionCode: "added" }],
-		tags: params.tags && params.tags.length > 0 ? params.tags : undefined,
+		tags: params.tags && params.tags.length > 0 ? [...params.tags] : undefined,
 	};
 }

--- a/src/utils/film-helpers.ts
+++ b/src/utils/film-helpers.ts
@@ -27,3 +27,13 @@ export const filmBrand = (film: Film): string => (film.brand ? normalizeBrand(fi
 export const filmType = (film: Film): string => film.type || "?";
 
 export const filmIso = (film: Film): number | string => film.iso || "?";
+
+export const collectAllTags = (films: Film[]): string[] => {
+	const tags = new Set<string>();
+	for (const f of films) {
+		if (f.tags) {
+			for (const tag of f.tags) tags.add(tag);
+		}
+	}
+	return Array.from(tags).sort((a, b) => a.localeCompare(b));
+};

--- a/src/utils/film-helpers.ts
+++ b/src/utils/film-helpers.ts
@@ -29,11 +29,13 @@ export const filmType = (film: Film): string => film.type || "?";
 export const filmIso = (film: Film): number | string => film.iso || "?";
 
 export const collectAllTags = (films: Film[]): string[] => {
-	const tags = new Set<string>();
+	const canonical = new Map<string, string>();
 	for (const f of films) {
-		if (f.tags) {
-			for (const tag of f.tags) tags.add(tag);
+		if (!f.tags) continue;
+		for (const tag of f.tags) {
+			const key = tag.toLowerCase();
+			if (!canonical.has(key)) canonical.set(key, tag);
 		}
 	}
-	return Array.from(tags).sort((a, b) => a.localeCompare(b));
+	return Array.from(canonical.values()).sort((a, b) => a.localeCompare(b));
 };

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,6 +1,6 @@
 import type { AppData } from "@/types";
 
-export const CURRENT_VERSION = 17;
+export const CURRENT_VERSION = 18;
 
 type MigrationFn = (data: Record<string, unknown>) => Record<string, unknown>;
 
@@ -244,6 +244,11 @@ function migrateV16toV17(data: Record<string, unknown>): Record<string, unknown>
 	return { ...data, version: 17 };
 }
 
+function migrateV17toV18(data: Record<string, unknown>): Record<string, unknown> {
+	// Add tags to Film. Optional field, no transformation needed.
+	return { ...data, version: 18 };
+}
+
 const migrations: Record<number, MigrationFn> = {
 	1: migrateV1toV2,
 	2: migrateV2toV3,
@@ -261,6 +266,7 @@ const migrations: Record<number, MigrationFn> = {
 	14: migrateV14toV15,
 	15: migrateV15toV16,
 	16: migrateV16toV17,
+	17: migrateV17toV18,
 };
 
 export function applyMigrations(data: Record<string, unknown>): AppData {

--- a/src/utils/use-stock-filters.ts
+++ b/src/utils/use-stock-filters.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Film } from "@/types";
-import { filmName, normalizeBrand } from "@/utils/film-helpers";
+import { collectAllTags, filmName, normalizeBrand } from "@/utils/film-helpers";
 
 export type SortOption =
 	| "name-asc"
@@ -19,6 +19,7 @@ export interface StockFilters {
 	type: string;
 	brands: string[];
 	isoValues: number[];
+	tags: string[];
 }
 
 interface ActiveFilter {
@@ -92,6 +93,7 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 		type: "all",
 		brands: [],
 		isoValues: [],
+		tags: [],
 	});
 	const [sortOption, setSortOption] = useState<SortOption>("name-asc");
 
@@ -133,6 +135,8 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 		return Array.from(isos).sort((a, b) => a - b);
 	}, [films]);
 
+	const availableTags = useMemo(() => collectAllTags(films), [films]);
+
 	const filteredFilms = useMemo(() => {
 		const result = films.filter((f) => {
 			if (stateFilter !== "all" && f.state !== stateFilter) return false;
@@ -144,6 +148,10 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 			}
 			if (filters.isoValues.length > 0) {
 				if (!f.iso || !filters.isoValues.includes(f.iso)) return false;
+			}
+			if (filters.tags.length > 0) {
+				const filmTags = f.tags ?? [];
+				if (!filmTags.some((t) => filters.tags.includes(t))) return false;
 			}
 			if (search) {
 				const name = filmName(f);
@@ -159,7 +167,11 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 
 	const hasActiveFilters = useMemo(
 		() =>
-			filters.format !== "all" || filters.type !== "all" || filters.brands.length > 0 || filters.isoValues.length > 0,
+			filters.format !== "all" ||
+			filters.type !== "all" ||
+			filters.brands.length > 0 ||
+			filters.isoValues.length > 0 ||
+			filters.tags.length > 0,
 		[filters],
 	);
 
@@ -176,6 +188,9 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 		}
 		for (const iso of filters.isoValues) {
 			descriptions.push({ key: `iso:${iso}`, label: `ISO ${iso}` });
+		}
+		for (const tag of filters.tags) {
+			descriptions.push({ key: `tag:${tag}`, label: tag });
 		}
 		return descriptions;
 	}, [filters]);
@@ -195,6 +210,12 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 			isoValues: prev.isoValues.includes(iso) ? prev.isoValues.filter((i) => i !== iso) : [...prev.isoValues, iso],
 		}));
 
+	const toggleTag = (tag: string) =>
+		setFilters((prev) => ({
+			...prev,
+			tags: prev.tags.includes(tag) ? prev.tags.filter((t) => t !== tag) : [...prev.tags, tag],
+		}));
+
 	const removeFilter = (key: string) => {
 		if (key === "format") {
 			setFormat("all");
@@ -206,12 +227,15 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 		} else if (key.startsWith("iso:")) {
 			const iso = Number(key.slice(4));
 			setFilters((prev) => ({ ...prev, isoValues: prev.isoValues.filter((i) => i !== iso) }));
+		} else if (key.startsWith("tag:")) {
+			const tag = key.slice(4);
+			setFilters((prev) => ({ ...prev, tags: prev.tags.filter((t) => t !== tag) }));
 		}
 	};
 
 	const resetFilters = () => {
 		setStateFilter("all");
-		setFilters({ format: "all", type: "all", brands: [], isoValues: [] });
+		setFilters({ format: "all", type: "all", brands: [], isoValues: [], tags: [] });
 	};
 
 	return {
@@ -228,12 +252,14 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 		availableTypes,
 		availableBrands,
 		availableIsoValues,
+		availableTags,
 		hasActiveFilters,
 		activeFilterDescriptions,
 		setFormat,
 		setType,
 		toggleBrand,
 		toggleIso,
+		toggleTag,
 		removeFilter,
 		resetFilters,
 	};

--- a/src/utils/use-stock-filters.ts
+++ b/src/utils/use-stock-filters.ts
@@ -151,7 +151,8 @@ export function useStockFilters(films: Film[], initialStateFilter?: string | nul
 			}
 			if (filters.tags.length > 0) {
 				const filmTags = f.tags ?? [];
-				if (!filmTags.some((t) => filters.tags.includes(t))) return false;
+				const selected = filters.tags.map((t) => t.toLowerCase());
+				if (!filmTags.some((t) => selected.includes(t.toLowerCase()))) return false;
 			}
 			if (search) {
 				const name = filmName(f);


### PR DESCRIPTION
Adds an optional `tags: string[]` field on Film to let users group
pellicules by project, trip or theme — reusable across filters,
display and stats.

- New TagInput UI component with autocomplete + inline create
- Stock filter: multi-select on available tags, active chips, reset
- FilmRow + FilmDetailScreen: tag badges in the header
- AddFilmDialog + EditModal: tag input with suggestions from existing tags
- StatsScreen: new "Par projet / tag" distribution block
- MapScreen: tag filter row alongside type and film filters
- Migration 17 → 18 (field is optional, no transformation)
- FR + EN translations
- Updated data-model and persistence docs

https://claude.ai/code/session_016djUZMFGjDDfoGM7qRi8W3