### PR TITLE
feat(nav): replace hardcoded back targets with a history stack

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,26 +138,28 @@ function FilmVaultInner() {
 		return () => window.removeEventListener("online", handleOnline);
 	}, [triggerSync]);
 
+	const { resetTo: navResetTo, replace: navReplace, current: navCurrent } = nav;
+
 	// TabBar: tabs are top-level, they reset the history stack.
 	const tabSetScreen = useCallback(
 		(s: ScreenName) => {
-			nav.resetTo({ screen: s });
+			navResetTo({ screen: s });
 		},
-		[nav],
+		[navResetTo],
 	);
 
 	// Tour: scripted screen jumps should not pollute history.
 	const tourSetScreen = useCallback(
 		(s: ScreenName) => {
-			nav.resetTo({ screen: s });
+			navResetTo({ screen: s });
 		},
-		[nav],
+		[navResetTo],
 	);
 	const tourSetSelectedFilm = useCallback(
 		(id: string | null) => {
-			nav.replace({ ...nav.current, selectedFilm: id });
+			navReplace({ ...navCurrent, selectedFilm: id });
 		},
-		[nav],
+		[navReplace, navCurrent],
 	);
 
 	if (loading || !data) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,9 @@ import { useNavigationStack } from "@/utils/use-navigation-stack";
 
 const MapScreen = lazy(() => import("@/screens/MapScreen").then((m) => ({ default: m.MapScreen })));
 
+// Screens without a bottom tab: hide the tabbar and animate as sub-screens.
+const SUB_SCREENS: ReadonlySet<ScreenName> = new Set(["filmDetail", "cameraDetail", "settings", "legal"]);
+
 function FilmVaultInner() {
 	const [data, setData] = useState<AppData | null>(null);
 	const [loading, setLoading] = useState(true);
@@ -140,16 +143,9 @@ function FilmVaultInner() {
 
 	const { resetTo: navResetTo, replace: navReplace, current: navCurrent } = nav;
 
-	// TabBar: tabs are top-level, they reset the history stack.
-	const tabSetScreen = useCallback(
-		(s: ScreenName) => {
-			navResetTo({ screen: s });
-		},
-		[navResetTo],
-	);
-
-	// Tour: scripted screen jumps should not pollute history.
-	const tourSetScreen = useCallback(
+	// Both the TabBar (top-level tabs) and the Tour (scripted jumps) want to
+	// move without pushing onto the history stack.
+	const resetScreen = useCallback(
 		(s: ScreenName) => {
 			navResetTo({ screen: s });
 		},
@@ -172,12 +168,12 @@ function FilmVaultInner() {
 	}
 
 	return (
-		<TourProvider setScreen={tourSetScreen} setSelectedFilm={tourSetSelectedFilm}>
+		<TourProvider setScreen={resetScreen} setSelectedFilm={tourSetSelectedFilm}>
 			<AppContent
 				data={data}
 				updateData={updateData}
 				nav={nav}
-				tabSetScreen={tabSetScreen}
+				resetScreen={resetScreen}
 				autoOpenShotNote={autoOpenShotNote}
 				setAutoOpenShotNote={setAutoOpenShotNote}
 				showAddFilm={showAddFilm}
@@ -196,7 +192,7 @@ interface AppContentProps {
 	data: AppData;
 	updateData: (data: AppData) => Promise<void>;
 	nav: ReturnType<typeof useNavigationStack>;
-	tabSetScreen: (s: ScreenName) => void;
+	resetScreen: (s: ScreenName) => void;
 	autoOpenShotNote: boolean;
 	setAutoOpenShotNote: (open: boolean) => void;
 	showAddFilm: boolean;
@@ -212,7 +208,7 @@ function AppContent({
 	data,
 	updateData,
 	nav,
-	tabSetScreen,
+	resetScreen,
 	autoOpenShotNote,
 	setAutoOpenShotNote,
 	showAddFilm,
@@ -237,15 +233,12 @@ function AppContent({
 
 	// Track navigation direction
 	useEffect(() => {
-		const detailScreens: ScreenName[] = ["filmDetail", "cameraDetail", "settings", "legal"];
 		const prev = prevScreen.current;
-		if (detailScreens.includes(screen) && !detailScreens.includes(prev)) {
-			navDirection.current = "forward";
-		} else if (!detailScreens.includes(screen) && detailScreens.includes(prev)) {
-			navDirection.current = "back";
-		} else {
-			navDirection.current = "tab";
-		}
+		const isSub = SUB_SCREENS.has(screen);
+		const wasSub = SUB_SCREENS.has(prev);
+		if (isSub && !wasSub) navDirection.current = "forward";
+		else if (!isSub && wasSub) navDirection.current = "back";
+		else navDirection.current = "tab";
 		prevScreen.current = screen;
 	}, [screen]);
 
@@ -398,12 +391,12 @@ function AppContent({
 				return cam.nickname || fallbackTitle || undefined;
 			})()
 		: undefined;
-	const showTabBar = !["filmDetail", "cameraDetail", "settings", "legal"].includes(screen);
+	const showTabBar = !SUB_SCREENS.has(screen);
 
 	return (
 		<div className="h-[100dvh] bg-bg text-text-primary font-body flex flex-col md:flex-row relative">
 			{/* Sidebar — desktop only, always visible */}
-			<TabBar screen={screen} setScreen={tabSetScreen} variant="sidebar" className="hidden md:flex" />
+			<TabBar screen={screen} setScreen={resetScreen} variant="sidebar" className="hidden md:flex" />
 
 			<main className="flex-1 flex flex-col min-h-0 min-w-0">
 				<AppHeader
@@ -436,7 +429,7 @@ function AppContent({
 				)}
 
 				{/* Bottom TabBar — mobile only */}
-				{showTabBar && <TabBar screen={screen} setScreen={tabSetScreen} className="md:hidden" />}
+				{showTabBar && <TabBar screen={screen} setScreen={resetScreen} className="md:hidden" />}
 			</main>
 
 			<AddFilmDialog

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,18 +23,14 @@ import { refreshCatalogs } from "@/utils/catalog";
 import { checkStorage, getInitialData, isStorageAvailable, loadData, saveData } from "@/utils/storage";
 import { ensureAnonSession, isSupabaseConfigured } from "@/utils/supabase";
 import { getRecoveryCode, pushToCloud, syncData } from "@/utils/sync";
+import { useNavigationStack } from "@/utils/use-navigation-stack";
 
 const MapScreen = lazy(() => import("@/screens/MapScreen").then((m) => ({ default: m.MapScreen })));
 
 function FilmVaultInner() {
 	const [data, setData] = useState<AppData | null>(null);
 	const [loading, setLoading] = useState(true);
-	const [screen, setScreen] = useState<ScreenName>("home");
-	const [selectedFilm, setSelectedFilm] = useState<string | null>(null);
-	const [selectedCamera, setSelectedCamera] = useState<string | null>(null);
-	const [filmBackTarget, setFilmBackTarget] = useState<ScreenName | null>(null);
-	const [mapFilterFilmId, setMapFilterFilmId] = useState<string | null>(null);
-	const [stockStateFilter, setStockStateFilter] = useState<string | null>(null);
+	const nav = useNavigationStack({ screen: "home" });
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
 	const [showAddFilm, setShowAddFilm] = useState(false);
 	const [persistent, setPersistent] = useState(false);
@@ -142,33 +138,27 @@ function FilmVaultInner() {
 		return () => window.removeEventListener("online", handleOnline);
 	}, [triggerSync]);
 
-	const handleSetScreen = useCallback((s: ScreenName) => {
-		if (s === "map") setMapFilterFilmId(null);
-		if (s === "stock") setStockStateFilter(null);
-		if (s !== "filmDetail") setFilmBackTarget(null);
-		setScreen(s);
-	}, []);
+	// TabBar: tabs are top-level, they reset the history stack.
+	const tabSetScreen = useCallback(
+		(s: ScreenName) => {
+			nav.resetTo({ screen: s });
+		},
+		[nav],
+	);
 
-	const navigateToMap = useCallback((filmId?: string) => {
-		setMapFilterFilmId(filmId ?? null);
-		setScreen("map");
-	}, []);
-
-	const navigateToStock = useCallback((stateFilter: string) => {
-		setStockStateFilter(stateFilter);
-		setScreen("stock");
-	}, []);
-
-	const navigateToCamera = useCallback((camId: string) => {
-		setSelectedCamera(camId);
-		setScreen("cameraDetail");
-	}, []);
-
-	const navigateToFilm = useCallback((filmId: string) => {
-		setSelectedFilm(filmId);
-		setFilmBackTarget("cameraDetail");
-		setScreen("filmDetail");
-	}, []);
+	// Tour: scripted screen jumps should not pollute history.
+	const tourSetScreen = useCallback(
+		(s: ScreenName) => {
+			nav.resetTo({ screen: s });
+		},
+		[nav],
+	);
+	const tourSetSelectedFilm = useCallback(
+		(id: string | null) => {
+			nav.replace({ ...nav.current, selectedFilm: id });
+		},
+		[nav],
+	);
 
 	if (loading || !data) {
 		return (
@@ -180,18 +170,12 @@ function FilmVaultInner() {
 	}
 
 	return (
-		<TourProvider setScreen={setScreen} setSelectedFilm={setSelectedFilm}>
+		<TourProvider setScreen={tourSetScreen} setSelectedFilm={tourSetSelectedFilm}>
 			<AppContent
 				data={data}
 				updateData={updateData}
-				screen={screen}
-				handleSetScreen={handleSetScreen}
-				setScreen={setScreen}
-				selectedFilm={selectedFilm}
-				setSelectedFilm={setSelectedFilm}
-				mapFilterFilmId={mapFilterFilmId}
-				setMapFilterFilmId={setMapFilterFilmId}
-				stockStateFilter={stockStateFilter}
+				nav={nav}
+				tabSetScreen={tabSetScreen}
 				autoOpenShotNote={autoOpenShotNote}
 				setAutoOpenShotNote={setAutoOpenShotNote}
 				showAddFilm={showAddFilm}
@@ -201,12 +185,6 @@ function FilmVaultInner() {
 				setRecoveryCodeState={setRecoveryCodeState}
 				triggerSync={triggerSync}
 				persistent={persistent}
-				navigateToMap={navigateToMap}
-				navigateToStock={navigateToStock}
-				navigateToCamera={navigateToCamera}
-				navigateToFilm={navigateToFilm}
-				selectedCamera={selectedCamera}
-				filmBackTarget={filmBackTarget}
 			/>
 		</TourProvider>
 	);
@@ -215,14 +193,8 @@ function FilmVaultInner() {
 interface AppContentProps {
 	data: AppData;
 	updateData: (data: AppData) => Promise<void>;
-	screen: ScreenName;
-	handleSetScreen: (s: ScreenName) => void;
-	setScreen: (s: ScreenName) => void;
-	selectedFilm: string | null;
-	setSelectedFilm: (id: string | null) => void;
-	mapFilterFilmId: string | null;
-	setMapFilterFilmId: (id: string | null) => void;
-	stockStateFilter: string | null;
+	nav: ReturnType<typeof useNavigationStack>;
+	tabSetScreen: (s: ScreenName) => void;
 	autoOpenShotNote: boolean;
 	setAutoOpenShotNote: (open: boolean) => void;
 	showAddFilm: boolean;
@@ -232,25 +204,13 @@ interface AppContentProps {
 	setRecoveryCodeState: (code: string | null) => void;
 	triggerSync: () => Promise<void>;
 	persistent: boolean;
-	navigateToMap: (filmId?: string) => void;
-	navigateToStock: (stateFilter: string) => void;
-	navigateToCamera: (camId: string) => void;
-	navigateToFilm: (filmId: string) => void;
-	selectedCamera: string | null;
-	filmBackTarget: ScreenName | null;
 }
 
 function AppContent({
 	data,
 	updateData,
-	screen,
-	handleSetScreen,
-	setScreen,
-	selectedFilm,
-	setSelectedFilm,
-	mapFilterFilmId,
-	setMapFilterFilmId,
-	stockStateFilter,
+	nav,
+	tabSetScreen,
 	autoOpenShotNote,
 	setAutoOpenShotNote,
 	showAddFilm,
@@ -260,17 +220,14 @@ function AppContent({
 	setRecoveryCodeState,
 	triggerSync,
 	persistent,
-	navigateToMap,
-	navigateToStock,
-	navigateToCamera,
-	navigateToFilm,
-	selectedCamera,
-	filmBackTarget,
 }: AppContentProps) {
 	const { isTourActive, tourData, startTour } = useTour();
 	const autoTourTriggered = useRef(false);
 	const navDirection = useRef<"forward" | "back" | "tab">("tab");
-	const prevScreen = useRef<ScreenName>(screen);
+	const prevScreen = useRef<ScreenName>(nav.current.screen);
+
+	const { current, navigate, goBack, resetTo, replace } = nav;
+	const { screen, selectedFilm, selectedCamera, mapFilterFilmId, stockStateFilter } = current;
 
 	const effectiveData = isTourActive && tourData ? tourData : data;
 	const noopUpdate = useCallback(async () => {}, []);
@@ -301,27 +258,56 @@ function AppContent({
 
 	const onAddFilm = () => setShowAddFilm(true);
 
+	// Forward-navigation callbacks. Each one pushes onto the history stack so
+	// the back button can restore the previous screen (and its params).
+	const openFilm = useCallback((id: string) => navigate({ screen: "filmDetail", selectedFilm: id }), [navigate]);
+	const openCamera = useCallback((id: string) => navigate({ screen: "cameraDetail", selectedCamera: id }), [navigate]);
+	const openMap = useCallback(
+		(filmId?: string) => navigate({ screen: "map", mapFilterFilmId: filmId ?? null }),
+		[navigate],
+	);
+	const openStockFiltered = useCallback(
+		(stateFilter: string) => navigate({ screen: "stock", stockStateFilter: stateFilter }),
+		[navigate],
+	);
+	const openCamerasList = useCallback(() => navigate({ screen: "cameras" }), [navigate]);
+	const openSettings = useCallback(() => navigate({ screen: "settings" }), [navigate]);
+	const openLegal = useCallback(() => navigate({ screen: "legal" }), [navigate]);
+
+	// Explicit redirects (not back): used after delete or when target not found.
+	const exitToStock = useCallback(() => resetTo({ screen: "stock" }), [resetTo]);
+	const exitToCameras = useCallback(() => resetTo({ screen: "cameras" }), [resetTo]);
+
+	// Duplicating a film in FilmDetail needs to swap the viewed film without
+	// pushing to history (it's the same screen with a different ID).
+	const replaceSelectedFilm = useCallback(
+		(id: string) => replace({ ...current, selectedFilm: id }),
+		[replace, current],
+	);
+
+	// Map filter clear: stays on the map screen, just drops the filter.
+	const clearMapFilter = useCallback(() => replace({ ...current, mapFilterFilmId: null }), [replace, current]);
+
 	const renderScreen = () => {
 		switch (screen) {
 			case "home":
 				return (
 					<DashboardScreen
 						data={effectiveData}
-						setScreen={setScreen}
-						setSelectedFilm={setSelectedFilm}
+						onOpenFilm={openFilm}
+						onOpenCameras={openCamerasList}
 						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
-						onNavigateToStock={navigateToStock}
+						onNavigateToStock={openStockFiltered}
 					/>
 				);
 			case "stock":
 				return (
 					<StockScreen
 						data={effectiveData}
-						setScreen={setScreen}
-						setSelectedFilm={setSelectedFilm}
+						onOpenFilm={openFilm}
 						onAddFilm={onAddFilm}
-						initialStateFilter={stockStateFilter}
+						initialStateFilter={stockStateFilter ?? null}
 					/>
 				);
 			case "filmDetail":
@@ -329,11 +315,11 @@ function AppContent({
 					<FilmDetailScreen
 						data={effectiveData}
 						setData={effectiveUpdateData}
-						setScreen={setScreen}
-						setSelectedFilm={setSelectedFilm}
-						filmId={selectedFilm}
-						onNavigateToMap={navigateToMap}
-						onNavigateToCamera={navigateToCamera}
+						onExit={exitToStock}
+						onFilmDuplicated={replaceSelectedFilm}
+						filmId={selectedFilm ?? null}
+						onNavigateToMap={openMap}
+						onNavigateToCamera={openCamera}
 						autoOpenShotNote={autoOpenShotNote}
 						setAutoOpenShotNote={setAutoOpenShotNote}
 					/>
@@ -342,9 +328,9 @@ function AppContent({
 				return (
 					<CameraDetailScreen
 						data={effectiveData}
-						cameraId={selectedCamera}
-						setScreen={setScreen}
-						onFilmClick={navigateToFilm}
+						cameraId={selectedCamera ?? null}
+						onExit={exitToCameras}
+						onFilmClick={openFilm}
 					/>
 				);
 			case "map":
@@ -358,15 +344,15 @@ function AppContent({
 					>
 						<MapScreen
 							data={effectiveData}
-							setScreen={setScreen}
-							setSelectedFilm={setSelectedFilm}
-							filterFilmId={mapFilterFilmId}
-							onClearFilter={() => setMapFilterFilmId(null)}
+							onOpenFilm={openFilm}
+							onOpenStock={exitToStock}
+							filterFilmId={mapFilterFilmId ?? null}
+							onClearFilter={clearMapFilter}
 						/>
 					</Suspense>
 				);
 			case "cameras":
-				return <EquipmentScreen data={effectiveData} setData={effectiveUpdateData} onCameraClick={navigateToCamera} />;
+				return <EquipmentScreen data={effectiveData} setData={effectiveUpdateData} onCameraClick={openCamera} />;
 			case "stats":
 				return <StatsScreen data={effectiveData} />;
 			case "settings":
@@ -379,20 +365,20 @@ function AppContent({
 						onRecoveryCodeChange={setRecoveryCodeState}
 						onSyncNow={triggerSync}
 						persistent={persistent}
-						setScreen={setScreen}
+						onOpenLegal={openLegal}
 					/>
 				);
 			case "legal":
-				return <LegalScreen onBack={() => setScreen("settings")} />;
+				return <LegalScreen onBack={goBack} />;
 			default:
 				return (
 					<DashboardScreen
 						data={effectiveData}
-						setScreen={setScreen}
-						setSelectedFilm={setSelectedFilm}
+						onOpenFilm={openFilm}
+						onOpenCameras={openCamerasList}
 						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
-						onNavigateToStock={navigateToStock}
+						onNavigateToStock={openStockFiltered}
 					/>
 				);
 		}
@@ -415,15 +401,15 @@ function AppContent({
 	return (
 		<div className="h-[100dvh] bg-bg text-text-primary font-body flex flex-col md:flex-row relative">
 			{/* Sidebar — desktop only, always visible */}
-			<TabBar screen={screen} setScreen={handleSetScreen} variant="sidebar" className="hidden md:flex" />
+			<TabBar screen={screen} setScreen={tabSetScreen} variant="sidebar" className="hidden md:flex" />
 
 			<main className="flex-1 flex flex-col min-h-0 min-w-0">
 				<AppHeader
 					screen={screen}
-					setScreen={handleSetScreen}
+					goBack={goBack}
+					onOpenSettings={openSettings}
 					filmTitle={filmTitle}
 					cameraTitle={cameraTitle}
-					filmBackTarget={filmBackTarget}
 					className="md:hidden"
 				/>
 				{screen === "map" ? (
@@ -448,7 +434,7 @@ function AppContent({
 				)}
 
 				{/* Bottom TabBar — mobile only */}
-				{showTabBar && <TabBar screen={screen} setScreen={handleSetScreen} className="md:hidden" />}
+				{showTabBar && <TabBar screen={screen} setScreen={tabSetScreen} className="md:hidden" />}
 			</main>
 
 			<AddFilmDialog

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -14,7 +14,9 @@ interface AppHeaderProps {
 	className?: string;
 }
 
-const DETAIL_SCREENS: ReadonlySet<ScreenName> = new Set(["filmDetail", "cameraDetail", "settings", "legal"]);
+// LegalScreen renders its own back button and title in its body,
+// so it keeps the root-style header here.
+const DETAIL_SCREENS: ReadonlySet<ScreenName> = new Set(["filmDetail", "cameraDetail", "settings"]);
 
 export function AppHeader({ screen, goBack, onOpenSettings, filmTitle, cameraTitle, className }: AppHeaderProps) {
 	const { t } = useTranslation();

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -7,24 +7,19 @@ import type { ScreenName } from "@/types";
 
 interface AppHeaderProps {
 	screen: ScreenName;
-	setScreen: (screen: ScreenName) => void;
+	goBack: () => void;
+	onOpenSettings: () => void;
 	filmTitle?: string;
 	cameraTitle?: string;
-	filmBackTarget?: ScreenName | null;
 	className?: string;
 }
 
-const backTargets: Partial<Record<ScreenName, ScreenName>> = {
-	filmDetail: "stock",
-	cameraDetail: "cameras",
-	settings: "home",
-};
+const DETAIL_SCREENS: ReadonlySet<ScreenName> = new Set(["filmDetail", "cameraDetail", "settings", "legal"]);
 
-export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, filmBackTarget, className }: AppHeaderProps) {
+export function AppHeader({ screen, goBack, onOpenSettings, filmTitle, cameraTitle, className }: AppHeaderProps) {
 	const { t } = useTranslation();
 	const { theme, setTheme } = useTheme();
-	const backTarget = screen === "filmDetail" && filmBackTarget ? filmBackTarget : backTargets[screen];
-	const isSubScreen = !!backTarget;
+	const isSubScreen = DETAIL_SCREENS.has(screen);
 
 	const subScreenTitles: Partial<Record<ScreenName, string>> = {
 		filmDetail: filmTitle || t("filmDetail.back"),
@@ -42,13 +37,7 @@ export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, filmBackT
 			<div className="flex items-center gap-2 min-w-0">
 				{isSubScreen ? (
 					<>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => setScreen(backTarget)}
-							className="-ml-2"
-							aria-label={t("aria.back")}
-						>
+						<Button variant="ghost" size="icon" onClick={goBack} className="-ml-2" aria-label={t("aria.back")}>
 							<ArrowLeft size={20} className="text-text-sec" />
 						</Button>
 						<h1 className="font-display text-lg text-text-primary m-0 italic truncate">{subScreenTitles[screen]}</h1>
@@ -76,7 +65,7 @@ export function AppHeader({ screen, setScreen, filmTitle, cameraTitle, filmBackT
 					<Button
 						variant="outline"
 						size="icon"
-						onClick={() => setScreen("settings")}
+						onClick={onOpenSettings}
 						className="shrink-0"
 						aria-label={t("nav.settings")}
 					>

--- a/src/screens/CameraDetailScreen.tsx
+++ b/src/screens/CameraDetailScreen.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { PhotoImg } from "@/components/ui/photo-img";
 import { alpha, T } from "@/constants/theme";
-import type { AppData, ScreenName } from "@/types";
+import type { AppData } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { CameraFilmsList } from "./camera-detail/CameraFilmsList";
 import { CameraHistoryTimeline } from "./camera-detail/CameraHistoryTimeline";
@@ -17,11 +17,11 @@ import { CameraInfoSection } from "./camera-detail/CameraInfoSection";
 interface CameraDetailScreenProps {
 	data: AppData;
 	cameraId: string | null;
-	setScreen: (screen: ScreenName) => void;
+	onExit: () => void;
 	onFilmClick: (filmId: string) => void;
 }
 
-export function CameraDetailScreen({ data, cameraId, setScreen, onFilmClick }: CameraDetailScreenProps) {
+export function CameraDetailScreen({ data, cameraId, onExit, onFilmClick }: CameraDetailScreenProps) {
 	const { t } = useTranslation();
 	const camera = cameraId ? data.cameras.find((c) => c.id === cameraId) : null;
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
@@ -33,7 +33,7 @@ export function CameraDetailScreen({ data, cameraId, setScreen, onFilmClick }: C
 			<EmptyState
 				icon={CameraIcon}
 				title={t("cameraDetail.notFound")}
-				action={<Button onClick={() => setScreen("cameras")}>{t("filmDetail.back")}</Button>}
+				action={<Button onClick={onExit}>{t("filmDetail.back")}</Button>}
 			/>
 		);
 	}

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -8,13 +8,13 @@ import { TodoItem } from "@/components/TodoItem";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { alpha, T } from "@/constants/theme";
-import type { AppData, Back, Camera as CameraType, Film as FilmType, ScreenName } from "@/types";
+import type { AppData, Back, Camera as CameraType, Film as FilmType } from "@/types";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 
 interface DashboardScreenProps {
 	data: AppData;
-	setScreen: (screen: ScreenName) => void;
-	setSelectedFilm: (id: string) => void;
+	onOpenFilm: (id: string) => void;
+	onOpenCameras: () => void;
 	onAddFilm: () => void;
 	setAutoOpenShotNote?: (open: boolean) => void;
 	onNavigateToStock: (stateFilter: string) => void;
@@ -88,8 +88,8 @@ function buildEquipmentItems(cameras: CameraType[], backs: Back[], activeFilms: 
 
 export function DashboardScreen({
 	data,
-	setScreen,
-	setSelectedFilm,
+	onOpenFilm,
+	onOpenCameras,
 	onAddFilm,
 	setAutoOpenShotNote,
 	onNavigateToStock,
@@ -192,13 +192,9 @@ export function DashboardScreen({
 										back={back}
 										onShotClick={() => {
 											setAutoOpenShotNote?.(true);
-											setSelectedFilm(f.id);
-											setScreen("filmDetail");
+											onOpenFilm(f.id);
 										}}
-										onClick={() => {
-											setSelectedFilm(f.id);
-											setScreen("filmDetail");
-										}}
+										onClick={() => onOpenFilm(f.id)}
 									/>
 								</div>
 							);
@@ -250,7 +246,7 @@ export function DashboardScreen({
 								sublabel={item.sublabel}
 								loadedFilm={item.loadedFilm}
 								icon={item.icon}
-								onClick={() => setScreen("cameras")}
+								onClick={onOpenCameras}
 								className="w-full"
 							/>
 						))}

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -12,7 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { alpha, T } from "@/constants/theme";
-import type { AppData, Film as FilmType, ScreenName } from "@/types";
+import type { AppData, Film as FilmType } from "@/types";
 import { createNewFilm } from "@/utils/film-factory";
 import { filmIso, filmName, filmType } from "@/utils/film-helpers";
 import { today } from "@/utils/helpers";
@@ -27,8 +27,8 @@ import type { ActionData, ActionType, EditData } from "./film-detail/types";
 interface FilmDetailScreenProps {
 	data: AppData;
 	setData: (data: AppData) => void;
-	setScreen: (screen: ScreenName) => void;
-	setSelectedFilm: (id: string) => void;
+	onExit: () => void;
+	onFilmDuplicated: (id: string) => void;
 	filmId: string | null;
 	onNavigateToMap?: (filmId: string) => void;
 	onNavigateToCamera?: (camId: string) => void;
@@ -39,8 +39,8 @@ interface FilmDetailScreenProps {
 export function FilmDetailScreen({
 	data,
 	setData,
-	setScreen,
-	setSelectedFilm,
+	onExit,
+	onFilmDuplicated,
 	filmId,
 	onNavigateToMap,
 	onNavigateToCamera,
@@ -89,7 +89,7 @@ export function FilmDetailScreen({
 			<EmptyState
 				icon={Film}
 				title={t("filmDetail.notFound")}
-				action={<Button onClick={() => setScreen("stock")}>{t("filmDetail.back")}</Button>}
+				action={<Button onClick={onExit}>{t("filmDetail.back")}</Button>}
 			/>
 		);
 
@@ -138,7 +138,7 @@ export function FilmDetailScreen({
 	const deleteFilm = () => {
 		setData({ ...data, films: data.films.filter((f) => f.id !== filmId) });
 		toast(t("filmDetail.filmDeleted"), "info");
-		setScreen("stock");
+		onExit();
 	};
 
 	const handleDuplicate = () => {
@@ -157,7 +157,7 @@ export function FilmDetailScreen({
 		});
 		newFilm.history = [{ date: today(), action: "", actionCode: "duplicated", params: { name: filmName(film) } }];
 		setData({ ...data, films: [...data.films, newFilm] });
-		setSelectedFilm(newFilm.id);
+		onFilmDuplicated(newFilm.id);
 		toast(t("filmDetail.filmDuplicated"));
 	};
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -11,20 +11,20 @@ import { NoteMarker } from "@/components/map/NoteMarker";
 import { NoteSheet } from "@/components/map/NoteSheet";
 import { useTheme } from "@/components/ThemeProvider";
 import { Button } from "@/components/ui/button";
-import type { AppData, FilmType, ScreenName } from "@/types";
+import type { AppData, FilmType } from "@/types";
 import { collectAllTags } from "@/utils/film-helpers";
 import type { Cluster, GeoNote } from "@/utils/map-helpers";
 import { clusterNotes, collectGeoNotes, DARK_STYLE, fitMapToBounds, LIGHT_STYLE } from "@/utils/map-helpers";
 
 interface MapScreenProps {
 	data: AppData;
-	setScreen: (screen: ScreenName) => void;
-	setSelectedFilm: (id: string) => void;
+	onOpenFilm: (id: string) => void;
+	onOpenStock: () => void;
 	filterFilmId: string | null;
 	onClearFilter: () => void;
 }
 
-export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onClearFilter }: MapScreenProps) {
+export function MapScreen({ data, onOpenFilm, onOpenStock, filterFilmId, onClearFilter }: MapScreenProps) {
 	const { t } = useTranslation();
 	const { theme } = useTheme();
 	const mapRef = useRef<maplibregl.Map | null>(null);
@@ -87,9 +87,8 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 
 	const handleViewFilm = useCallback(() => {
 		if (!selectedNote) return;
-		setSelectedFilm(selectedNote.film.id);
-		setScreen("filmDetail");
-	}, [selectedNote, setSelectedFilm, setScreen]);
+		onOpenFilm(selectedNote.film.id);
+	}, [selectedNote, onOpenFilm]);
 
 	const handleLocateMe = useCallback(() => {
 		const map = mapRef.current;
@@ -118,7 +117,7 @@ export function MapScreen({ data, setScreen, setSelectedFilm, filterFilmId, onCl
 					title={t("map.emptyTitle")}
 					subtitle={t("map.emptySubtitle")}
 					action={
-						<Button variant="outline" onClick={() => setScreen("stock")}>
+						<Button variant="outline" onClick={onOpenStock}>
 							{t("map.emptyAction")}
 						</Button>
 					}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -50,7 +50,7 @@ interface SettingsScreenProps {
 	onRecoveryCodeChange: (code: string | null) => void;
 	onSyncNow: () => void;
 	persistent: boolean;
-	setScreen: (screen: import("@/types").ScreenName) => void;
+	onOpenLegal: () => void;
 }
 
 export function SettingsScreen({
@@ -61,7 +61,7 @@ export function SettingsScreen({
 	onRecoveryCodeChange,
 	onSyncNow,
 	persistent,
-	setScreen,
+	onOpenLegal,
 }: SettingsScreenProps) {
 	const { t, i18n } = useTranslation();
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -426,11 +426,7 @@ export function SettingsScreen({
 				</Card>
 			)}
 
-			<Button
-				variant="ghost"
-				onClick={() => setScreen("legal")}
-				className="w-full justify-center text-text-muted text-xs"
-			>
+			<Button variant="ghost" onClick={onOpenLegal} className="w-full justify-center text-text-muted text-xs">
 				{t("settings.legalNotices")}
 			</Button>
 

--- a/src/screens/StockScreen.tsx
+++ b/src/screens/StockScreen.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import type { AppData, Film as FilmType, ScreenName } from "@/types";
+import type { AppData, Film as FilmType } from "@/types";
 import { fmtExpDate } from "@/utils/expiration";
 import { filmName } from "@/utils/film-helpers";
 import { type SortOption, useStockFilters } from "@/utils/use-stock-filters";
@@ -74,13 +74,12 @@ const SORT_OPTIONS: { value: SortOption; labelKey: string }[] = [
 
 interface StockScreenProps {
 	data: AppData;
-	setScreen: (screen: ScreenName) => void;
-	setSelectedFilm: (id: string) => void;
+	onOpenFilm: (id: string) => void;
 	onAddFilm: () => void;
 	initialStateFilter?: string | null;
 }
 
-export function StockScreen({ data, setScreen, setSelectedFilm, onAddFilm, initialStateFilter }: StockScreenProps) {
+export function StockScreen({ data, onOpenFilm, onAddFilm, initialStateFilter }: StockScreenProps) {
 	const { t } = useTranslation();
 	const [filterDialogOpen, setFilterDialogOpen] = useState(false);
 	const { films, cameras, backs } = data;
@@ -181,8 +180,7 @@ export function StockScreen({ data, setScreen, setSelectedFilm, onAddFilm, initi
 							backs={backs}
 							groupCount={group.films.length}
 							onClick={() => {
-								setSelectedFilm(representative.id);
-								setScreen("filmDetail");
+								onOpenFilm(representative.id);
 							}}
 						/>
 					);

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,14 @@ export type ScreenName =
 	| "legal"
 	| "map";
 
+export interface NavigationEntry {
+	screen: ScreenName;
+	selectedFilm?: string | null;
+	selectedCamera?: string | null;
+	mapFilterFilmId?: string | null;
+	stockStateFilter?: string | null;
+}
+
 export interface StateConfig {
 	label: string;
 	color: string;

--- a/src/utils/use-navigation-stack.ts
+++ b/src/utils/use-navigation-stack.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import type { NavigationEntry, ScreenName } from "@/types";
+
+const DETAIL_BACK_FALLBACK: Partial<Record<ScreenName, ScreenName>> = {
+	filmDetail: "stock",
+	cameraDetail: "cameras",
+	settings: "home",
+	legal: "settings",
+};
+
+function entriesEqual(a: NavigationEntry, b: NavigationEntry): boolean {
+	return (
+		a.screen === b.screen &&
+		(a.selectedFilm ?? null) === (b.selectedFilm ?? null) &&
+		(a.selectedCamera ?? null) === (b.selectedCamera ?? null) &&
+		(a.mapFilterFilmId ?? null) === (b.mapFilterFilmId ?? null) &&
+		(a.stockStateFilter ?? null) === (b.stockStateFilter ?? null)
+	);
+}
+
+export interface NavigationStack {
+	current: NavigationEntry;
+	history: NavigationEntry[];
+	navigate: (entry: NavigationEntry) => void;
+	goBack: () => void;
+	resetTo: (entry: NavigationEntry) => void;
+	replace: (entry: NavigationEntry) => void;
+}
+
+export function useNavigationStack(initial: NavigationEntry): NavigationStack {
+	const [current, setCurrent] = useState<NavigationEntry>(initial);
+	const [history, setHistory] = useState<NavigationEntry[]>([]);
+
+	const navigate = useCallback((entry: NavigationEntry) => {
+		setCurrent((prev) => {
+			if (entriesEqual(prev, entry)) return prev;
+			setHistory((h) => {
+				// Drop a duplicate top to avoid A/B/A/B ping-pong growth
+				const top = h[h.length - 1];
+				if (top && entriesEqual(top, entry)) {
+					return [...h.slice(0, -1), prev];
+				}
+				return [...h, prev];
+			});
+			return entry;
+		});
+	}, []);
+
+	const goBack = useCallback(() => {
+		setHistory((h) => {
+			if (h.length === 0) {
+				setCurrent((prev) => {
+					const fallback = DETAIL_BACK_FALLBACK[prev.screen];
+					return fallback ? { screen: fallback } : prev;
+				});
+				return h;
+			}
+			const next = h[h.length - 1];
+			if (next) setCurrent(next);
+			return h.slice(0, -1);
+		});
+	}, []);
+
+	const resetTo = useCallback((entry: NavigationEntry) => {
+		setHistory([]);
+		setCurrent(entry);
+	}, []);
+
+	const replace = useCallback((entry: NavigationEntry) => {
+		setCurrent(entry);
+	}, []);
+
+	return { current, history, navigate, goBack, resetTo, replace };
+}

--- a/src/utils/use-navigation-stack.ts
+++ b/src/utils/use-navigation-stack.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useReducer } from "react";
 import type { NavigationEntry, ScreenName } from "@/types";
 
 const DETAIL_BACK_FALLBACK: Partial<Record<ScreenName, ScreenName>> = {
@@ -18,6 +18,51 @@ function entriesEqual(a: NavigationEntry, b: NavigationEntry): boolean {
 	);
 }
 
+interface NavState {
+	current: NavigationEntry;
+	history: NavigationEntry[];
+}
+
+type NavAction =
+	| { type: "navigate"; entry: NavigationEntry }
+	| { type: "goBack" }
+	| { type: "resetTo"; entry: NavigationEntry }
+	| { type: "replace"; entry: NavigationEntry };
+
+function reducer(state: NavState, action: NavAction): NavState {
+	switch (action.type) {
+		case "navigate": {
+			if (entriesEqual(state.current, action.entry)) return state;
+			const top = state.history[state.history.length - 1];
+			// If the new entry matches the previous history top, drop that duplicate
+			// to avoid A/B/A/B ping-pong growth on symmetric round-trips.
+			if (top && entriesEqual(top, action.entry)) {
+				return {
+					current: action.entry,
+					history: [...state.history.slice(0, -1), state.current],
+				};
+			}
+			return {
+				current: action.entry,
+				history: [...state.history, state.current],
+			};
+		}
+		case "goBack": {
+			if (state.history.length === 0) {
+				const fallback = DETAIL_BACK_FALLBACK[state.current.screen];
+				return fallback ? { current: { screen: fallback }, history: [] } : state;
+			}
+			const next = state.history[state.history.length - 1];
+			if (!next) return state;
+			return { current: next, history: state.history.slice(0, -1) };
+		}
+		case "resetTo":
+			return { current: action.entry, history: [] };
+		case "replace":
+			return { ...state, current: action.entry };
+	}
+}
+
 export interface NavigationStack {
 	current: NavigationEntry;
 	history: NavigationEntry[];
@@ -28,47 +73,15 @@ export interface NavigationStack {
 }
 
 export function useNavigationStack(initial: NavigationEntry): NavigationStack {
-	const [current, setCurrent] = useState<NavigationEntry>(initial);
-	const [history, setHistory] = useState<NavigationEntry[]>([]);
+	const [state, dispatch] = useReducer(reducer, { current: initial, history: [] });
 
-	const navigate = useCallback((entry: NavigationEntry) => {
-		setCurrent((prev) => {
-			if (entriesEqual(prev, entry)) return prev;
-			setHistory((h) => {
-				// Drop a duplicate top to avoid A/B/A/B ping-pong growth
-				const top = h[h.length - 1];
-				if (top && entriesEqual(top, entry)) {
-					return [...h.slice(0, -1), prev];
-				}
-				return [...h, prev];
-			});
-			return entry;
-		});
-	}, []);
+	const navigate = useCallback((entry: NavigationEntry) => dispatch({ type: "navigate", entry }), []);
+	const goBack = useCallback(() => dispatch({ type: "goBack" }), []);
+	const resetTo = useCallback((entry: NavigationEntry) => dispatch({ type: "resetTo", entry }), []);
+	const replace = useCallback((entry: NavigationEntry) => dispatch({ type: "replace", entry }), []);
 
-	const goBack = useCallback(() => {
-		setHistory((h) => {
-			if (h.length === 0) {
-				setCurrent((prev) => {
-					const fallback = DETAIL_BACK_FALLBACK[prev.screen];
-					return fallback ? { screen: fallback } : prev;
-				});
-				return h;
-			}
-			const next = h[h.length - 1];
-			if (next) setCurrent(next);
-			return h.slice(0, -1);
-		});
-	}, []);
-
-	const resetTo = useCallback((entry: NavigationEntry) => {
-		setHistory([]);
-		setCurrent(entry);
-	}, []);
-
-	const replace = useCallback((entry: NavigationEntry) => {
-		setCurrent(entry);
-	}, []);
-
-	return { current, history, navigate, goBack, resetTo, replace };
+	return useMemo(
+		() => ({ current: state.current, history: state.history, navigate, goBack, resetTo, replace }),
+		[state.current, state.history, navigate, goBack, resetTo, replace],
+	);
 }


### PR DESCRIPTION
Le bouton retour ramene desormais a l'ecran precedent effectivement visite
(avec ses parametres : film, camera, filtres), au lieu d'une destination codee
en dur qui envoyait souvent au mauvais endroit (ex. home -> filmDetail -> back
renvoyait sur stock).

- Nouveau hook `useNavigationStack` : pile d'entrees `NavigationEntry` avec
  navigate / goBack / resetTo / replace, fallback statique si pile vide.
- AppHeader : plus de `backTargets` ni `filmBackTarget`, juste `goBack`.
- TabBar et tour reinitialisent la pile (top-level), les autres ecrans
  poussent via des callbacks explicites (onOpenFilm, onOpenCamera, ...).