### PR TITLE
feat(fab): add global floating action menu with quick shot logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,13 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { AddFilmDialog } from "@/components/AddFilmDialog";
 import { AppHeader } from "@/components/AppHeader";
+import { AddBackDialog } from "@/components/equipment/AddBackDialog";
+import { AddCameraDialog } from "@/components/equipment/AddCameraDialog";
+import { AddLensDialog } from "@/components/equipment/AddLensDialog";
+import { FloatingActionMenu } from "@/components/FloatingActionMenu";
 import { PwaInstallBanner } from "@/components/PwaInstallBanner";
 import { PwaUpdateBanner } from "@/components/PwaUpdateBanner";
+import { QuickShotDialog } from "@/components/QuickShotDialog";
 import { TabBar } from "@/components/TabBar";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ToastProvider, useToast } from "@/components/Toast";
@@ -36,6 +41,10 @@ function FilmVaultInner() {
 	const nav = useNavigationStack({ screen: "home" });
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
 	const [showAddFilm, setShowAddFilm] = useState(false);
+	const [showAddCamera, setShowAddCamera] = useState(false);
+	const [showAddLens, setShowAddLens] = useState(false);
+	const [showAddBack, setShowAddBack] = useState(false);
+	const [showQuickShot, setShowQuickShot] = useState(false);
 	const [persistent, setPersistent] = useState(false);
 	const [syncing, setSyncing] = useState(false);
 	const [recoveryCode, setRecoveryCodeState] = useState<string | null>(null);
@@ -178,6 +187,14 @@ function FilmVaultInner() {
 				setAutoOpenShotNote={setAutoOpenShotNote}
 				showAddFilm={showAddFilm}
 				setShowAddFilm={setShowAddFilm}
+				showAddCamera={showAddCamera}
+				setShowAddCamera={setShowAddCamera}
+				showAddLens={showAddLens}
+				setShowAddLens={setShowAddLens}
+				showAddBack={showAddBack}
+				setShowAddBack={setShowAddBack}
+				showQuickShot={showQuickShot}
+				setShowQuickShot={setShowQuickShot}
 				syncing={syncing}
 				recoveryCode={recoveryCode}
 				setRecoveryCodeState={setRecoveryCodeState}
@@ -197,6 +214,14 @@ interface AppContentProps {
 	setAutoOpenShotNote: (open: boolean) => void;
 	showAddFilm: boolean;
 	setShowAddFilm: (open: boolean) => void;
+	showAddCamera: boolean;
+	setShowAddCamera: (open: boolean) => void;
+	showAddLens: boolean;
+	setShowAddLens: (open: boolean) => void;
+	showAddBack: boolean;
+	setShowAddBack: (open: boolean) => void;
+	showQuickShot: boolean;
+	setShowQuickShot: (open: boolean) => void;
 	syncing: boolean;
 	recoveryCode: string | null;
 	setRecoveryCodeState: (code: string | null) => void;
@@ -213,6 +238,14 @@ function AppContent({
 	setAutoOpenShotNote,
 	showAddFilm,
 	setShowAddFilm,
+	showAddCamera,
+	setShowAddCamera,
+	showAddLens,
+	setShowAddLens,
+	showAddBack,
+	setShowAddBack,
+	showQuickShot,
+	setShowQuickShot,
 	syncing,
 	recoveryCode,
 	setRecoveryCodeState,
@@ -437,6 +470,43 @@ function AppContent({
 				onOpenChange={setShowAddFilm}
 				data={effectiveData}
 				setData={effectiveUpdateData}
+			/>
+			<AddCameraDialog
+				open={showAddCamera}
+				onOpenChange={setShowAddCamera}
+				data={effectiveData}
+				setData={effectiveUpdateData}
+			/>
+			<AddLensDialog
+				open={showAddLens}
+				onOpenChange={setShowAddLens}
+				data={effectiveData}
+				setData={effectiveUpdateData}
+			/>
+			<AddBackDialog
+				open={showAddBack}
+				onOpenChange={setShowAddBack}
+				data={effectiveData}
+				setData={effectiveUpdateData}
+			/>
+			<QuickShotDialog
+				open={showQuickShot}
+				onOpenChange={setShowQuickShot}
+				data={effectiveData}
+				setData={effectiveUpdateData}
+				onAddFilm={() => {
+					setShowQuickShot(false);
+					setShowAddFilm(true);
+				}}
+			/>
+			<FloatingActionMenu
+				visible={showTabBar && !isTourActive}
+				hasLoadedFilm={effectiveData.films.some((f) => f.state === "loaded" || f.state === "partial")}
+				onAddFilm={() => setShowAddFilm(true)}
+				onAddCamera={() => setShowAddCamera(true)}
+				onAddLens={() => setShowAddLens(true)}
+				onAddBack={() => setShowAddBack(true)}
+				onQuickShot={() => setShowQuickShot(true)}
 			/>
 			<PwaUpdateBanner />
 			<PwaInstallBanner />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -501,7 +501,6 @@ function AppContent({
 			/>
 			<FloatingActionMenu
 				visible={showTabBar && !isTourActive}
-				hasLoadedFilm={effectiveData.films.some((f) => f.state === "loaded" || f.state === "partial")}
 				onAddFilm={() => setShowAddFilm(true)}
 				onAddCamera={() => setShowAddCamera(true)}
 				onAddLens={() => setShowAddLens(true)}

--- a/src/components/FloatingActionMenu.tsx
+++ b/src/components/FloatingActionMenu.tsx
@@ -1,0 +1,99 @@
+import { Camera, Film as FilmIcon, Focus, NotebookPen, Package, Plus } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+interface FloatingActionMenuProps {
+	visible: boolean;
+	hasLoadedFilm: boolean;
+	onAddFilm: () => void;
+	onAddCamera: () => void;
+	onAddLens: () => void;
+	onAddBack: () => void;
+	onQuickShot: () => void;
+}
+
+export function FloatingActionMenu({
+	visible,
+	hasLoadedFilm,
+	onAddFilm,
+	onAddCamera,
+	onAddLens,
+	onAddBack,
+	onQuickShot,
+}: FloatingActionMenuProps) {
+	const { t } = useTranslation();
+	const [open, setOpen] = useState(false);
+
+	if (!visible) return null;
+
+	const run = (handler: () => void) => {
+		setOpen(false);
+		// Defer to next tick so the current Dialog finishes closing before the
+		// next one opens (prevents two Radix focus traps from fighting).
+		setTimeout(handler, 0);
+	};
+
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => setOpen(true)}
+				aria-label={t("fab.openMenu")}
+				className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 md:bottom-6 md:right-6 z-40 w-14 h-14 rounded-full bg-accent hover:bg-accent-hover shadow-lg flex items-center justify-center text-white transition-colors"
+			>
+				<Plus size={24} strokeWidth={2.5} />
+			</button>
+
+			<Dialog open={open} onOpenChange={setOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{t("fab.title")}</DialogTitle>
+						<DialogCloseButton />
+					</DialogHeader>
+
+					<div className="flex flex-col gap-3">
+						<div className="grid grid-cols-2 gap-3">
+							<GridCard icon={FilmIcon} label={t("fab.film")} onClick={() => run(onAddFilm)} />
+							<GridCard icon={Camera} label={t("fab.camera")} onClick={() => run(onAddCamera)} />
+							<GridCard icon={Package} label={t("fab.back")} onClick={() => run(onAddBack)} />
+							<GridCard icon={Focus} label={t("fab.lens")} onClick={() => run(onAddLens)} />
+						</div>
+
+						<button
+							type="button"
+							onClick={() => run(onQuickShot)}
+							disabled={!hasLoadedFilm}
+							className="w-full bg-accent hover:bg-accent-hover disabled:bg-surface-alt disabled:text-text-muted disabled:cursor-not-allowed text-white rounded-lg p-4 flex flex-col items-center justify-center gap-1 transition-colors"
+						>
+							<div className="flex items-center gap-2">
+								<NotebookPen size={18} />
+								<span className="text-[15px] font-semibold">{t("fab.quickShot")}</span>
+							</div>
+							{!hasLoadedFilm && <span className="text-[12px] opacity-80">{t("fab.quickShotDisabled")}</span>}
+						</button>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</>
+	);
+}
+
+interface GridCardProps {
+	icon: typeof FilmIcon;
+	label: string;
+	onClick: () => void;
+}
+
+function GridCard({ icon: Icon, label, onClick }: GridCardProps) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className="aspect-square flex flex-col items-center justify-center gap-2 bg-surface-alt hover:bg-card-hover border border-border rounded-lg p-3 transition-colors"
+		>
+			<Icon size={28} className="text-text-primary" />
+			<span className="text-[13px] font-semibold text-text-primary font-body">{label}</span>
+		</button>
+	);
+}

--- a/src/components/FloatingActionMenu.tsx
+++ b/src/components/FloatingActionMenu.tsx
@@ -2,10 +2,10 @@ import { Camera, Film as FilmIcon, Focus, NotebookPen, Package, Plus } from "luc
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { LucideIcon } from "@/types";
 
 interface FloatingActionMenuProps {
 	visible: boolean;
-	hasLoadedFilm: boolean;
 	onAddFilm: () => void;
 	onAddCamera: () => void;
 	onAddLens: () => void;
@@ -15,7 +15,6 @@ interface FloatingActionMenuProps {
 
 export function FloatingActionMenu({
 	visible,
-	hasLoadedFilm,
 	onAddFilm,
 	onAddCamera,
 	onAddLens,
@@ -63,14 +62,10 @@ export function FloatingActionMenu({
 						<button
 							type="button"
 							onClick={() => run(onQuickShot)}
-							disabled={!hasLoadedFilm}
-							className="w-full bg-accent hover:bg-accent-hover disabled:bg-surface-alt disabled:text-text-muted disabled:cursor-not-allowed text-white rounded-lg p-4 flex flex-col items-center justify-center gap-1 transition-colors"
+							className="w-full bg-accent hover:bg-accent-hover text-white rounded-lg p-4 flex items-center justify-center gap-2 transition-colors"
 						>
-							<div className="flex items-center gap-2">
-								<NotebookPen size={18} />
-								<span className="text-[15px] font-semibold">{t("fab.quickShot")}</span>
-							</div>
-							{!hasLoadedFilm && <span className="text-[12px] opacity-80">{t("fab.quickShotDisabled")}</span>}
+							<NotebookPen size={18} />
+							<span className="text-[15px] font-semibold">{t("fab.quickShot")}</span>
 						</button>
 					</div>
 				</DialogContent>
@@ -80,7 +75,7 @@ export function FloatingActionMenu({
 }
 
 interface GridCardProps {
-	icon: typeof FilmIcon;
+	icon: LucideIcon;
 	label: string;
 	onClick: () => void;
 }

--- a/src/components/QuickShotDialog.tsx
+++ b/src/components/QuickShotDialog.tsx
@@ -13,7 +13,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/photography";
 import type { AppData, ShotNote } from "@/types";
 import { filmName } from "@/utils/film-helpers";
-import { uid } from "@/utils/helpers";
+import { nowDateTimeLocal, uid } from "@/utils/helpers";
 import { lensDisplayName } from "@/utils/lens-helpers";
 
 interface QuickShotDialogProps {
@@ -22,12 +22,6 @@ interface QuickShotDialogProps {
 	data: AppData;
 	setData: (data: AppData) => void;
 	onAddFilm?: () => void;
-}
-
-function nowDateTimeLocal(): string {
-	const now = new Date();
-	const pad = (n: number) => String(n).padStart(2, "0");
-	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
 }
 
 function nextFrame(posesShot: number | null | undefined): string {
@@ -45,6 +39,7 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 	const [aperture, setAperture] = useState("");
 	const [shutterSpeed, setShutterSpeed] = useState("");
 	const [lensId, setLensId] = useState("");
+	const [lens, setLens] = useState("");
 	const [notes, setNotes] = useState("");
 	const [location, setLocation] = useState("");
 	const [latitude, setLatitude] = useState("");
@@ -87,6 +82,7 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 			setFilmId("");
 			setFrameNumber("");
 			setLensId("");
+			setLens("");
 			resetExposureFields();
 			return;
 		}
@@ -95,6 +91,7 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 			setFilmId(only.id);
 			setFrameNumber(nextFrame(only.posesShot));
 			setLensId(only.lensId ?? "");
+			setLens(only.lens ?? "");
 		}
 	}, [open]);
 
@@ -104,6 +101,7 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		if (film) {
 			setFrameNumber(nextFrame(film.posesShot));
 			setLensId(film.lensId ?? "");
+			setLens(film.lens ?? "");
 			resetExposureFields();
 		}
 	};
@@ -143,12 +141,13 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		const fn = Number.parseInt(frameNumber, 10);
 		const lat = latitude ? Number.parseFloat(latitude) : null;
 		const lng = longitude ? Number.parseFloat(longitude) : null;
+		const resolvedLens = selectedLens ? lensDisplayName(selectedLens) : lens.trim() || null;
 		return {
 			id: uid(),
 			frameNumber: Number.isNaN(fn) ? null : fn,
 			aperture: aperture || null,
 			shutterSpeed: shutterSpeed || null,
-			lens: selectedLens ? lensDisplayName(selectedLens) : null,
+			lens: resolvedLens,
 			lensId: lensId || null,
 			location: location || null,
 			latitude: lat != null && !Number.isNaN(lat) ? lat : null,
@@ -276,23 +275,32 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 						/>
 					</div>
 
-					{visibleLenses.length > 0 && (
-						<FormField label={t("quickShot.lensField")}>
-							<Select value={lensId || "__other__"} onValueChange={(v) => setLensId(v === "__other__" ? "" : v)}>
-								<SelectTrigger>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									{visibleLenses.map((l) => (
-										<SelectItem key={l.id} value={l.id}>
-											{lensDisplayName(l)}
-										</SelectItem>
-									))}
-									<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-								</SelectContent>
-							</Select>
-						</FormField>
-					)}
+					<FormField label={t("quickShot.lensField")}>
+						<div className="flex flex-col gap-2">
+							{visibleLenses.length > 0 && (
+								<Select value={lensId || "__other__"} onValueChange={(v) => setLensId(v === "__other__" ? "" : v)}>
+									<SelectTrigger>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{visibleLenses.map((l) => (
+											<SelectItem key={l.id} value={l.id}>
+												{lensDisplayName(l)}
+											</SelectItem>
+										))}
+										<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+									</SelectContent>
+								</Select>
+							)}
+							{!lensId && (
+								<Input
+									value={lens}
+									onChange={(e) => setLens(e.target.value)}
+									placeholder={t("filmDetail.shotNotesLensPlaceholder")}
+								/>
+							)}
+						</div>
+					</FormField>
 
 					<FormField label={t("quickShot.noteField")}>
 						<Textarea value={notes} onChange={(e) => setNotes(e.target.value)} />

--- a/src/components/QuickShotDialog.tsx
+++ b/src/components/QuickShotDialog.tsx
@@ -1,0 +1,353 @@
+import { ExternalLink, Loader2, LocateFixed, NotebookPen, Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PhotoPicker } from "@/components/PhotoPicker";
+import { useToast } from "@/components/Toast";
+import { AutocompleteInput } from "@/components/ui/autocomplete-input";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/photography";
+import type { AppData, ShotNote } from "@/types";
+import { filmName } from "@/utils/film-helpers";
+import { uid } from "@/utils/helpers";
+import { lensDisplayName } from "@/utils/lens-helpers";
+
+interface QuickShotDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	data: AppData;
+	setData: (data: AppData) => void;
+	onAddFilm?: () => void;
+}
+
+function nowDateTimeLocal(): string {
+	const now = new Date();
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+}
+
+function nextFrame(posesShot: number | null | undefined): string {
+	return String((posesShot ?? 0) + 1);
+}
+
+export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }: QuickShotDialogProps) {
+	const { t } = useTranslation();
+	const { toast } = useToast();
+
+	const eligibleFilms = data.films.filter((f) => f.state === "loaded" || f.state === "partial");
+
+	const [filmId, setFilmId] = useState("");
+	const [frameNumber, setFrameNumber] = useState("");
+	const [aperture, setAperture] = useState("");
+	const [shutterSpeed, setShutterSpeed] = useState("");
+	const [lensId, setLensId] = useState("");
+	const [notes, setNotes] = useState("");
+	const [location, setLocation] = useState("");
+	const [latitude, setLatitude] = useState("");
+	const [longitude, setLongitude] = useState("");
+	const [photo, setPhoto] = useState<string[]>([]);
+	const [gpsLoading, setGpsLoading] = useState(false);
+
+	const currentFilm = filmId ? (data.films.find((f) => f.id === filmId) ?? null) : null;
+	const camera = currentFilm?.cameraId ? data.cameras.find((c) => c.id === currentFilm.cameraId) : null;
+	const selectedLens = lensId ? data.lenses.find((l) => l.id === lensId) : null;
+
+	const speedConfig: ExposureConfig | null = selectedLens?.shutterSpeedMin
+		? { min: selectedLens.shutterSpeedMin, max: selectedLens.shutterSpeedMax, stops: selectedLens.shutterSpeedStops }
+		: camera
+			? { min: camera.shutterSpeedMin, max: camera.shutterSpeedMax, stops: camera.shutterSpeedStops }
+			: null;
+
+	const apertureConfig: ExposureConfig | null = selectedLens?.apertureStops
+		? { min: selectedLens.apertureMin, max: selectedLens.apertureMax, stops: selectedLens.apertureStops }
+		: camera?.apertureStops
+			? { stops: camera.apertureStops }
+			: null;
+
+	const filteredSpeeds = filterSpeeds(speedConfig);
+	const filteredApertures = filterApertures(apertureConfig);
+
+	const resetExposureFields = () => {
+		setAperture("");
+		setShutterSpeed("");
+		setNotes("");
+		setLocation("");
+		setLatitude("");
+		setLongitude("");
+		setPhoto([]);
+	};
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: only react to open flips; snapshot other state on open.
+	useEffect(() => {
+		if (!open) {
+			setFilmId("");
+			setFrameNumber("");
+			setLensId("");
+			resetExposureFields();
+			return;
+		}
+		const only = eligibleFilms.length === 1 ? eligibleFilms[0] : null;
+		if (only && !filmId) {
+			setFilmId(only.id);
+			setFrameNumber(nextFrame(only.posesShot));
+			setLensId(only.lensId ?? "");
+		}
+	}, [open]);
+
+	const handleFilmChange = (newId: string) => {
+		setFilmId(newId);
+		const film = data.films.find((f) => f.id === newId);
+		if (film) {
+			setFrameNumber(nextFrame(film.posesShot));
+			setLensId(film.lensId ?? "");
+			resetExposureFields();
+		}
+	};
+
+	const handleGpsLocate = () => {
+		if (!navigator.geolocation) {
+			toast(t("filmDetail.shotNotesGpsError"));
+			return;
+		}
+		setGpsLoading(true);
+		navigator.geolocation.getCurrentPosition(
+			async (position) => {
+				const { latitude: lat, longitude: lng } = position.coords;
+				setLatitude(String(lat));
+				setLongitude(String(lng));
+				try {
+					const res = await fetch(
+						`https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lng}&zoom=18&addressdetails=1`,
+						{ headers: { "Accept-Language": navigator.language } },
+					);
+					const body = await res.json();
+					if (body.display_name) setLocation(body.display_name);
+				} catch {
+					// reverse geocoding failed — coordinates still saved
+				}
+				setGpsLoading(false);
+			},
+			() => {
+				setGpsLoading(false);
+				toast(t("filmDetail.shotNotesGpsError"));
+			},
+			{ enableHighAccuracy: true, timeout: 10000 },
+		);
+	};
+
+	const buildNote = (): ShotNote => {
+		const fn = Number.parseInt(frameNumber, 10);
+		const lat = latitude ? Number.parseFloat(latitude) : null;
+		const lng = longitude ? Number.parseFloat(longitude) : null;
+		return {
+			id: uid(),
+			frameNumber: Number.isNaN(fn) ? null : fn,
+			aperture: aperture || null,
+			shutterSpeed: shutterSpeed || null,
+			lens: selectedLens ? lensDisplayName(selectedLens) : null,
+			lensId: lensId || null,
+			location: location || null,
+			latitude: lat != null && !Number.isNaN(lat) ? lat : null,
+			longitude: lng != null && !Number.isNaN(lng) ? lng : null,
+			notes: notes || null,
+			date: nowDateTimeLocal(),
+			photo: photo[0] ?? null,
+		};
+	};
+
+	const persist = (note: ShotNote): void => {
+		if (!currentFilm) return;
+		const newNotes = [...(currentFilm.shotNotes ?? []), note];
+		const newPoses = Math.max(currentFilm.posesShot ?? 0, note.frameNumber ?? 0);
+		const newFilms = data.films.map((f) =>
+			f.id === currentFilm.id ? { ...f, shotNotes: newNotes, posesShot: newPoses } : f,
+		);
+		setData({ ...data, films: newFilms });
+	};
+
+	const handleSave = () => {
+		if (!currentFilm || !frameNumber) return;
+		persist(buildNote());
+		toast(t("quickShot.saved"));
+		onOpenChange(false);
+	};
+
+	const handleSaveAndNext = () => {
+		if (!currentFilm || !frameNumber) return;
+		const note = buildNote();
+		persist(note);
+		toast(t("quickShot.saved"));
+		const nextFn = (note.frameNumber ?? 0) + 1;
+		setFrameNumber(String(nextFn));
+		resetExposureFields();
+	};
+
+	const frameInt = Number.parseInt(frameNumber, 10);
+	const posesTotal = currentFilm?.posesTotal ?? null;
+	const nextWouldExceed = !Number.isNaN(frameInt) && posesTotal != null && frameInt + 1 > posesTotal;
+	const canSave = !!currentFilm && !!frameNumber && !Number.isNaN(frameInt);
+
+	// Empty state: no films loaded
+	if (eligibleFilms.length === 0) {
+		return (
+			<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{t("quickShot.title")}</DialogTitle>
+						<DialogCloseButton />
+					</DialogHeader>
+					<div className="flex flex-col items-center gap-4 py-6 text-center">
+						<NotebookPen size={32} className="text-text-muted opacity-40" />
+						<p className="text-sm text-text-sec">{t("quickShot.emptyMessage")}</p>
+						{onAddFilm && (
+							<Button onClick={onAddFilm} className="w-full justify-center">
+								<Plus size={16} /> {t("quickShot.addFilm")}
+							</Button>
+						)}
+						<Button variant="ghost" onClick={() => onOpenChange(false)} className="w-full justify-center">
+							{t("quickShot.cancel")}
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
+		);
+	}
+
+	const visibleLenses = data.lenses.filter((l) => !l.soldAt || l.id === lensId);
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{t("quickShot.title")}</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+
+				<div className="flex flex-col gap-4">
+					<FormField label={t("quickShot.filmField")}>
+						<Select value={filmId} onValueChange={handleFilmChange}>
+							<SelectTrigger>
+								<SelectValue placeholder={t("quickShot.filmPlaceholder")} />
+							</SelectTrigger>
+							<SelectContent>
+								{eligibleFilms.map((f) => {
+									const cam = f.cameraId ? data.cameras.find((c) => c.id === f.cameraId) : null;
+									const camLabel = cam ? ` · ${cam.nickname || cam.model}` : "";
+									return (
+										<SelectItem key={f.id} value={f.id}>
+											{filmName(f)}
+											{camLabel}
+										</SelectItem>
+									);
+								})}
+							</SelectContent>
+						</Select>
+					</FormField>
+
+					<FormField label={posesTotal ? `${t("quickShot.frameField")} / ${posesTotal}` : t("quickShot.frameField")}>
+						<Input
+							type="number"
+							min={1}
+							max={posesTotal ?? undefined}
+							value={frameNumber}
+							onChange={(e) => setFrameNumber(e.target.value)}
+							className="font-mono"
+						/>
+					</FormField>
+
+					<div className="grid grid-cols-2 gap-3">
+						<AutocompleteInput
+							label={t("quickShot.apertureField")}
+							value={aperture}
+							onChange={setAperture}
+							suggestions={filteredApertures}
+							showAllOnFocus
+						/>
+						<AutocompleteInput
+							label={t("quickShot.shutterField")}
+							value={shutterSpeed}
+							onChange={setShutterSpeed}
+							suggestions={filteredSpeeds}
+							showAllOnFocus
+						/>
+					</div>
+
+					{visibleLenses.length > 0 && (
+						<FormField label={t("quickShot.lensField")}>
+							<Select value={lensId || "__other__"} onValueChange={(v) => setLensId(v === "__other__" ? "" : v)}>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{visibleLenses.map((l) => (
+										<SelectItem key={l.id} value={l.id}>
+											{lensDisplayName(l)}
+										</SelectItem>
+									))}
+									<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+								</SelectContent>
+							</Select>
+						</FormField>
+					)}
+
+					<FormField label={t("quickShot.noteField")}>
+						<Textarea value={notes} onChange={(e) => setNotes(e.target.value)} />
+					</FormField>
+
+					<FormField label={t("quickShot.locationField")}>
+						<div className="flex gap-2">
+							<Input
+								value={location}
+								onChange={(e) => setLocation(e.target.value)}
+								className="flex-1"
+								placeholder={t("filmDetail.shotNotesLocationPlaceholder")}
+							/>
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								onClick={handleGpsLocate}
+								disabled={gpsLoading}
+								className="shrink-0 h-10 w-10 p-0"
+								aria-label={t("filmDetail.shotNotesGpsButton")}
+							>
+								{gpsLoading ? <Loader2 size={16} className="animate-spin" /> : <LocateFixed size={16} />}
+							</Button>
+						</div>
+						{latitude && longitude && (
+							<a
+								href={`https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=17/${latitude}/${longitude}`}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-flex items-center gap-1 text-xs text-accent mt-1 hover:underline"
+							>
+								<ExternalLink size={12} />
+								{Number.parseFloat(latitude).toFixed(5)}, {Number.parseFloat(longitude).toFixed(5)}
+							</a>
+						)}
+					</FormField>
+
+					<PhotoPicker photos={photo} onChange={setPhoto} max={1} label={t("quickShot.photoField")} />
+
+					<div className="flex flex-col gap-2">
+						<Button onClick={handleSave} disabled={!canSave} className="w-full justify-center">
+							{t("quickShot.save")}
+						</Button>
+						<Button
+							variant="outline"
+							onClick={handleSaveAndNext}
+							disabled={!canSave || nextWouldExceed}
+							className="w-full justify-center"
+						>
+							{t("quickShot.saveAndNext")}
+						</Button>
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/ShotNotesSection.tsx
+++ b/src/components/ShotNotesSection.tsx
@@ -15,7 +15,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/photography";
 import type { Camera, Film, Lens, ShotNote } from "@/types";
-import { uid } from "@/utils/helpers";
+import { nowDateTimeLocal, uid } from "@/utils/helpers";
 import { lensDisplayName } from "@/utils/lens-helpers";
 
 interface ShotNotesSectionProps {
@@ -111,12 +111,6 @@ function formToNote(form: NoteFormData, id?: string): ShotNote {
 		date: form.date || null,
 		photo: form.photo[0] || null,
 	};
-}
-
-function nowDateTimeLocal(): string {
-	const now = new Date();
-	const pad = (n: number) => String(n).padStart(2, "0");
-	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
 }
 
 function nextFrameNumber(notes: ShotNote[], posesTotal?: number | null): string {

--- a/src/components/equipment/AddBackDialog.tsx
+++ b/src/components/equipment/AddBackDialog.tsx
@@ -1,0 +1,151 @@
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PhotoPicker } from "@/components/PhotoPicker";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { type AppData, type Back, INSTANT_FORMATS } from "@/types";
+import { cameraDisplayName } from "@/utils/camera-helpers";
+import { uid } from "@/utils/helpers";
+
+interface AddBackDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	data: AppData;
+	setData: (data: AppData) => void;
+}
+
+const emptyBack = {
+	name: "",
+	nickname: "",
+	ref: "",
+	serial: "",
+	format: "120",
+	compatibleCameraIds: [] as string[],
+	photo: undefined as string | undefined,
+};
+
+export function AddBackDialog({ open, onOpenChange, data, setData }: AddBackDialogProps) {
+	const { t } = useTranslation();
+	const [newBack, setNewBack] = useState(emptyBack);
+
+	useEffect(() => {
+		if (!open) setNewBack(emptyBack);
+	}, [open]);
+
+	const interchangeableCameras = data.cameras.filter((c) => c.hasInterchangeableBack && !c.soldAt);
+
+	const toggleCamera = (cameraId: string) => {
+		const ids = newBack.compatibleCameraIds;
+		if (ids.includes(cameraId)) {
+			setNewBack({ ...newBack, compatibleCameraIds: ids.filter((id) => id !== cameraId) });
+		} else {
+			setNewBack({ ...newBack, compatibleCameraIds: [...ids, cameraId] });
+		}
+	};
+
+	const addBack = () => {
+		if (!newBack.name) return;
+		const back: Back = {
+			id: uid(),
+			name: newBack.name,
+			nickname: newBack.nickname,
+			ref: newBack.ref,
+			serial: newBack.serial,
+			format: newBack.format,
+			compatibleCameraIds: newBack.compatibleCameraIds,
+			photo: newBack.photo,
+		};
+		setData({ ...data, backs: [...data.backs, back] });
+		onOpenChange(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{t("cameras.addBackTitle")}</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+				<div className="flex flex-col gap-4">
+					<PhotoPicker
+						photos={newBack.photo ? [newBack.photo] : []}
+						onChange={(p) => setNewBack({ ...newBack, photo: p[0] || undefined })}
+						max={1}
+						size={32}
+						placeholderIcon
+						label={t("cameras.photo")}
+					/>
+					<FormField label={t("cameras.backName")}>
+						<Input
+							value={newBack.name}
+							onChange={(e) => setNewBack({ ...newBack, name: e.target.value })}
+							placeholder={t("cameras.backNamePlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.backFormat")}>
+						<Select value={newBack.format} onValueChange={(v) => setNewBack({ ...newBack, format: v })}>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="35mm">{t("filmFormats.35mm")}</SelectItem>
+								<SelectItem value="120">{t("filmFormats.120")}</SelectItem>
+								{INSTANT_FORMATS.map((f) => (
+									<SelectItem key={f} value={f}>
+										{t(`filmFormats.${f}`)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</FormField>
+					<FormField label={t("cameras.reference")}>
+						<Input
+							value={newBack.ref}
+							onChange={(e) => setNewBack({ ...newBack, ref: e.target.value })}
+							placeholder={t("cameras.refPlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.backNickname")}>
+						<Input
+							value={newBack.nickname}
+							onChange={(e) => setNewBack({ ...newBack, nickname: e.target.value })}
+							placeholder={t("cameras.backNicknamePlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.backSerial")}>
+						<Input
+							value={newBack.serial}
+							onChange={(e) => setNewBack({ ...newBack, serial: e.target.value })}
+							placeholder={t("cameras.serialPlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.compatibleCameras")}>
+						{interchangeableCameras.length > 0 ? (
+							<div className="flex flex-col gap-2">
+								{interchangeableCameras.map((c) => (
+									<div key={c.id} className="flex items-center justify-between gap-3">
+										<span className="text-[13px] text-text-sec font-body">{cameraDisplayName(c)}</span>
+										<Switch
+											checked={newBack.compatibleCameraIds.includes(c.id)}
+											onCheckedChange={() => toggleCamera(c.id)}
+										/>
+									</div>
+								))}
+							</div>
+						) : (
+							<span className="text-[12px] text-text-muted font-body">{t("cameras.noCompatibleCameras")}</span>
+						)}
+					</FormField>
+					<Button onClick={addBack} disabled={!newBack.name} className="w-full justify-center">
+						<Plus size={16} /> {t("cameras.addBackButton")}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/equipment/AddCameraDialog.tsx
+++ b/src/components/equipment/AddCameraDialog.tsx
@@ -1,0 +1,221 @@
+import { Plus } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PhotoPicker } from "@/components/PhotoPicker";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { SHUTTER_SPEEDS } from "@/constants/photography";
+import { type AppData, type Camera as CameraType, INSTANT_FORMATS, type StopIncrement } from "@/types";
+import { uid } from "@/utils/helpers";
+
+interface AddCameraDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	data: AppData;
+	setData: (data: AppData) => void;
+}
+
+const emptyCam = {
+	brand: "",
+	model: "",
+	nickname: "",
+	serial: "",
+	format: "35mm",
+	mount: "",
+	hasInterchangeableBack: false,
+	photo: undefined as string | undefined,
+	shutterSpeedMin: "" as string,
+	shutterSpeedMax: "" as string,
+	shutterSpeedStops: "" as string,
+	apertureStops: "" as string,
+};
+
+export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCameraDialogProps) {
+	const { t } = useTranslation();
+	const [newCam, setNewCam] = useState(emptyCam);
+
+	useEffect(() => {
+		if (!open) setNewCam(emptyCam);
+	}, [open]);
+
+	const addCamera = () => {
+		if (!newCam.brand && !newCam.model) return;
+		const camera: CameraType = {
+			id: uid(),
+			brand: newCam.brand,
+			model: newCam.model,
+			nickname: newCam.nickname,
+			serial: newCam.serial,
+			format: newCam.format,
+			mount: newCam.mount || null,
+			hasInterchangeableBack: newCam.hasInterchangeableBack || false,
+			photo: newCam.photo,
+			shutterSpeedMin: newCam.shutterSpeedMin || null,
+			shutterSpeedMax: newCam.shutterSpeedMax || null,
+			shutterSpeedStops: (newCam.shutterSpeedStops as StopIncrement) || null,
+			apertureStops: (newCam.apertureStops as StopIncrement) || null,
+		};
+		setData({ ...data, cameras: [...data.cameras, camera] });
+		onOpenChange(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{t("cameras.newCamera")}</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+				<div className="flex flex-col gap-4">
+					<PhotoPicker
+						photos={newCam.photo ? [newCam.photo] : []}
+						onChange={(p) => setNewCam({ ...newCam, photo: p[0] || undefined })}
+						max={1}
+						size={48}
+						placeholderIcon
+						label={t("cameras.photo")}
+					/>
+					<FormField label={t("cameras.brand")}>
+						<Input
+							value={newCam.brand}
+							onChange={(e) => setNewCam({ ...newCam, brand: e.target.value })}
+							placeholder={t("cameras.brandPlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.model")}>
+						<Input
+							value={newCam.model}
+							onChange={(e) => setNewCam({ ...newCam, model: e.target.value })}
+							placeholder={t("cameras.modelPlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.nickname")}>
+						<Input
+							value={newCam.nickname}
+							onChange={(e) => setNewCam({ ...newCam, nickname: e.target.value })}
+							placeholder={t("cameras.nicknamePlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.serial")}>
+						<Input
+							value={newCam.serial}
+							onChange={(e) => setNewCam({ ...newCam, serial: e.target.value })}
+							placeholder={t("cameras.serialPlaceholder")}
+						/>
+					</FormField>
+					<FormField label={t("cameras.format")}>
+						<Select value={newCam.format} onValueChange={(v) => setNewCam({ ...newCam, format: v })}>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="35mm">{t("filmFormats.35mm")}</SelectItem>
+								<SelectItem value="120">{t("filmFormats.120")}</SelectItem>
+								{INSTANT_FORMATS.map((f) => (
+									<SelectItem key={f} value={f}>
+										{t(`filmFormats.${f}`)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</FormField>
+					<FormField label={t("cameras.mount")}>
+						<Input
+							value={newCam.mount}
+							onChange={(e) => setNewCam({ ...newCam, mount: e.target.value })}
+							placeholder={t("cameras.mountPlaceholder")}
+						/>
+					</FormField>
+					<div className="flex items-center justify-between gap-3">
+						<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+							{t("cameras.interchangeableBack")}
+						</label>
+						<Switch
+							checked={newCam.hasInterchangeableBack}
+							onCheckedChange={(v) => setNewCam({ ...newCam, hasInterchangeableBack: v })}
+						/>
+					</div>
+
+					<div className="border-t border-border pt-4 mt-1">
+						<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+							{t("cameras.exposureSection")}
+						</span>
+					</div>
+					<div className="grid grid-cols-2 gap-3">
+						<FormField label={t("cameras.shutterSpeedMin")}>
+							<Select
+								value={newCam.shutterSpeedMin}
+								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMin: v })}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder="—" />
+								</SelectTrigger>
+								<SelectContent>
+									{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+										<SelectItem key={s} value={s}>
+											{s}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</FormField>
+						<FormField label={t("cameras.shutterSpeedMax")}>
+							<Select
+								value={newCam.shutterSpeedMax}
+								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMax: v })}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder="—" />
+								</SelectTrigger>
+								<SelectContent>
+									{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+										<SelectItem key={s} value={s}>
+											{s}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</FormField>
+					</div>
+					<div className="grid grid-cols-2 gap-3">
+						<FormField label={t("cameras.shutterSpeedStops")}>
+							<Select
+								value={newCam.shutterSpeedStops}
+								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedStops: v })}
+							>
+								<SelectTrigger>
+									<SelectValue placeholder="—" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+									<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+									<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+								</SelectContent>
+							</Select>
+						</FormField>
+						<FormField label={t("cameras.apertureStops")}>
+							<Select value={newCam.apertureStops} onValueChange={(v) => setNewCam({ ...newCam, apertureStops: v })}>
+								<SelectTrigger>
+									<SelectValue placeholder="—" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+									<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+									<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+								</SelectContent>
+							</Select>
+						</FormField>
+					</div>
+
+					<Button onClick={addCamera} disabled={!newCam.brand && !newCam.model} className="w-full justify-center">
+						<Plus size={16} /> {t("cameras.add")}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/equipment/AddLensDialog.tsx
+++ b/src/components/equipment/AddLensDialog.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { AppData } from "@/types";
+import { uid } from "@/utils/helpers";
+import { emptyLensForm, formToLens, LensForm, type LensFormData } from "./LensForm";
+
+interface AddLensDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	data: AppData;
+	setData: (data: AppData) => void;
+}
+
+export function AddLensDialog({ open, onOpenChange, data, setData }: AddLensDialogProps) {
+	const { t } = useTranslation();
+	const [newLens, setNewLens] = useState<LensFormData>(emptyLensForm);
+
+	useEffect(() => {
+		if (!open) setNewLens(emptyLensForm);
+	}, [open]);
+
+	const addLens = () => {
+		if (!newLens.brand && !newLens.model) return;
+		const lens = formToLens(newLens, uid());
+		setData({ ...data, lenses: [...data.lenses, lens] });
+		onOpenChange(false);
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{t("lenses.newLens")}</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+				<LensForm form={newLens} setForm={setNewLens} onSave={addLens} isEdit={false} />
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/equipment/BacksTab.tsx
+++ b/src/components/equipment/BacksTab.tsx
@@ -19,7 +19,7 @@ import { alpha, T } from "@/constants/theme";
 import { type AppData, type Back, INSTANT_FORMATS } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { filmName } from "@/utils/film-helpers";
-import { uid } from "@/utils/helpers";
+import { AddBackDialog } from "./AddBackDialog";
 
 interface BacksTabProps {
 	data: AppData;
@@ -29,15 +29,6 @@ interface BacksTabProps {
 export function BacksTab({ data, setData }: BacksTabProps) {
 	const { t } = useTranslation();
 	const [showBackModal, setShowBackModal] = useState(false);
-	const [newBack, setNewBack] = useState({
-		name: "",
-		nickname: "",
-		ref: "",
-		serial: "",
-		format: "120",
-		compatibleCameraIds: [] as string[],
-		photo: undefined as string | undefined,
-	});
 	const [editBack, setEditBack] = useState<Back | null>(null);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 	const [pendingHardDeleteId, setPendingHardDeleteId] = useState<string | null>(null);
@@ -46,42 +37,14 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 	const activeBacks = data.backs.filter((b) => !b.soldAt);
 	const soldBacks = data.backs.filter((b) => b.soldAt);
 
-	const toggleBackCamera = (
-		cameraId: string,
-		backState: { compatibleCameraIds: string[] },
-		setter: (ids: string[]) => void,
-	) => {
-		const ids = backState.compatibleCameraIds;
+	const toggleEditBackCamera = (cameraId: string) => {
+		if (!editBack) return;
+		const ids = editBack.compatibleCameraIds;
 		if (ids.includes(cameraId)) {
-			setter(ids.filter((id) => id !== cameraId));
+			setEditBack({ ...editBack, compatibleCameraIds: ids.filter((id) => id !== cameraId) });
 		} else {
-			setter([...ids, cameraId]);
+			setEditBack({ ...editBack, compatibleCameraIds: [...ids, cameraId] });
 		}
-	};
-
-	const addBack = () => {
-		if (!newBack.name) return;
-		const back: Back = {
-			id: uid(),
-			name: newBack.name,
-			nickname: newBack.nickname,
-			ref: newBack.ref,
-			serial: newBack.serial,
-			format: newBack.format,
-			compatibleCameraIds: newBack.compatibleCameraIds,
-			photo: newBack.photo,
-		};
-		setData({ ...data, backs: [...data.backs, back] });
-		setShowBackModal(false);
-		setNewBack({
-			name: "",
-			nickname: "",
-			ref: "",
-			serial: "",
-			format: "120",
-			compatibleCameraIds: [],
-			photo: undefined,
-		});
 	};
 
 	const saveEditBack = () => {
@@ -278,91 +241,7 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 				)}
 			</div>
 
-			{/* Add back modal */}
-			<Dialog open={showBackModal} onOpenChange={(open) => !open && setShowBackModal(false)}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>{t("cameras.addBackTitle")}</DialogTitle>
-						<DialogCloseButton />
-					</DialogHeader>
-					<div className="flex flex-col gap-4">
-						<PhotoPicker
-							photos={newBack.photo ? [newBack.photo] : []}
-							onChange={(p) => setNewBack({ ...newBack, photo: p[0] || undefined })}
-							max={1}
-							size={32}
-							placeholderIcon
-							label={t("cameras.photo")}
-						/>
-						<FormField label={t("cameras.backName")}>
-							<Input
-								value={newBack.name}
-								onChange={(e) => setNewBack({ ...newBack, name: e.target.value })}
-								placeholder={t("cameras.backNamePlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.backFormat")}>
-							<Select value={newBack.format} onValueChange={(v) => setNewBack({ ...newBack, format: v })}>
-								<SelectTrigger>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="35mm">{t("filmFormats.35mm")}</SelectItem>
-									<SelectItem value="120">{t("filmFormats.120")}</SelectItem>
-									{INSTANT_FORMATS.map((f) => (
-										<SelectItem key={f} value={f}>
-											{t(`filmFormats.${f}`)}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</FormField>
-						<FormField label={t("cameras.reference")}>
-							<Input
-								value={newBack.ref}
-								onChange={(e) => setNewBack({ ...newBack, ref: e.target.value })}
-								placeholder={t("cameras.refPlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.backNickname")}>
-							<Input
-								value={newBack.nickname}
-								onChange={(e) => setNewBack({ ...newBack, nickname: e.target.value })}
-								placeholder={t("cameras.backNicknamePlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.backSerial")}>
-							<Input
-								value={newBack.serial}
-								onChange={(e) => setNewBack({ ...newBack, serial: e.target.value })}
-								placeholder={t("cameras.serialPlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.compatibleCameras")}>
-							{interchangeableCameras.length > 0 ? (
-								<div className="flex flex-col gap-2">
-									{interchangeableCameras.map((c) => (
-										<div key={c.id} className="flex items-center justify-between gap-3">
-											<span className="text-[13px] text-text-sec font-body">{cameraDisplayName(c)}</span>
-											<Switch
-												checked={newBack.compatibleCameraIds.includes(c.id)}
-												onCheckedChange={() =>
-													toggleBackCamera(c.id, newBack, (ids) => setNewBack({ ...newBack, compatibleCameraIds: ids }))
-												}
-											/>
-										</div>
-									))}
-								</div>
-							) : (
-								<span className="text-[12px] text-text-muted font-body">{t("cameras.noCompatibleCameras")}</span>
-							)}
-						</FormField>
-						<Button onClick={addBack} disabled={!newBack.name} className="w-full justify-center">
-							<Plus size={16} /> {t("cameras.addBackButton")}
-						</Button>
-					</div>
-				</DialogContent>
-			</Dialog>
+			<AddBackDialog open={showBackModal} onOpenChange={setShowBackModal} data={data} setData={setData} />
 
 			{/* Edit back modal */}
 			<Dialog open={!!editBack} onOpenChange={(open) => !open && setEditBack(null)}>
@@ -423,11 +302,7 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 												<span className="text-[13px] text-text-sec font-body">{cameraDisplayName(c)}</span>
 												<Switch
 													checked={editBack.compatibleCameraIds.includes(c.id)}
-													onCheckedChange={() =>
-														toggleBackCamera(c.id, editBack, (ids) =>
-															setEditBack({ ...editBack, compatibleCameraIds: ids }),
-														)
-													}
+													onCheckedChange={() => toggleEditBackCamera(c.id)}
 												/>
 											</div>
 										))}

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -20,7 +20,7 @@ import { alpha, T } from "@/constants/theme";
 import { type AppData, type Camera as CameraType, INSTANT_FORMATS, type StopIncrement } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { filmName } from "@/utils/film-helpers";
-import { uid } from "@/utils/helpers";
+import { AddCameraDialog } from "./AddCameraDialog";
 
 interface CamerasTabProps {
 	data: AppData;
@@ -31,61 +31,12 @@ interface CamerasTabProps {
 export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	const { t } = useTranslation();
 	const [showAdd, setShowAdd] = useState(false);
-	const [newCam, setNewCam] = useState({
-		brand: "",
-		model: "",
-		nickname: "",
-		serial: "",
-		format: "35mm",
-		mount: "",
-		hasInterchangeableBack: false,
-		photo: undefined as string | undefined,
-		shutterSpeedMin: "" as string,
-		shutterSpeedMax: "" as string,
-		shutterSpeedStops: "" as string,
-		apertureStops: "" as string,
-	});
 	const [editCam, setEditCam] = useState<(CameraType & { mount?: string | null }) | null>(null);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 	const [pendingHardDeleteId, setPendingHardDeleteId] = useState<string | null>(null);
 
 	const activeCameras = data.cameras.filter((c) => !c.soldAt);
 	const soldCameras = data.cameras.filter((c) => c.soldAt);
-
-	const addCamera = () => {
-		if (!newCam.brand && !newCam.model) return;
-		const camera: CameraType = {
-			id: uid(),
-			brand: newCam.brand,
-			model: newCam.model,
-			nickname: newCam.nickname,
-			serial: newCam.serial,
-			format: newCam.format,
-			mount: newCam.mount || null,
-			hasInterchangeableBack: newCam.hasInterchangeableBack || false,
-			photo: newCam.photo,
-			shutterSpeedMin: newCam.shutterSpeedMin || null,
-			shutterSpeedMax: newCam.shutterSpeedMax || null,
-			shutterSpeedStops: (newCam.shutterSpeedStops as StopIncrement) || null,
-			apertureStops: (newCam.apertureStops as StopIncrement) || null,
-		};
-		setData({ ...data, cameras: [...data.cameras, camera] });
-		setShowAdd(false);
-		setNewCam({
-			brand: "",
-			model: "",
-			nickname: "",
-			serial: "",
-			format: "35mm",
-			mount: "",
-			hasInterchangeableBack: false,
-			photo: undefined,
-			shutterSpeedMin: "",
-			shutterSpeedMax: "",
-			shutterSpeedStops: "",
-			apertureStops: "",
-		});
-	};
 
 	const saveEditCamera = () => {
 		if (!editCam?.brand && !editCam?.model) return;
@@ -352,160 +303,7 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 				)}
 			</div>
 
-			{/* Add camera modal */}
-			<Dialog open={showAdd} onOpenChange={(open) => !open && setShowAdd(false)}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>{t("cameras.newCamera")}</DialogTitle>
-						<DialogCloseButton />
-					</DialogHeader>
-					<div className="flex flex-col gap-4">
-						<PhotoPicker
-							photos={newCam.photo ? [newCam.photo] : []}
-							onChange={(p) => setNewCam({ ...newCam, photo: p[0] || undefined })}
-							max={1}
-							size={48}
-							placeholderIcon
-							label={t("cameras.photo")}
-						/>
-						<FormField label={t("cameras.brand")}>
-							<Input
-								value={newCam.brand}
-								onChange={(e) => setNewCam({ ...newCam, brand: e.target.value })}
-								placeholder={t("cameras.brandPlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.model")}>
-							<Input
-								value={newCam.model}
-								onChange={(e) => setNewCam({ ...newCam, model: e.target.value })}
-								placeholder={t("cameras.modelPlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.nickname")}>
-							<Input
-								value={newCam.nickname}
-								onChange={(e) => setNewCam({ ...newCam, nickname: e.target.value })}
-								placeholder={t("cameras.nicknamePlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.serial")}>
-							<Input
-								value={newCam.serial}
-								onChange={(e) => setNewCam({ ...newCam, serial: e.target.value })}
-								placeholder={t("cameras.serialPlaceholder")}
-							/>
-						</FormField>
-						<FormField label={t("cameras.format")}>
-							<Select value={newCam.format} onValueChange={(v) => setNewCam({ ...newCam, format: v })}>
-								<SelectTrigger>
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="35mm">{t("filmFormats.35mm")}</SelectItem>
-									<SelectItem value="120">{t("filmFormats.120")}</SelectItem>
-									{INSTANT_FORMATS.map((f) => (
-										<SelectItem key={f} value={f}>
-											{t(`filmFormats.${f}`)}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</FormField>
-						<FormField label={t("cameras.mount")}>
-							<Input
-								value={newCam.mount}
-								onChange={(e) => setNewCam({ ...newCam, mount: e.target.value })}
-								placeholder={t("cameras.mountPlaceholder")}
-							/>
-						</FormField>
-						<div className="flex items-center justify-between gap-3">
-							<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-								{t("cameras.interchangeableBack")}
-							</label>
-							<Switch
-								checked={newCam.hasInterchangeableBack}
-								onCheckedChange={(v) => setNewCam({ ...newCam, hasInterchangeableBack: v })}
-							/>
-						</div>
-
-						<div className="border-t border-border pt-4 mt-1">
-							<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-								{t("cameras.exposureSection")}
-							</span>
-						</div>
-						<div className="grid grid-cols-2 gap-3">
-							<FormField label={t("cameras.shutterSpeedMin")}>
-								<Select
-									value={newCam.shutterSpeedMin}
-									onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMin: v })}
-								>
-									<SelectTrigger>
-										<SelectValue placeholder="—" />
-									</SelectTrigger>
-									<SelectContent>
-										{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-											<SelectItem key={s} value={s}>
-												{s}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</FormField>
-							<FormField label={t("cameras.shutterSpeedMax")}>
-								<Select
-									value={newCam.shutterSpeedMax}
-									onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMax: v })}
-								>
-									<SelectTrigger>
-										<SelectValue placeholder="—" />
-									</SelectTrigger>
-									<SelectContent>
-										{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-											<SelectItem key={s} value={s}>
-												{s}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							</FormField>
-						</div>
-						<div className="grid grid-cols-2 gap-3">
-							<FormField label={t("cameras.shutterSpeedStops")}>
-								<Select
-									value={newCam.shutterSpeedStops}
-									onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedStops: v })}
-								>
-									<SelectTrigger>
-										<SelectValue placeholder="—" />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-										<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-										<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-									</SelectContent>
-								</Select>
-							</FormField>
-							<FormField label={t("cameras.apertureStops")}>
-								<Select value={newCam.apertureStops} onValueChange={(v) => setNewCam({ ...newCam, apertureStops: v })}>
-									<SelectTrigger>
-										<SelectValue placeholder="—" />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-										<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-										<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-									</SelectContent>
-								</Select>
-							</FormField>
-						</div>
-
-						<Button onClick={addCamera} disabled={!newCam.brand && !newCam.model} className="w-full justify-center">
-							<Plus size={16} /> {t("cameras.add")}
-						</Button>
-					</div>
-				</DialogContent>
-			</Dialog>
+			<AddCameraDialog open={showAdd} onOpenChange={setShowAdd} data={data} setData={setData} />
 
 			{/* Edit camera modal */}
 			<Dialog open={!!editCam} onOpenChange={(open) => !open && setEditCam(null)}>

--- a/src/components/equipment/LensForm.tsx
+++ b/src/components/equipment/LensForm.tsx
@@ -1,0 +1,353 @@
+import { Check, PackageX, Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { PhotoPicker } from "@/components/PhotoPicker";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { APERTURES, filterApertures, filterSpeeds } from "@/constants/photography";
+import type { Lens, StopIncrement } from "@/types";
+
+export interface LensFormData {
+	isZoom: boolean;
+	brand: string;
+	model: string;
+	nickname: string;
+	serial: string;
+	mount: string;
+	focalLengthMin: string;
+	focalLengthMax: string;
+	maxApertureAtMin: string;
+	maxApertureAtMax: string;
+	apertureMin: string;
+	apertureMax: string;
+	apertureStops: string;
+	shutterSpeedMin: string;
+	shutterSpeedMax: string;
+	shutterSpeedStops: string;
+	photo: string | undefined;
+}
+
+export const emptyLensForm: LensFormData = {
+	isZoom: false,
+	brand: "",
+	model: "",
+	nickname: "",
+	serial: "",
+	mount: "",
+	focalLengthMin: "",
+	focalLengthMax: "",
+	maxApertureAtMin: "",
+	maxApertureAtMax: "",
+	apertureMin: "",
+	apertureMax: "",
+	apertureStops: "",
+	shutterSpeedMin: "",
+	shutterSpeedMax: "",
+	shutterSpeedStops: "",
+	photo: undefined,
+};
+
+export function lensToForm(lens: Lens): LensFormData {
+	return {
+		isZoom: lens.isZoom ?? false,
+		brand: lens.brand,
+		model: lens.model,
+		nickname: lens.nickname || "",
+		serial: lens.serial || "",
+		mount: lens.mount || "",
+		focalLengthMin: lens.focalLengthMin != null ? String(lens.focalLengthMin) : "",
+		focalLengthMax: lens.focalLengthMax != null ? String(lens.focalLengthMax) : "",
+		maxApertureAtMin: lens.maxApertureAtMin || "",
+		maxApertureAtMax: lens.maxApertureAtMax || "",
+		apertureMin: lens.apertureMin || "",
+		apertureMax: lens.apertureMax || "",
+		apertureStops: lens.apertureStops || "",
+		shutterSpeedMin: lens.shutterSpeedMin || "",
+		shutterSpeedMax: lens.shutterSpeedMax || "",
+		shutterSpeedStops: lens.shutterSpeedStops || "",
+		photo: lens.photo,
+	};
+}
+
+export function formToLens(form: LensFormData, id: string): Lens {
+	const fMin = Number.parseInt(form.focalLengthMin, 10);
+	const fMax = Number.parseInt(form.focalLengthMax, 10);
+	const validZoom = form.isZoom && !Number.isNaN(fMin) && !Number.isNaN(fMax) && fMax > fMin;
+	return {
+		id,
+		brand: form.brand,
+		model: form.model,
+		nickname: form.nickname || undefined,
+		serial: form.serial || undefined,
+		photo: form.photo,
+		mount: form.mount || undefined,
+		isZoom: validZoom,
+		focalLengthMin: Number.isNaN(fMin) ? null : fMin,
+		focalLengthMax: validZoom ? fMax : Number.isNaN(fMin) ? null : fMin,
+		maxApertureAtMin: form.maxApertureAtMin || null,
+		maxApertureAtMax: validZoom ? form.maxApertureAtMax || null : null,
+		apertureMin: form.apertureMin || null,
+		apertureMax: form.apertureMax || null,
+		apertureStops: (form.apertureStops as StopIncrement) || null,
+		shutterSpeedMin: form.shutterSpeedMin || null,
+		shutterSpeedMax: form.shutterSpeedMax || null,
+		shutterSpeedStops: (form.shutterSpeedStops as StopIncrement) || null,
+	};
+}
+
+interface LensFormProps {
+	form: LensFormData;
+	setForm: (form: LensFormData) => void;
+	onSave: () => void;
+	isEdit: boolean;
+	onSell?: () => void;
+}
+
+export function LensForm({ form, setForm, onSave, isEdit, onSell }: LensFormProps) {
+	const { t } = useTranslation();
+
+	return (
+		<div className="flex flex-col gap-4">
+			<PhotoPicker
+				photos={form.photo ? [form.photo] : []}
+				onChange={(p) => setForm({ ...form, photo: p[0] || undefined })}
+				max={1}
+				size={48}
+				placeholderIcon
+				label={t("lenses.photo")}
+			/>
+			<FormField label={t("lenses.brand")}>
+				<Input
+					value={form.brand}
+					onChange={(e) => setForm({ ...form, brand: e.target.value })}
+					placeholder={t("lenses.brandPlaceholder")}
+				/>
+			</FormField>
+			<FormField label={t("lenses.model")}>
+				<Input
+					value={form.model}
+					onChange={(e) => setForm({ ...form, model: e.target.value })}
+					placeholder={t("lenses.modelPlaceholder")}
+				/>
+			</FormField>
+			<FormField label={t("lenses.nickname")}>
+				<Input
+					value={form.nickname}
+					onChange={(e) => setForm({ ...form, nickname: e.target.value })}
+					placeholder={t("lenses.nicknamePlaceholder")}
+				/>
+			</FormField>
+			<FormField label={t("lenses.serial")}>
+				<Input
+					value={form.serial}
+					onChange={(e) => setForm({ ...form, serial: e.target.value })}
+					placeholder={t("lenses.serialPlaceholder")}
+				/>
+			</FormField>
+			<FormField label={t("lenses.mount")}>
+				<Input
+					value={form.mount}
+					onChange={(e) => setForm({ ...form, mount: e.target.value })}
+					placeholder={t("lenses.mountPlaceholder")}
+				/>
+			</FormField>
+
+			<div className="border-t border-border pt-4 mt-1">
+				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+					{t("lenses.focalSection")}
+				</span>
+			</div>
+			<label className="flex items-center justify-between gap-3 cursor-pointer">
+				<span className="text-sm text-text-primary">{t("lenses.isZoom")}</span>
+				<Switch checked={form.isZoom} onCheckedChange={(v) => setForm({ ...form, isZoom: v })} />
+			</label>
+			{form.isZoom ? (
+				<div className="grid grid-cols-2 gap-3">
+					<FormField label={t("lenses.focalLengthMin")}>
+						<Input
+							type="number"
+							min={1}
+							value={form.focalLengthMin}
+							onChange={(e) => setForm({ ...form, focalLengthMin: e.target.value })}
+							placeholder={t("lenses.focalLengthPlaceholder")}
+							className="font-mono"
+						/>
+					</FormField>
+					<FormField label={t("lenses.focalLengthMax")}>
+						<Input
+							type="number"
+							min={1}
+							value={form.focalLengthMax}
+							onChange={(e) => setForm({ ...form, focalLengthMax: e.target.value })}
+							placeholder={t("lenses.focalLengthPlaceholder")}
+							className="font-mono"
+						/>
+					</FormField>
+				</div>
+			) : (
+				<FormField label={t("lenses.focalLength")}>
+					<Input
+						type="number"
+						min={1}
+						value={form.focalLengthMin}
+						onChange={(e) => setForm({ ...form, focalLengthMin: e.target.value })}
+						placeholder={t("lenses.focalLengthPlaceholder")}
+						className="font-mono"
+					/>
+				</FormField>
+			)}
+			<div className={`grid gap-3 ${form.isZoom ? "grid-cols-2" : "grid-cols-1"}`}>
+				<FormField label={form.isZoom ? t("lenses.maxApertureAtMin") : t("lenses.maxAperture")}>
+					<Select value={form.maxApertureAtMin} onValueChange={(v) => setForm({ ...form, maxApertureAtMin: v })}>
+						<SelectTrigger>
+							<SelectValue placeholder="—" />
+						</SelectTrigger>
+						<SelectContent>
+							{APERTURES.filter((_, i) => i === 0 || (i - 1) % 3 === 0).map((a) => (
+								<SelectItem key={a} value={a}>
+									{a}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</FormField>
+				{form.isZoom && (
+					<FormField label={t("lenses.maxApertureAtMax")}>
+						<Select value={form.maxApertureAtMax} onValueChange={(v) => setForm({ ...form, maxApertureAtMax: v })}>
+							<SelectTrigger>
+								<SelectValue placeholder="—" />
+							</SelectTrigger>
+							<SelectContent>
+								{APERTURES.filter((_, i) => i === 0 || (i - 1) % 3 === 0).map((a) => (
+									<SelectItem key={a} value={a}>
+										{a}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</FormField>
+				)}
+			</div>
+
+			<div className="border-t border-border pt-4 mt-1">
+				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+					{t("lenses.apertureSection")}
+				</span>
+			</div>
+			<FormField label={t("lenses.apertureStops")}>
+				<Select value={form.apertureStops} onValueChange={(v) => setForm({ ...form, apertureStops: v })}>
+					<SelectTrigger>
+						<SelectValue placeholder="—" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="1">{t("lenses.stopsFull")}</SelectItem>
+						<SelectItem value="1/2">{t("lenses.stopsHalf")}</SelectItem>
+						<SelectItem value="1/3">{t("lenses.stopsThird")}</SelectItem>
+					</SelectContent>
+				</Select>
+			</FormField>
+			<div className="grid grid-cols-2 gap-3">
+				<FormField label={t("lenses.apertureMin")}>
+					<Select value={form.apertureMin} onValueChange={(v) => setForm({ ...form, apertureMin: v })}>
+						<SelectTrigger>
+							<SelectValue placeholder="—" />
+						</SelectTrigger>
+						<SelectContent>
+							{filterApertures(form.apertureStops ? { stops: form.apertureStops as StopIncrement } : null).map((a) => (
+								<SelectItem key={a} value={a}>
+									{a}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</FormField>
+				<FormField label={t("lenses.apertureMax")}>
+					<Select value={form.apertureMax} onValueChange={(v) => setForm({ ...form, apertureMax: v })}>
+						<SelectTrigger>
+							<SelectValue placeholder="—" />
+						</SelectTrigger>
+						<SelectContent>
+							{filterApertures(form.apertureStops ? { stops: form.apertureStops as StopIncrement } : null).map((a) => (
+								<SelectItem key={a} value={a}>
+									{a}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</FormField>
+			</div>
+
+			<div className="border-t border-border pt-4 mt-1">
+				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+					{t("lenses.exposureSection")}
+				</span>
+			</div>
+			<FormField label={t("lenses.shutterSpeedStops")}>
+				<Select value={form.shutterSpeedStops} onValueChange={(v) => setForm({ ...form, shutterSpeedStops: v })}>
+					<SelectTrigger>
+						<SelectValue placeholder="—" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="1">{t("lenses.stopsFull")}</SelectItem>
+						<SelectItem value="1/2">{t("lenses.stopsHalf")}</SelectItem>
+						<SelectItem value="1/3">{t("lenses.stopsThird")}</SelectItem>
+					</SelectContent>
+				</Select>
+			</FormField>
+			<div className="grid grid-cols-2 gap-3">
+				<FormField label={t("lenses.shutterSpeedMin")}>
+					<Select value={form.shutterSpeedMin} onValueChange={(v) => setForm({ ...form, shutterSpeedMin: v })}>
+						<SelectTrigger>
+							<SelectValue placeholder="—" />
+						</SelectTrigger>
+						<SelectContent>
+							{filterSpeeds(form.shutterSpeedStops ? { stops: form.shutterSpeedStops as StopIncrement } : null).map(
+								(s) => (
+									<SelectItem key={s} value={s}>
+										{s}
+									</SelectItem>
+								),
+							)}
+						</SelectContent>
+					</Select>
+				</FormField>
+				<FormField label={t("lenses.shutterSpeedMax")}>
+					<Select value={form.shutterSpeedMax} onValueChange={(v) => setForm({ ...form, shutterSpeedMax: v })}>
+						<SelectTrigger>
+							<SelectValue placeholder="—" />
+						</SelectTrigger>
+						<SelectContent>
+							{filterSpeeds(form.shutterSpeedStops ? { stops: form.shutterSpeedStops as StopIncrement } : null).map(
+								(s) => (
+									<SelectItem key={s} value={s}>
+										{s}
+									</SelectItem>
+								),
+							)}
+						</SelectContent>
+					</Select>
+				</FormField>
+			</div>
+
+			<Button onClick={onSave} disabled={!form.brand && !form.model} className="w-full justify-center">
+				{isEdit ? (
+					<>
+						<Check size={16} /> {t("lenses.save")}
+					</>
+				) : (
+					<>
+						<Plus size={16} /> {t("lenses.add")}
+					</>
+				)}
+			</Button>
+
+			{isEdit && onSell && (
+				<Button variant="destructive" onClick={onSell} className="w-full justify-center">
+					<PackageX size={14} /> {t("lenses.sellLens")}
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/src/components/equipment/LensesTab.tsx
+++ b/src/components/equipment/LensesTab.tsx
@@ -1,8 +1,7 @@
-import { Check, Edit3, Focus, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Edit3, Focus, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
-import { PhotoPicker } from "@/components/PhotoPicker";
 import { PhotoViewer } from "@/components/PhotoViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -10,88 +9,21 @@ import { Card } from "@/components/ui/card";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { FormField } from "@/components/ui/form-field";
-import { Input } from "@/components/ui/input";
 import { PhotoImg } from "@/components/ui/photo-img";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { APERTURES, filterApertures, filterSpeeds } from "@/constants/photography";
 import { alpha, T } from "@/constants/theme";
-import type { AppData, Lens, StopIncrement } from "@/types";
-import { uid } from "@/utils/helpers";
+import type { AppData, Lens } from "@/types";
 import { lensApertureLabel, lensDisplayName, lensFocalLabel } from "@/utils/lens-helpers";
+import { AddLensDialog } from "./AddLensDialog";
+import { emptyLensForm, formToLens, LensForm, type LensFormData, lensToForm } from "./LensForm";
 
 interface LensesTabProps {
 	data: AppData;
 	setData: (data: AppData) => void;
 }
 
-interface LensFormData {
-	isZoom: boolean;
-	brand: string;
-	model: string;
-	nickname: string;
-	serial: string;
-	mount: string;
-	focalLengthMin: string;
-	focalLengthMax: string;
-	maxApertureAtMin: string;
-	maxApertureAtMax: string;
-	apertureMin: string;
-	apertureMax: string;
-	apertureStops: string;
-	shutterSpeedMin: string;
-	shutterSpeedMax: string;
-	shutterSpeedStops: string;
-	photo: string | undefined;
-}
-
-const emptyLensForm: LensFormData = {
-	isZoom: false,
-	brand: "",
-	model: "",
-	nickname: "",
-	serial: "",
-	mount: "",
-	focalLengthMin: "",
-	focalLengthMax: "",
-	maxApertureAtMin: "",
-	maxApertureAtMax: "",
-	apertureMin: "",
-	apertureMax: "",
-	apertureStops: "",
-	shutterSpeedMin: "",
-	shutterSpeedMax: "",
-	shutterSpeedStops: "",
-	photo: undefined,
-};
-
-function lensToForm(lens: Lens): LensFormData {
-	return {
-		isZoom: lens.isZoom ?? false,
-		brand: lens.brand,
-		model: lens.model,
-		nickname: lens.nickname || "",
-		serial: lens.serial || "",
-		mount: lens.mount || "",
-		focalLengthMin: lens.focalLengthMin != null ? String(lens.focalLengthMin) : "",
-		focalLengthMax: lens.focalLengthMax != null ? String(lens.focalLengthMax) : "",
-		maxApertureAtMin: lens.maxApertureAtMin || "",
-		maxApertureAtMax: lens.maxApertureAtMax || "",
-		apertureMin: lens.apertureMin || "",
-		apertureMax: lens.apertureMax || "",
-		apertureStops: lens.apertureStops || "",
-		shutterSpeedMin: lens.shutterSpeedMin || "",
-		shutterSpeedMax: lens.shutterSpeedMax || "",
-		shutterSpeedStops: lens.shutterSpeedStops || "",
-		photo: lens.photo,
-	};
-}
-
 export function LensesTab({ data, setData }: LensesTabProps) {
 	const { t } = useTranslation();
 	const [showAdd, setShowAdd] = useState(false);
-	const [newLens, setNewLens] = useState<LensFormData>(emptyLensForm);
 	const [editLensId, setEditLensId] = useState<string | null>(null);
 	const [editLens, setEditLens] = useState<LensFormData>(emptyLensForm);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
@@ -99,40 +31,6 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 
 	const activeLenses = data.lenses.filter((l) => !l.soldAt);
 	const soldLenses = data.lenses.filter((l) => l.soldAt);
-
-	const formToLens = (form: LensFormData, id: string): Lens => {
-		const fMin = Number.parseInt(form.focalLengthMin, 10);
-		const fMax = Number.parseInt(form.focalLengthMax, 10);
-		const validZoom = form.isZoom && !Number.isNaN(fMin) && !Number.isNaN(fMax) && fMax > fMin;
-		return {
-			id,
-			brand: form.brand,
-			model: form.model,
-			nickname: form.nickname || undefined,
-			serial: form.serial || undefined,
-			photo: form.photo,
-			mount: form.mount || undefined,
-			isZoom: validZoom,
-			focalLengthMin: Number.isNaN(fMin) ? null : fMin,
-			focalLengthMax: validZoom ? fMax : Number.isNaN(fMin) ? null : fMin,
-			maxApertureAtMin: form.maxApertureAtMin || null,
-			maxApertureAtMax: validZoom ? form.maxApertureAtMax || null : null,
-			apertureMin: form.apertureMin || null,
-			apertureMax: form.apertureMax || null,
-			apertureStops: (form.apertureStops as StopIncrement) || null,
-			shutterSpeedMin: form.shutterSpeedMin || null,
-			shutterSpeedMax: form.shutterSpeedMax || null,
-			shutterSpeedStops: (form.shutterSpeedStops as StopIncrement) || null,
-		};
-	};
-
-	const addLens = () => {
-		if (!newLens.brand && !newLens.model) return;
-		const lens = formToLens(newLens, uid());
-		setData({ ...data, lenses: [...data.lenses, lens] });
-		setShowAdd(false);
-		setNewLens(emptyLensForm);
-	};
 
 	const saveEditLens = () => {
 		if (!editLensId || (!editLens.brand && !editLens.model)) return;
@@ -174,252 +72,6 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 		setEditLensId(lens.id);
 		setEditLens(lensToForm(lens));
 	};
-
-	const renderForm = (form: LensFormData, setForm: (f: LensFormData) => void, onSave: () => void, isEdit: boolean) => (
-		<div className="flex flex-col gap-4">
-			<PhotoPicker
-				photos={form.photo ? [form.photo] : []}
-				onChange={(p) => setForm({ ...form, photo: p[0] || undefined })}
-				max={1}
-				size={48}
-				placeholderIcon
-				label={t("lenses.photo")}
-			/>
-			<FormField label={t("lenses.brand")}>
-				<Input
-					value={form.brand}
-					onChange={(e) => setForm({ ...form, brand: e.target.value })}
-					placeholder={t("lenses.brandPlaceholder")}
-				/>
-			</FormField>
-			<FormField label={t("lenses.model")}>
-				<Input
-					value={form.model}
-					onChange={(e) => setForm({ ...form, model: e.target.value })}
-					placeholder={t("lenses.modelPlaceholder")}
-				/>
-			</FormField>
-			<FormField label={t("lenses.nickname")}>
-				<Input
-					value={form.nickname}
-					onChange={(e) => setForm({ ...form, nickname: e.target.value })}
-					placeholder={t("lenses.nicknamePlaceholder")}
-				/>
-			</FormField>
-			<FormField label={t("lenses.serial")}>
-				<Input
-					value={form.serial}
-					onChange={(e) => setForm({ ...form, serial: e.target.value })}
-					placeholder={t("lenses.serialPlaceholder")}
-				/>
-			</FormField>
-			<FormField label={t("lenses.mount")}>
-				<Input
-					value={form.mount}
-					onChange={(e) => setForm({ ...form, mount: e.target.value })}
-					placeholder={t("lenses.mountPlaceholder")}
-				/>
-			</FormField>
-
-			{/* Focal length section */}
-			<div className="border-t border-border pt-4 mt-1">
-				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-					{t("lenses.focalSection")}
-				</span>
-			</div>
-			<label className="flex items-center justify-between gap-3 cursor-pointer">
-				<span className="text-sm text-text-primary">{t("lenses.isZoom")}</span>
-				<Switch checked={form.isZoom} onCheckedChange={(v) => setForm({ ...form, isZoom: v })} />
-			</label>
-			{form.isZoom ? (
-				<div className="grid grid-cols-2 gap-3">
-					<FormField label={t("lenses.focalLengthMin")}>
-						<Input
-							type="number"
-							min={1}
-							value={form.focalLengthMin}
-							onChange={(e) => setForm({ ...form, focalLengthMin: e.target.value })}
-							placeholder={t("lenses.focalLengthPlaceholder")}
-							className="font-mono"
-						/>
-					</FormField>
-					<FormField label={t("lenses.focalLengthMax")}>
-						<Input
-							type="number"
-							min={1}
-							value={form.focalLengthMax}
-							onChange={(e) => setForm({ ...form, focalLengthMax: e.target.value })}
-							placeholder={t("lenses.focalLengthPlaceholder")}
-							className="font-mono"
-						/>
-					</FormField>
-				</div>
-			) : (
-				<FormField label={t("lenses.focalLength")}>
-					<Input
-						type="number"
-						min={1}
-						value={form.focalLengthMin}
-						onChange={(e) => setForm({ ...form, focalLengthMin: e.target.value })}
-						placeholder={t("lenses.focalLengthPlaceholder")}
-						className="font-mono"
-					/>
-				</FormField>
-			)}
-			<div className={`grid gap-3 ${form.isZoom ? "grid-cols-2" : "grid-cols-1"}`}>
-				<FormField label={form.isZoom ? t("lenses.maxApertureAtMin") : t("lenses.maxAperture")}>
-					<Select value={form.maxApertureAtMin} onValueChange={(v) => setForm({ ...form, maxApertureAtMin: v })}>
-						<SelectTrigger>
-							<SelectValue placeholder="—" />
-						</SelectTrigger>
-						<SelectContent>
-							{APERTURES.filter((_, i) => i === 0 || (i - 1) % 3 === 0).map((a) => (
-								<SelectItem key={a} value={a}>
-									{a}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</FormField>
-				{form.isZoom && (
-					<FormField label={t("lenses.maxApertureAtMax")}>
-						<Select value={form.maxApertureAtMax} onValueChange={(v) => setForm({ ...form, maxApertureAtMax: v })}>
-							<SelectTrigger>
-								<SelectValue placeholder="—" />
-							</SelectTrigger>
-							<SelectContent>
-								{APERTURES.filter((_, i) => i === 0 || (i - 1) % 3 === 0).map((a) => (
-									<SelectItem key={a} value={a}>
-										{a}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-					</FormField>
-				)}
-			</div>
-
-			{/* Aperture section */}
-			<div className="border-t border-border pt-4 mt-1">
-				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-					{t("lenses.apertureSection")}
-				</span>
-			</div>
-			<FormField label={t("lenses.apertureStops")}>
-				<Select value={form.apertureStops} onValueChange={(v) => setForm({ ...form, apertureStops: v })}>
-					<SelectTrigger>
-						<SelectValue placeholder="—" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="1">{t("lenses.stopsFull")}</SelectItem>
-						<SelectItem value="1/2">{t("lenses.stopsHalf")}</SelectItem>
-						<SelectItem value="1/3">{t("lenses.stopsThird")}</SelectItem>
-					</SelectContent>
-				</Select>
-			</FormField>
-			<div className="grid grid-cols-2 gap-3">
-				<FormField label={t("lenses.apertureMin")}>
-					<Select value={form.apertureMin} onValueChange={(v) => setForm({ ...form, apertureMin: v })}>
-						<SelectTrigger>
-							<SelectValue placeholder="—" />
-						</SelectTrigger>
-						<SelectContent>
-							{filterApertures(form.apertureStops ? { stops: form.apertureStops as StopIncrement } : null).map((a) => (
-								<SelectItem key={a} value={a}>
-									{a}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</FormField>
-				<FormField label={t("lenses.apertureMax")}>
-					<Select value={form.apertureMax} onValueChange={(v) => setForm({ ...form, apertureMax: v })}>
-						<SelectTrigger>
-							<SelectValue placeholder="—" />
-						</SelectTrigger>
-						<SelectContent>
-							{filterApertures(form.apertureStops ? { stops: form.apertureStops as StopIncrement } : null).map((a) => (
-								<SelectItem key={a} value={a}>
-									{a}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</FormField>
-			</div>
-
-			{/* Shutter speed section (leaf shutter) */}
-			<div className="border-t border-border pt-4 mt-1">
-				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-					{t("lenses.exposureSection")}
-				</span>
-			</div>
-			<FormField label={t("lenses.shutterSpeedStops")}>
-				<Select value={form.shutterSpeedStops} onValueChange={(v) => setForm({ ...form, shutterSpeedStops: v })}>
-					<SelectTrigger>
-						<SelectValue placeholder="—" />
-					</SelectTrigger>
-					<SelectContent>
-						<SelectItem value="1">{t("lenses.stopsFull")}</SelectItem>
-						<SelectItem value="1/2">{t("lenses.stopsHalf")}</SelectItem>
-						<SelectItem value="1/3">{t("lenses.stopsThird")}</SelectItem>
-					</SelectContent>
-				</Select>
-			</FormField>
-			<div className="grid grid-cols-2 gap-3">
-				<FormField label={t("lenses.shutterSpeedMin")}>
-					<Select value={form.shutterSpeedMin} onValueChange={(v) => setForm({ ...form, shutterSpeedMin: v })}>
-						<SelectTrigger>
-							<SelectValue placeholder="—" />
-						</SelectTrigger>
-						<SelectContent>
-							{filterSpeeds(form.shutterSpeedStops ? { stops: form.shutterSpeedStops as StopIncrement } : null).map(
-								(s) => (
-									<SelectItem key={s} value={s}>
-										{s}
-									</SelectItem>
-								),
-							)}
-						</SelectContent>
-					</Select>
-				</FormField>
-				<FormField label={t("lenses.shutterSpeedMax")}>
-					<Select value={form.shutterSpeedMax} onValueChange={(v) => setForm({ ...form, shutterSpeedMax: v })}>
-						<SelectTrigger>
-							<SelectValue placeholder="—" />
-						</SelectTrigger>
-						<SelectContent>
-							{filterSpeeds(form.shutterSpeedStops ? { stops: form.shutterSpeedStops as StopIncrement } : null).map(
-								(s) => (
-									<SelectItem key={s} value={s}>
-										{s}
-									</SelectItem>
-								),
-							)}
-						</SelectContent>
-					</Select>
-				</FormField>
-			</div>
-
-			<Button onClick={onSave} disabled={!form.brand && !form.model} className="w-full justify-center">
-				{isEdit ? (
-					<>
-						<Check size={16} /> {t("lenses.save")}
-					</>
-				) : (
-					<>
-						<Plus size={16} /> {t("lenses.add")}
-					</>
-				)}
-			</Button>
-
-			{isEdit && editLensId && (
-				<Button variant="destructive" onClick={() => sellLens(editLensId)} className="w-full justify-center">
-					<PackageX size={14} /> {t("lenses.sellLens")}
-				</Button>
-			)}
-		</div>
-	);
 
 	return (
 		<>
@@ -596,16 +248,7 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 				)}
 			</div>
 
-			{/* Add lens modal */}
-			<Dialog open={showAdd} onOpenChange={(open) => !open && setShowAdd(false)}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>{t("lenses.newLens")}</DialogTitle>
-						<DialogCloseButton />
-					</DialogHeader>
-					{renderForm(newLens, setNewLens, addLens, false)}
-				</DialogContent>
-			</Dialog>
+			<AddLensDialog open={showAdd} onOpenChange={setShowAdd} data={data} setData={setData} />
 
 			{/* Edit lens modal */}
 			<Dialog open={!!editLensId} onOpenChange={(open) => !open && setEditLensId(null)}>
@@ -614,7 +257,13 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 						<DialogTitle>{t("lenses.editLens")}</DialogTitle>
 						<DialogCloseButton />
 					</DialogHeader>
-					{renderForm(editLens, setEditLens, saveEditLens, true)}
+					<LensForm
+						form={editLens}
+						setForm={setEditLens}
+						onSave={saveEditLens}
+						isEdit={true}
+						onSell={editLensId ? () => sellLens(editLensId) : undefined}
+					/>
 				</DialogContent>
 			</Dialog>
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -562,7 +562,6 @@ export const en = {
 		lens: "Lens",
 		back: "Back",
 		quickShot: "Log a shot",
-		quickShotDisabled: "Load a film to start",
 	},
 
 	// Quick shot dialog

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -553,6 +553,38 @@ export const en = {
 		reload: "Reload",
 	},
 
+	// Floating action menu (FAB)
+	fab: {
+		openMenu: "Quick add menu",
+		title: "Add",
+		film: "Film",
+		camera: "Camera",
+		lens: "Lens",
+		back: "Back",
+		quickShot: "Log a shot",
+		quickShotDisabled: "Load a film to start",
+	},
+
+	// Quick shot dialog
+	quickShot: {
+		title: "Log a shot",
+		filmField: "Film",
+		filmPlaceholder: "Choose a loaded film…",
+		frameField: "Frame #",
+		apertureField: "Aperture",
+		shutterField: "Shutter",
+		lensField: "Lens",
+		noteField: "Note",
+		locationField: "Location",
+		photoField: "Photo",
+		save: "Save",
+		saveAndNext: "Save + next",
+		saved: "Shot saved",
+		emptyMessage: "No film currently loaded or partially exposed.",
+		addFilm: "Add a film",
+		cancel: "Cancel",
+	},
+
 	// App-level
 	app: {
 		loading: "Loading data…",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -562,7 +562,6 @@ export const fr = {
 		lens: "Objectif",
 		back: "Dos",
 		quickShot: "Noter une prise de vue",
-		quickShotDisabled: "Charge une pellicule pour commencer",
 	},
 
 	// Quick shot dialog

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -553,6 +553,38 @@ export const fr = {
 		reload: "Recharger",
 	},
 
+	// Floating action menu (FAB)
+	fab: {
+		openMenu: "Menu d'ajout rapide",
+		title: "Ajouter",
+		film: "Pellicule",
+		camera: "Appareil",
+		lens: "Objectif",
+		back: "Dos",
+		quickShot: "Noter une prise de vue",
+		quickShotDisabled: "Charge une pellicule pour commencer",
+	},
+
+	// Quick shot dialog
+	quickShot: {
+		title: "Noter une prise",
+		filmField: "Pellicule",
+		filmPlaceholder: "Choisir une pellicule chargée…",
+		frameField: "Vue n°",
+		apertureField: "Ouverture",
+		shutterField: "Vitesse",
+		lensField: "Objectif",
+		noteField: "Note",
+		locationField: "Lieu",
+		photoField: "Photo",
+		save: "Enregistrer",
+		saveAndNext: "Enregistrer + suivante",
+		saved: "Prise enregistrée",
+		emptyMessage: "Aucune pellicule chargée ou partiellement exposée.",
+		addFilm: "Ajouter une pellicule",
+		cancel: "Annuler",
+	},
+
 	// App-level
 	app: {
 		loading: "Chargement des données…",

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -17,3 +17,9 @@ export const currentMonthYear = (): string => {
 	const now = new Date();
 	return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
 };
+
+export const nowDateTimeLocal = (): string => {
+	const now = new Date();
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+};


### PR DESCRIPTION
New FAB in bottom-right opens a bottom-sheet grid with shortcuts to add a
film, camera, lens, or back, plus a highlighted "Log a shot" action that
records a ShotNote on any loaded or partial film and bumps posesShot. The
shot dialog pre-fills frame number and lens from the active film, keeps
them across "Save + next" for on-the-go logging, and falls back to an
"Add a film" prompt when no film is loaded.

Hidden on sub-screens (filmDetail/cameraDetail/settings/legal) and during
the onboarding tour. Equipment tab add-forms were extracted into
AddCameraDialog / AddLensDialog / AddBackDialog (with a shared LensForm)
so both the tab buttons and the FAB drive the same dialogs.

https://claude.ai/code/session_01D8YM5JUz95V8SU9xyJCiBt