### PR TITLE
feat(cameras): add interchangeable lens & manual controls flags

### DIFF
--- a/src/components/QuickShotDialog.tsx
+++ b/src/components/QuickShotDialog.tsx
@@ -14,7 +14,7 @@ import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/
 import type { AppData, ShotNote } from "@/types";
 import { filmName } from "@/utils/film-helpers";
 import { nowDateTimeLocal, uid } from "@/utils/helpers";
-import { lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
 
 interface QuickShotDialogProps {
 	open: boolean;
@@ -50,6 +50,9 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 	const currentFilm = filmId ? (data.films.find((f) => f.id === filmId) ?? null) : null;
 	const camera = currentFilm?.cameraId ? data.cameras.find((c) => c.id === currentFilm.cameraId) : null;
 	const selectedLens = lensId ? data.lenses.find((l) => l.id === lensId) : null;
+
+	const showManualFields = camera?.hasManualControls ?? true;
+	const showLensField = camera?.hasInterchangeableLens ?? true;
 
 	const speedConfig: ExposureConfig | null = selectedLens?.shutterSpeedMin
 		? { min: selectedLens.shutterSpeedMin, max: selectedLens.shutterSpeedMax, stops: selectedLens.shutterSpeedStops }
@@ -145,10 +148,10 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		return {
 			id: uid(),
 			frameNumber: Number.isNaN(fn) ? null : fn,
-			aperture: aperture || null,
-			shutterSpeed: shutterSpeed || null,
-			lens: resolvedLens,
-			lensId: lensId || null,
+			aperture: showManualFields ? aperture || null : null,
+			shutterSpeed: showManualFields ? shutterSpeed || null : null,
+			lens: showLensField ? resolvedLens : null,
+			lensId: showLensField ? lensId || null : null,
 			location: location || null,
 			latitude: lat != null && !Number.isNaN(lat) ? lat : null,
 			longitude: lng != null && !Number.isNaN(lng) ? lng : null,
@@ -216,7 +219,7 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		);
 	}
 
-	const visibleLenses = data.lenses.filter((l) => !l.soldAt || l.id === lensId);
+	const visibleLenses = filterLensesByMount(data.lenses, camera).filter((l) => !l.soldAt || l.id === lensId);
 
 	return (
 		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
@@ -258,49 +261,53 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 						/>
 					</FormField>
 
-					<div className="grid grid-cols-2 gap-3">
-						<AutocompleteInput
-							label={t("quickShot.apertureField")}
-							value={aperture}
-							onChange={setAperture}
-							suggestions={filteredApertures}
-							showAllOnFocus
-						/>
-						<AutocompleteInput
-							label={t("quickShot.shutterField")}
-							value={shutterSpeed}
-							onChange={setShutterSpeed}
-							suggestions={filteredSpeeds}
-							showAllOnFocus
-						/>
-					</div>
-
-					<FormField label={t("quickShot.lensField")}>
-						<div className="flex flex-col gap-2">
-							{visibleLenses.length > 0 && (
-								<Select value={lensId || "__other__"} onValueChange={(v) => setLensId(v === "__other__" ? "" : v)}>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{visibleLenses.map((l) => (
-											<SelectItem key={l.id} value={l.id}>
-												{lensDisplayName(l)}
-											</SelectItem>
-										))}
-										<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-									</SelectContent>
-								</Select>
-							)}
-							{!lensId && (
-								<Input
-									value={lens}
-									onChange={(e) => setLens(e.target.value)}
-									placeholder={t("filmDetail.shotNotesLensPlaceholder")}
-								/>
-							)}
+					{showManualFields && (
+						<div className="grid grid-cols-2 gap-3">
+							<AutocompleteInput
+								label={t("quickShot.apertureField")}
+								value={aperture}
+								onChange={setAperture}
+								suggestions={filteredApertures}
+								showAllOnFocus
+							/>
+							<AutocompleteInput
+								label={t("quickShot.shutterField")}
+								value={shutterSpeed}
+								onChange={setShutterSpeed}
+								suggestions={filteredSpeeds}
+								showAllOnFocus
+							/>
 						</div>
-					</FormField>
+					)}
+
+					{showLensField && (
+						<FormField label={t("quickShot.lensField")}>
+							<div className="flex flex-col gap-2">
+								{visibleLenses.length > 0 && (
+									<Select value={lensId || "__other__"} onValueChange={(v) => setLensId(v === "__other__" ? "" : v)}>
+										<SelectTrigger>
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{visibleLenses.map((l) => (
+												<SelectItem key={l.id} value={l.id}>
+													{lensDisplayName(l)}
+												</SelectItem>
+											))}
+											<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+										</SelectContent>
+									</Select>
+								)}
+								{!lensId && (
+									<Input
+										value={lens}
+										onChange={(e) => setLens(e.target.value)}
+										placeholder={t("filmDetail.shotNotesLensPlaceholder")}
+									/>
+								)}
+							</div>
+						</FormField>
+					)}
 
 					<FormField label={t("quickShot.noteField")}>
 						<Textarea value={notes} onChange={(e) => setNotes(e.target.value)} />

--- a/src/components/QuickShotDialog.tsx
+++ b/src/components/QuickShotDialog.tsx
@@ -219,7 +219,9 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		);
 	}
 
-	const visibleLenses = filterLensesByMount(data.lenses, camera).filter((l) => !l.soldAt || l.id === lensId);
+	// Always preserve the currently-selected lens in the dropdown options, even if its
+	// mount doesn't match (or is unset), so the Select value can never become orphaned.
+	const visibleLenses = filterLensesByMount(data.lenses, camera, lensId).filter((l) => !l.soldAt || l.id === lensId);
 
 	return (
 		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>

--- a/src/components/ShotNotesSection.tsx
+++ b/src/components/ShotNotesSection.tsx
@@ -374,7 +374,9 @@ function ShotNotesSection({
 							<FormField label={t("filmDetail.shotNotesLens")}>
 								{(() => {
 									const allLenses = lenses ?? [];
-									const filteredByMount = filterLensesByMount(allLenses, camera);
+									// Preserve the currently-selected lens even if its mount doesn't match the
+									// camera (or is unset), so the Select value never becomes orphaned.
+									const filteredByMount = filterLensesByMount(allLenses, camera, form.lensId);
 									const visibleLenses = filteredByMount.filter((l) => !l.soldAt || l.id === form.lensId);
 									if (visibleLenses.length === 0) {
 										return (

--- a/src/components/ShotNotesSection.tsx
+++ b/src/components/ShotNotesSection.tsx
@@ -16,7 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/photography";
 import type { Camera, Film, Lens, ShotNote } from "@/types";
 import { nowDateTimeLocal, uid } from "@/utils/helpers";
-import { lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
 
 interface ShotNotesSectionProps {
 	film: Film;
@@ -138,6 +138,9 @@ function ShotNotesSection({
 	const camera = cameras?.find((c) => c.id === film.cameraId);
 	const selectedLens = form.lensId ? lenses?.find((l) => l.id === form.lensId) : null;
 
+	const showManualFields = camera?.hasManualControls ?? true;
+	const showLensField = camera?.hasInterchangeableLens ?? true;
+
 	// Speed config: lens (leaf shutter) takes priority over camera
 	const speedConfig: ExposureConfig | null = selectedLens?.shutterSpeedMin
 		? { min: selectedLens.shutterSpeedMin, max: selectedLens.shutterSpeedMax, stops: selectedLens.shutterSpeedStops }
@@ -186,7 +189,14 @@ function ShotNotesSection({
 	};
 
 	const handleSave = () => {
-		const note = formToNote(form, editingId ?? undefined);
+		const baseNote = formToNote(form, editingId ?? undefined);
+		const note: ShotNote = {
+			...baseNote,
+			aperture: showManualFields ? baseNote.aperture : null,
+			shutterSpeed: showManualFields ? baseNote.shutterSpeed : null,
+			lens: showLensField ? baseNote.lens : null,
+			lensId: showLensField ? baseNote.lensId : null,
+		};
 		const hasContent =
 			note.frameNumber != null ||
 			note.aperture ||
@@ -339,78 +349,84 @@ function ShotNotesSection({
 							/>
 						</FormField>
 
-						<div className="grid grid-cols-2 gap-3">
-							<AutocompleteInput
-								label={t("filmDetail.shotNotesAperture")}
-								placeholder={t("filmDetail.shotNotesAperturePlaceholder")}
-								value={form.aperture}
-								onChange={(v) => updateField("aperture", v)}
-								suggestions={filteredApertures}
-								showAllOnFocus
-							/>
-							<AutocompleteInput
-								label={t("filmDetail.shotNotesShutter")}
-								placeholder={t("filmDetail.shotNotesShutterPlaceholder")}
-								value={form.shutterSpeed}
-								onChange={(v) => updateField("shutterSpeed", v)}
-								suggestions={filteredSpeeds}
-								showAllOnFocus
-							/>
-						</div>
+						{showManualFields && (
+							<div className="grid grid-cols-2 gap-3">
+								<AutocompleteInput
+									label={t("filmDetail.shotNotesAperture")}
+									placeholder={t("filmDetail.shotNotesAperturePlaceholder")}
+									value={form.aperture}
+									onChange={(v) => updateField("aperture", v)}
+									suggestions={filteredApertures}
+									showAllOnFocus
+								/>
+								<AutocompleteInput
+									label={t("filmDetail.shotNotesShutter")}
+									placeholder={t("filmDetail.shotNotesShutterPlaceholder")}
+									value={form.shutterSpeed}
+									onChange={(v) => updateField("shutterSpeed", v)}
+									suggestions={filteredSpeeds}
+									showAllOnFocus
+								/>
+							</div>
+						)}
 
-						<FormField label={t("filmDetail.shotNotesLens")}>
-							{(() => {
-								const visibleLenses = lenses?.filter((l) => !l.soldAt || l.id === form.lensId) ?? [];
-								if (visibleLenses.length === 0) {
-									return (
-										<Input
-											placeholder={t("filmDetail.shotNotesLensPlaceholder")}
-											value={form.lens}
-											onChange={(e) => updateField("lens", e.target.value)}
-										/>
-									);
-								}
-								return (
-									<>
-										<Select
-											value={form.lensId || "__other__"}
-											onValueChange={(v) => {
-												if (v === "__other__") {
-													setForm((prev) => ({ ...prev, lensId: "", lens: "" }));
-												} else {
-													const lens = lenses?.find((l) => l.id === v);
-													setForm((prev) => ({
-														...prev,
-														lensId: v,
-														lens: lens ? lensDisplayName(lens) : "",
-													}));
-												}
-											}}
-										>
-											<SelectTrigger>
-												<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
-											</SelectTrigger>
-											<SelectContent>
-												{visibleLenses.map((l) => (
-													<SelectItem key={l.id} value={l.id}>
-														{lensDisplayName(l)}
-													</SelectItem>
-												))}
-												<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-											</SelectContent>
-										</Select>
-										{!form.lensId && (
+						{showLensField && (
+							<FormField label={t("filmDetail.shotNotesLens")}>
+								{(() => {
+									const allLenses = lenses ?? [];
+									const filteredByMount = filterLensesByMount(allLenses, camera);
+									const visibleLenses = filteredByMount.filter((l) => !l.soldAt || l.id === form.lensId);
+									if (visibleLenses.length === 0) {
+										return (
 											<Input
 												placeholder={t("filmDetail.shotNotesLensPlaceholder")}
 												value={form.lens}
 												onChange={(e) => updateField("lens", e.target.value)}
-												className="mt-2"
 											/>
-										)}
-									</>
-								);
-							})()}
-						</FormField>
+										);
+									}
+									return (
+										<>
+											<Select
+												value={form.lensId || "__other__"}
+												onValueChange={(v) => {
+													if (v === "__other__") {
+														setForm((prev) => ({ ...prev, lensId: "", lens: "" }));
+													} else {
+														const lens = lenses?.find((l) => l.id === v);
+														setForm((prev) => ({
+															...prev,
+															lensId: v,
+															lens: lens ? lensDisplayName(lens) : "",
+														}));
+													}
+												}}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
+												</SelectTrigger>
+												<SelectContent>
+													{visibleLenses.map((l) => (
+														<SelectItem key={l.id} value={l.id}>
+															{lensDisplayName(l)}
+														</SelectItem>
+													))}
+													<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+												</SelectContent>
+											</Select>
+											{!form.lensId && (
+												<Input
+													placeholder={t("filmDetail.shotNotesLensPlaceholder")}
+													value={form.lens}
+													onChange={(e) => updateField("lens", e.target.value)}
+													className="mt-2"
+												/>
+											)}
+										</>
+									);
+								})()}
+							</FormField>
+						)}
 
 						<FormField label={t("filmDetail.shotNotesLocation")}>
 							<div className="flex gap-2">

--- a/src/components/equipment/AddCameraDialog.tsx
+++ b/src/components/equipment/AddCameraDialog.tsx
@@ -27,6 +27,8 @@ const emptyCam = {
 	format: "35mm",
 	mount: "",
 	hasInterchangeableBack: false,
+	hasInterchangeableLens: true,
+	hasManualControls: true,
 	photo: undefined as string | undefined,
 	shutterSpeedMin: "" as string,
 	shutterSpeedMax: "" as string,
@@ -51,13 +53,15 @@ export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCamera
 			nickname: newCam.nickname,
 			serial: newCam.serial,
 			format: newCam.format,
-			mount: newCam.mount || null,
+			mount: newCam.hasInterchangeableLens ? newCam.mount || null : null,
 			hasInterchangeableBack: newCam.hasInterchangeableBack || false,
+			hasInterchangeableLens: newCam.hasInterchangeableLens,
+			hasManualControls: newCam.hasManualControls,
 			photo: newCam.photo,
-			shutterSpeedMin: newCam.shutterSpeedMin || null,
-			shutterSpeedMax: newCam.shutterSpeedMax || null,
-			shutterSpeedStops: (newCam.shutterSpeedStops as StopIncrement) || null,
-			apertureStops: (newCam.apertureStops as StopIncrement) || null,
+			shutterSpeedMin: newCam.hasManualControls ? newCam.shutterSpeedMin || null : null,
+			shutterSpeedMax: newCam.hasManualControls ? newCam.shutterSpeedMax || null : null,
+			shutterSpeedStops: newCam.hasManualControls ? (newCam.shutterSpeedStops as StopIncrement) || null : null,
+			apertureStops: newCam.hasManualControls ? (newCam.apertureStops as StopIncrement) || null : null,
 		};
 		setData({ ...data, cameras: [...data.cameras, camera] });
 		onOpenChange(false);
@@ -123,13 +127,33 @@ export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCamera
 							</SelectContent>
 						</Select>
 					</FormField>
-					<FormField label={t("cameras.mount")}>
-						<Input
-							value={newCam.mount}
-							onChange={(e) => setNewCam({ ...newCam, mount: e.target.value })}
-							placeholder={t("cameras.mountPlaceholder")}
+					<div className="flex items-center justify-between gap-3">
+						<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+							{t("cameras.interchangeableLens")}
+						</label>
+						<Switch
+							checked={newCam.hasInterchangeableLens}
+							onCheckedChange={(v) => setNewCam({ ...newCam, hasInterchangeableLens: v })}
 						/>
-					</FormField>
+					</div>
+					{newCam.hasInterchangeableLens && (
+						<FormField label={t("cameras.mount")}>
+							<Input
+								value={newCam.mount}
+								onChange={(e) => setNewCam({ ...newCam, mount: e.target.value })}
+								placeholder={t("cameras.mountPlaceholder")}
+							/>
+						</FormField>
+					)}
+					<div className="flex items-center justify-between gap-3">
+						<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+							{t("cameras.manualControls")}
+						</label>
+						<Switch
+							checked={newCam.hasManualControls}
+							onCheckedChange={(v) => setNewCam({ ...newCam, hasManualControls: v })}
+						/>
+					</div>
 					<div className="flex items-center justify-between gap-3">
 						<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
 							{t("cameras.interchangeableBack")}
@@ -140,76 +164,83 @@ export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCamera
 						/>
 					</div>
 
-					<div className="border-t border-border pt-4 mt-1">
-						<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-							{t("cameras.exposureSection")}
-						</span>
-					</div>
-					<div className="grid grid-cols-2 gap-3">
-						<FormField label={t("cameras.shutterSpeedMin")}>
-							<Select
-								value={newCam.shutterSpeedMin}
-								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMin: v })}
-							>
-								<SelectTrigger>
-									<SelectValue placeholder="—" />
-								</SelectTrigger>
-								<SelectContent>
-									{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-										<SelectItem key={s} value={s}>
-											{s}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</FormField>
-						<FormField label={t("cameras.shutterSpeedMax")}>
-							<Select
-								value={newCam.shutterSpeedMax}
-								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMax: v })}
-							>
-								<SelectTrigger>
-									<SelectValue placeholder="—" />
-								</SelectTrigger>
-								<SelectContent>
-									{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-										<SelectItem key={s} value={s}>
-											{s}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</FormField>
-					</div>
-					<div className="grid grid-cols-2 gap-3">
-						<FormField label={t("cameras.shutterSpeedStops")}>
-							<Select
-								value={newCam.shutterSpeedStops}
-								onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedStops: v })}
-							>
-								<SelectTrigger>
-									<SelectValue placeholder="—" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-									<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-									<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-								</SelectContent>
-							</Select>
-						</FormField>
-						<FormField label={t("cameras.apertureStops")}>
-							<Select value={newCam.apertureStops} onValueChange={(v) => setNewCam({ ...newCam, apertureStops: v })}>
-								<SelectTrigger>
-									<SelectValue placeholder="—" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-									<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-									<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-								</SelectContent>
-							</Select>
-						</FormField>
-					</div>
+					{newCam.hasManualControls && (
+						<>
+							<div className="border-t border-border pt-4 mt-1">
+								<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+									{t("cameras.exposureSection")}
+								</span>
+							</div>
+							<div className="grid grid-cols-2 gap-3">
+								<FormField label={t("cameras.shutterSpeedMin")}>
+									<Select
+										value={newCam.shutterSpeedMin}
+										onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMin: v })}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="—" />
+										</SelectTrigger>
+										<SelectContent>
+											{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+												<SelectItem key={s} value={s}>
+													{s}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</FormField>
+								<FormField label={t("cameras.shutterSpeedMax")}>
+									<Select
+										value={newCam.shutterSpeedMax}
+										onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedMax: v })}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="—" />
+										</SelectTrigger>
+										<SelectContent>
+											{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+												<SelectItem key={s} value={s}>
+													{s}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</FormField>
+							</div>
+							<div className="grid grid-cols-2 gap-3">
+								<FormField label={t("cameras.shutterSpeedStops")}>
+									<Select
+										value={newCam.shutterSpeedStops}
+										onValueChange={(v) => setNewCam({ ...newCam, shutterSpeedStops: v })}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="—" />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+											<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+											<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+										</SelectContent>
+									</Select>
+								</FormField>
+								<FormField label={t("cameras.apertureStops")}>
+									<Select
+										value={newCam.apertureStops}
+										onValueChange={(v) => setNewCam({ ...newCam, apertureStops: v })}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="—" />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+											<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+											<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+										</SelectContent>
+									</Select>
+								</FormField>
+							</div>
+						</>
+					)}
 
 					<Button onClick={addCamera} disabled={!newCam.brand && !newCam.model} className="w-full justify-center">
 						<Plus size={16} /> {t("cameras.add")}

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -40,6 +40,8 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 
 	const saveEditCamera = () => {
 		if (!editCam?.brand && !editCam?.model) return;
+		const hasLens = editCam.hasInterchangeableLens ?? true;
+		const hasManual = editCam.hasManualControls ?? true;
 		const newCams = data.cameras.map((c) =>
 			c.id === editCam.id
 				? {
@@ -49,13 +51,15 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 						nickname: editCam.nickname,
 						serial: editCam.serial,
 						format: editCam.format,
-						mount: editCam.mount || null,
+						mount: hasLens ? editCam.mount || null : null,
 						hasInterchangeableBack: editCam.hasInterchangeableBack || false,
+						hasInterchangeableLens: hasLens,
+						hasManualControls: hasManual,
 						photo: editCam.photo,
-						shutterSpeedMin: editCam.shutterSpeedMin || null,
-						shutterSpeedMax: editCam.shutterSpeedMax || null,
-						shutterSpeedStops: editCam.shutterSpeedStops || null,
-						apertureStops: editCam.apertureStops || null,
+						shutterSpeedMin: hasManual ? editCam.shutterSpeedMin || null : null,
+						shutterSpeedMax: hasManual ? editCam.shutterSpeedMax || null : null,
+						shutterSpeedStops: hasManual ? editCam.shutterSpeedStops || null : null,
+						apertureStops: hasManual ? editCam.apertureStops || null : null,
 					}
 				: c,
 		);
@@ -353,13 +357,33 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 									</SelectContent>
 								</Select>
 							</FormField>
-							<FormField label={t("cameras.mount")}>
-								<Input
-									value={editCam.mount || ""}
-									onChange={(e) => setEditCam({ ...editCam, mount: e.target.value })}
-									placeholder={t("cameras.mountPlaceholder")}
+							<div className="flex items-center justify-between gap-3">
+								<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+									{t("cameras.interchangeableLens")}
+								</label>
+								<Switch
+									checked={editCam.hasInterchangeableLens ?? true}
+									onCheckedChange={(v) => setEditCam({ ...editCam, hasInterchangeableLens: v })}
 								/>
-							</FormField>
+							</div>
+							{(editCam.hasInterchangeableLens ?? true) && (
+								<FormField label={t("cameras.mount")}>
+									<Input
+										value={editCam.mount || ""}
+										onChange={(e) => setEditCam({ ...editCam, mount: e.target.value })}
+										placeholder={t("cameras.mountPlaceholder")}
+									/>
+								</FormField>
+							)}
+							<div className="flex items-center justify-between gap-3">
+								<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+									{t("cameras.manualControls")}
+								</label>
+								<Switch
+									checked={editCam.hasManualControls ?? true}
+									onCheckedChange={(v) => setEditCam({ ...editCam, hasManualControls: v })}
+								/>
+							</div>
 							<div className="flex items-center justify-between gap-3">
 								<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
 									{t("cameras.interchangeableBack")}
@@ -370,79 +394,85 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 								/>
 							</div>
 
-							<div className="border-t border-border pt-4 mt-1">
-								<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
-									{t("cameras.exposureSection")}
-								</span>
-							</div>
-							<div className="grid grid-cols-2 gap-3">
-								<FormField label={t("cameras.shutterSpeedMin")}>
-									<Select
-										value={editCam.shutterSpeedMin || ""}
-										onValueChange={(v) => setEditCam({ ...editCam, shutterSpeedMin: v || null })}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder="—" />
-										</SelectTrigger>
-										<SelectContent>
-											{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-												<SelectItem key={s} value={s}>
-													{s}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</FormField>
-								<FormField label={t("cameras.shutterSpeedMax")}>
-									<Select
-										value={editCam.shutterSpeedMax || ""}
-										onValueChange={(v) => setEditCam({ ...editCam, shutterSpeedMax: v || null })}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder="—" />
-										</SelectTrigger>
-										<SelectContent>
-											{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
-												<SelectItem key={s} value={s}>
-													{s}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</FormField>
-							</div>
-							<div className="grid grid-cols-2 gap-3">
-								<FormField label={t("cameras.shutterSpeedStops")}>
-									<Select
-										value={editCam.shutterSpeedStops || ""}
-										onValueChange={(v) => setEditCam({ ...editCam, shutterSpeedStops: (v as StopIncrement) || null })}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder="—" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-											<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-											<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-										</SelectContent>
-									</Select>
-								</FormField>
-								<FormField label={t("cameras.apertureStops")}>
-									<Select
-										value={editCam.apertureStops || ""}
-										onValueChange={(v) => setEditCam({ ...editCam, apertureStops: (v as StopIncrement) || null })}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder="—" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
-											<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
-											<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
-										</SelectContent>
-									</Select>
-								</FormField>
-							</div>
+							{(editCam.hasManualControls ?? true) && (
+								<>
+									<div className="border-t border-border pt-4 mt-1">
+										<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">
+											{t("cameras.exposureSection")}
+										</span>
+									</div>
+									<div className="grid grid-cols-2 gap-3">
+										<FormField label={t("cameras.shutterSpeedMin")}>
+											<Select
+												value={editCam.shutterSpeedMin || ""}
+												onValueChange={(v) => setEditCam({ ...editCam, shutterSpeedMin: v || null })}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="—" />
+												</SelectTrigger>
+												<SelectContent>
+													{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+														<SelectItem key={s} value={s}>
+															{s}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormField>
+										<FormField label={t("cameras.shutterSpeedMax")}>
+											<Select
+												value={editCam.shutterSpeedMax || ""}
+												onValueChange={(v) => setEditCam({ ...editCam, shutterSpeedMax: v || null })}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="—" />
+												</SelectTrigger>
+												<SelectContent>
+													{SHUTTER_SPEEDS.filter((_, i) => i % 3 === 0).map((s) => (
+														<SelectItem key={s} value={s}>
+															{s}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormField>
+									</div>
+									<div className="grid grid-cols-2 gap-3">
+										<FormField label={t("cameras.shutterSpeedStops")}>
+											<Select
+												value={editCam.shutterSpeedStops || ""}
+												onValueChange={(v) =>
+													setEditCam({ ...editCam, shutterSpeedStops: (v as StopIncrement) || null })
+												}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="—" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+													<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+													<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+												</SelectContent>
+											</Select>
+										</FormField>
+										<FormField label={t("cameras.apertureStops")}>
+											<Select
+												value={editCam.apertureStops || ""}
+												onValueChange={(v) => setEditCam({ ...editCam, apertureStops: (v as StopIncrement) || null })}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="—" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="1">{t("cameras.stopsFull")}</SelectItem>
+													<SelectItem value="1/2">{t("cameras.stopsHalf")}</SelectItem>
+													<SelectItem value="1/3">{t("cameras.stopsThird")}</SelectItem>
+												</SelectContent>
+											</Select>
+										</FormField>
+									</div>
+								</>
+							)}
 
 							<Button
 								onClick={saveEditCamera}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -423,6 +423,8 @@ export const en = {
 		mount: "Mount",
 		mountPlaceholder: "E.g.: Canon EF, Nikon F…",
 		interchangeableBack: "Interchangeable back",
+		interchangeableLens: "Interchangeable lens",
+		manualControls: "Manual controls",
 		photo: "Photo",
 		backs: "backs",
 		loaded_one: "{{count}} loaded",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -423,6 +423,8 @@ export const fr = {
 		mount: "Monture",
 		mountPlaceholder: "Ex : Canon EF, Nikon F…",
 		interchangeableBack: "Dos interchangeable",
+		interchangeableLens: "Objectif interchangeable",
+		manualControls: "Réglages manuels",
 		photo: "Photo",
 		backs: "dos",
 		loaded_one: "{{count}} chargée",

--- a/src/screens/camera-detail/CameraInfoSection.tsx
+++ b/src/screens/camera-detail/CameraInfoSection.tsx
@@ -1,4 +1,4 @@
-import { Aperture, Camera as CameraIcon, Gauge, Hash, Layers, PackageX, Puzzle, Tag } from "lucide-react";
+import { Aperture, Camera as CameraIcon, Gauge, Hash, Layers, PackageX, Puzzle, Settings2, Tag } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { InfoLine } from "@/components/InfoLine";
 import type { Camera } from "@/types";
@@ -24,6 +24,8 @@ export function CameraInfoSection({ camera }: CameraInfoSectionProps) {
 			: null;
 	const shutterStops = stopsLabel(camera.shutterSpeedStops, t);
 	const apertureStops = stopsLabel(camera.apertureStops, t);
+	const hasInterchangeableLens = camera.hasInterchangeableLens ?? true;
+	const hasManualControls = camera.hasManualControls ?? true;
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -32,13 +34,31 @@ export function CameraInfoSection({ camera }: CameraInfoSectionProps) {
 			{camera.nickname && <InfoLine icon={Hash} label={t("cameras.nickname")} value={camera.nickname} />}
 			{camera.serial && <InfoLine icon={Hash} label={t("cameras.serial")} value={camera.serial} />}
 			{camera.format && <InfoLine icon={Layers} label={t("cameras.format")} value={camera.format} />}
-			{camera.mount && <InfoLine icon={Puzzle} label={t("cameras.mount")} value={camera.mount} />}
+			<InfoLine
+				icon={Puzzle}
+				label={t("cameras.interchangeableLens")}
+				value={hasInterchangeableLens ? t("common.yes") : t("common.no")}
+			/>
+			{hasInterchangeableLens && camera.mount && (
+				<InfoLine icon={Puzzle} label={t("cameras.mount")} value={camera.mount} />
+			)}
+			<InfoLine
+				icon={Settings2}
+				label={t("cameras.manualControls")}
+				value={hasManualControls ? t("common.yes") : t("common.no")}
+			/>
 			{camera.hasInterchangeableBack && (
 				<InfoLine icon={Puzzle} label={t("cameras.interchangeableBack")} value={t("common.yes")} />
 			)}
-			{shutterRange && <InfoLine icon={Gauge} label={t("cameraDetail.shutterRange")} value={shutterRange} />}
-			{shutterStops && <InfoLine icon={Gauge} label={t("cameras.shutterSpeedStops")} value={shutterStops} />}
-			{apertureStops && <InfoLine icon={Aperture} label={t("cameras.apertureStops")} value={apertureStops} />}
+			{hasManualControls && shutterRange && (
+				<InfoLine icon={Gauge} label={t("cameraDetail.shutterRange")} value={shutterRange} />
+			)}
+			{hasManualControls && shutterStops && (
+				<InfoLine icon={Gauge} label={t("cameras.shutterSpeedStops")} value={shutterStops} />
+			)}
+			{hasManualControls && apertureStops && (
+				<InfoLine icon={Aperture} label={t("cameras.apertureStops")} value={apertureStops} />
+			)}
 			{camera.soldAt && (
 				<InfoLine icon={PackageX} label={t("cameraDetail.archivedOn")} value={fmtDate(camera.soldAt)} />
 			)}

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -16,7 +16,7 @@ import { type AppData, type Back, type Camera, type Film, isInstantFormat } from
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 import { collectAllTags } from "@/utils/film-helpers";
 import { today } from "@/utils/helpers";
-import { lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
 import type { ActionType, EditData } from "./types";
 
 interface EditModalProps {
@@ -60,9 +60,15 @@ export function EditModal({
 }: EditModalProps) {
 	const { t } = useTranslation();
 
+	const selectedCamera = editData.cameraId ? data.cameras.find((c) => c.id === editData.cameraId) : null;
+	const showLensField = selectedCamera?.hasInterchangeableLens ?? true;
+
 	// Include the currently-selected lens even if sold, so editing a film that references
 	// an archived lens still shows the correct Select value (instead of rendering blank).
-	const visibleLenses = data.lenses.filter((l) => !l.soldAt || l.id === editData.lensId);
+	// Filter by camera mount when both camera and lenses have a mount defined.
+	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera).filter(
+		(l) => !l.soldAt || l.id === editData.lensId,
+	);
 
 	return (
 		<Dialog open={showAction === "edit"} onOpenChange={(open) => !open && closeAction()}>
@@ -203,53 +209,55 @@ export function EditModal({
 									</Select>
 								</FormField>
 							)}
-							<FormField label={t("filmDetail.lensField")}>
-								{visibleLenses.length > 0 ? (
-									<>
-										<Select
-											value={editData.lensId || "__other__"}
-											onValueChange={(v) => {
-												if (v === "__other__") {
-													setEditData({ ...editData, lensId: "", lens: "" });
-												} else {
-													const lens = data.lenses.find((l) => l.id === v);
-													setEditData({
-														...editData,
-														lensId: v,
-														lens: lens ? lensDisplayName(lens) : "",
-													});
-												}
-											}}
-										>
-											<SelectTrigger>
-												<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
-											</SelectTrigger>
-											<SelectContent>
-												{visibleLenses.map((l) => (
-													<SelectItem key={l.id} value={l.id}>
-														{lensDisplayName(l)}
-													</SelectItem>
-												))}
-												<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-											</SelectContent>
-										</Select>
-										{!editData.lensId && (
-											<Input
-												value={editData.lens}
-												onChange={(e) => setEditData({ ...editData, lens: e.target.value })}
-												placeholder={t("filmDetail.lensPlaceholder")}
-												className="mt-2"
-											/>
-										)}
-									</>
-								) : (
-									<Input
-										value={editData.lens}
-										onChange={(e) => setEditData({ ...editData, lens: e.target.value })}
-										placeholder={t("filmDetail.lensPlaceholder")}
-									/>
-								)}
-							</FormField>
+							{showLensField && (
+								<FormField label={t("filmDetail.lensField")}>
+									{visibleLenses.length > 0 ? (
+										<>
+											<Select
+												value={editData.lensId || "__other__"}
+												onValueChange={(v) => {
+													if (v === "__other__") {
+														setEditData({ ...editData, lensId: "", lens: "" });
+													} else {
+														const lens = data.lenses.find((l) => l.id === v);
+														setEditData({
+															...editData,
+															lensId: v,
+															lens: lens ? lensDisplayName(lens) : "",
+														});
+													}
+												}}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
+												</SelectTrigger>
+												<SelectContent>
+													{visibleLenses.map((l) => (
+														<SelectItem key={l.id} value={l.id}>
+															{lensDisplayName(l)}
+														</SelectItem>
+													))}
+													<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+												</SelectContent>
+											</Select>
+											{!editData.lensId && (
+												<Input
+													value={editData.lens}
+													onChange={(e) => setEditData({ ...editData, lens: e.target.value })}
+													placeholder={t("filmDetail.lensPlaceholder")}
+													className="mt-2"
+												/>
+											)}
+										</>
+									) : (
+										<Input
+											value={editData.lens}
+											onChange={(e) => setEditData({ ...editData, lens: e.target.value })}
+											placeholder={t("filmDetail.lensPlaceholder")}
+										/>
+									)}
+								</FormField>
+							)}
 							<FormField label={t("filmDetail.shootIsoField")}>
 								<Input
 									type="number"
@@ -448,8 +456,8 @@ export function EditModal({
 							if (showLoading) {
 								editUpdate.cameraId = editData.cameraId || null;
 								editUpdate.backId = editData.backId || null;
-								editUpdate.lensId = editData.lensId || null;
-								editUpdate.lens = editData.lens.trim() || null;
+								editUpdate.lensId = showLensField ? editData.lensId || null : null;
+								editUpdate.lens = showLensField ? editData.lens.trim() || null : null;
 								editUpdate.shootIso = editData.shootIso.trim() ? safeInt(editData.shootIso) : null;
 								editUpdate.startDate = editData.startDate || null;
 								editUpdate.posesTotal = editData.posesTotal.trim() ? safeInt(editData.posesTotal) : null;

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -63,10 +63,10 @@ export function EditModal({
 	const selectedCamera = editData.cameraId ? data.cameras.find((c) => c.id === editData.cameraId) : null;
 	const showLensField = selectedCamera?.hasInterchangeableLens ?? true;
 
-	// Include the currently-selected lens even if sold, so editing a film that references
-	// an archived lens still shows the correct Select value (instead of rendering blank).
-	// Filter by camera mount when both camera and lenses have a mount defined.
-	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera).filter(
+	// Include the currently-selected lens even if sold or if its mount doesn't match the
+	// camera's mount, so editing a film that references such a lens still shows the correct
+	// Select value (instead of rendering blank or silently overwriting the existing choice).
+	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera, editData.lensId).filter(
 		(l) => !l.soldAt || l.id === editData.lensId,
 	);
 

--- a/src/screens/film-detail/TransitionModals.tsx
+++ b/src/screens/film-detail/TransitionModals.tsx
@@ -9,7 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { T } from "@/constants/theme";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 import { today } from "@/utils/helpers";
-import { lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
 import type { ModalBaseProps } from "./types";
 
 export function TransitionModals({
@@ -25,9 +25,14 @@ export function TransitionModals({
 	fIso,
 }: ModalBaseProps) {
 	const { t } = useTranslation();
+	const selectedCamera = actionData.cameraId ? data.cameras.find((c) => c.id === actionData.cameraId) : null;
+	const showLensField = selectedCamera?.hasInterchangeableLens ?? true;
 	// Include the currently-selected lens even if sold, so reloading or continuing a film that
 	// references an archived lens still renders the Select with the correct value.
-	const visibleLenses = data.lenses.filter((l) => !l.soldAt || l.id === actionData.lensId);
+	// Filter by camera mount when the selected camera has a mount defined.
+	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera).filter(
+		(l) => !l.soldAt || l.id === actionData.lensId,
+	);
 
 	return (
 		<>
@@ -75,53 +80,55 @@ export function TransitionModals({
 								</Select>
 							</FormField>
 						)}
-						<FormField label={t("filmDetail.lensField")}>
-							{visibleLenses.length > 0 ? (
-								<>
-									<Select
-										value={actionData.lensId || "__other__"}
-										onValueChange={(v) => {
-											if (v === "__other__") {
-												setActionData({ ...actionData, lensId: undefined, lens: "" });
-											} else {
-												const lens = data.lenses.find((l) => l.id === v);
-												setActionData({
-													...actionData,
-													lensId: v,
-													lens: lens ? lensDisplayName(lens) : "",
-												});
-											}
-										}}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
-										</SelectTrigger>
-										<SelectContent>
-											{visibleLenses.map((l) => (
-												<SelectItem key={l.id} value={l.id}>
-													{lensDisplayName(l)}
-												</SelectItem>
-											))}
-											<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-										</SelectContent>
-									</Select>
-									{!actionData.lensId && (
-										<Input
-											value={actionData.lens || ""}
-											onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
-											placeholder={t("filmDetail.lensPlaceholder")}
-											className="mt-2"
-										/>
-									)}
-								</>
-							) : (
-								<Input
-									value={actionData.lens || ""}
-									onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
-									placeholder={t("filmDetail.lensPlaceholder")}
-								/>
-							)}
-						</FormField>
+						{showLensField && (
+							<FormField label={t("filmDetail.lensField")}>
+								{visibleLenses.length > 0 ? (
+									<>
+										<Select
+											value={actionData.lensId || "__other__"}
+											onValueChange={(v) => {
+												if (v === "__other__") {
+													setActionData({ ...actionData, lensId: undefined, lens: "" });
+												} else {
+													const lens = data.lenses.find((l) => l.id === v);
+													setActionData({
+														...actionData,
+														lensId: v,
+														lens: lens ? lensDisplayName(lens) : "",
+													});
+												}
+											}}
+										>
+											<SelectTrigger>
+												<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
+											</SelectTrigger>
+											<SelectContent>
+												{visibleLenses.map((l) => (
+													<SelectItem key={l.id} value={l.id}>
+														{lensDisplayName(l)}
+													</SelectItem>
+												))}
+												<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+											</SelectContent>
+										</Select>
+										{!actionData.lensId && (
+											<Input
+												value={actionData.lens || ""}
+												onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
+												placeholder={t("filmDetail.lensPlaceholder")}
+												className="mt-2"
+											/>
+										)}
+									</>
+								) : (
+									<Input
+										value={actionData.lens || ""}
+										onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
+										placeholder={t("filmDetail.lensPlaceholder")}
+									/>
+								)}
+							</FormField>
+						)}
 						<FormField label={t("filmDetail.shootIsoField")}>
 							<Input
 								type="number"
@@ -155,13 +162,14 @@ export function TransitionModals({
 							onClick={() => {
 								const loadCam = data.cameras.find((c) => c.id === actionData.cameraId);
 								const photos = actionData.photos?.length ? actionData.photos : undefined;
+								const camHasLens = loadCam?.hasInterchangeableLens ?? true;
 								updateFilm(
 									{
 										state: "loaded",
 										cameraId: actionData.cameraId,
 										backId: actionData.backId || null,
-										lensId: actionData.lensId || null,
-										lens: actionData.lens?.trim() || null,
+										lensId: camHasLens ? actionData.lensId || null : null,
+										lens: camHasLens ? actionData.lens?.trim() || null : null,
 										shootIso: Number.parseInt(actionData.shootIso || "", 10) || (typeof fIso === "number" ? fIso : 0),
 										startDate: actionData.startDate || today(),
 										comment: actionData.comment?.trim() || film.comment,
@@ -352,53 +360,55 @@ export function TransitionModals({
 								</Select>
 							</FormField>
 						)}
-						<FormField label={t("filmDetail.lensField")}>
-							{visibleLenses.length > 0 ? (
-								<>
-									<Select
-										value={actionData.lensId || "__other__"}
-										onValueChange={(v) => {
-											if (v === "__other__") {
-												setActionData({ ...actionData, lensId: undefined, lens: "" });
-											} else {
-												const lens = data.lenses.find((l) => l.id === v);
-												setActionData({
-													...actionData,
-													lensId: v,
-													lens: lens ? lensDisplayName(lens) : "",
-												});
-											}
-										}}
-									>
-										<SelectTrigger>
-											<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
-										</SelectTrigger>
-										<SelectContent>
-											{visibleLenses.map((l) => (
-												<SelectItem key={l.id} value={l.id}>
-													{lensDisplayName(l)}
-												</SelectItem>
-											))}
-											<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
-										</SelectContent>
-									</Select>
-									{!actionData.lensId && (
-										<Input
-											value={actionData.lens || ""}
-											onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
-											placeholder={t("filmDetail.lensPlaceholder")}
-											className="mt-2"
-										/>
-									)}
-								</>
-							) : (
-								<Input
-									value={actionData.lens || ""}
-									onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
-									placeholder={t("filmDetail.lensPlaceholder")}
-								/>
-							)}
-						</FormField>
+						{showLensField && (
+							<FormField label={t("filmDetail.lensField")}>
+								{visibleLenses.length > 0 ? (
+									<>
+										<Select
+											value={actionData.lensId || "__other__"}
+											onValueChange={(v) => {
+												if (v === "__other__") {
+													setActionData({ ...actionData, lensId: undefined, lens: "" });
+												} else {
+													const lens = data.lenses.find((l) => l.id === v);
+													setActionData({
+														...actionData,
+														lensId: v,
+														lens: lens ? lensDisplayName(lens) : "",
+													});
+												}
+											}}
+										>
+											<SelectTrigger>
+												<SelectValue placeholder={t("filmDetail.chooseLensPlaceholder")} />
+											</SelectTrigger>
+											<SelectContent>
+												{visibleLenses.map((l) => (
+													<SelectItem key={l.id} value={l.id}>
+														{lensDisplayName(l)}
+													</SelectItem>
+												))}
+												<SelectItem value="__other__">{t("filmDetail.otherLens")}</SelectItem>
+											</SelectContent>
+										</Select>
+										{!actionData.lensId && (
+											<Input
+												value={actionData.lens || ""}
+												onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
+												placeholder={t("filmDetail.lensPlaceholder")}
+												className="mt-2"
+											/>
+										)}
+									</>
+								) : (
+									<Input
+										value={actionData.lens || ""}
+										onChange={(e) => setActionData({ ...actionData, lens: e.target.value })}
+										placeholder={t("filmDetail.lensPlaceholder")}
+									/>
+								)}
+							</FormField>
+						)}
 						<FormField label={t("filmDetail.resumeDateField")}>
 							<Input
 								type="date"
@@ -418,13 +428,16 @@ export function TransitionModals({
 							onClick={() => {
 								const reloadCam = data.cameras.find((c) => c.id === actionData.cameraId);
 								const photos = actionData.photos?.length ? actionData.photos : undefined;
+								const reloadCamHasLens = reloadCam?.hasInterchangeableLens ?? true;
+								const resolvedLensId = "lensId" in actionData ? (actionData.lensId ?? null) : (film.lensId ?? null);
+								const resolvedLens = actionData.lens?.trim() || film.lens || null;
 								updateFilm(
 									{
 										state: "loaded",
 										cameraId: actionData.cameraId,
 										backId: actionData.backId || null,
-										lensId: "lensId" in actionData ? (actionData.lensId ?? null) : (film.lensId ?? null),
-										lens: actionData.lens?.trim() || film.lens || null,
+										lensId: reloadCamHasLens ? resolvedLensId : null,
+										lens: reloadCamHasLens ? resolvedLens : null,
 										startDate: actionData.startDate || today(),
 										history: [
 											...(film.history || []),

--- a/src/screens/film-detail/TransitionModals.tsx
+++ b/src/screens/film-detail/TransitionModals.tsx
@@ -27,10 +27,10 @@ export function TransitionModals({
 	const { t } = useTranslation();
 	const selectedCamera = actionData.cameraId ? data.cameras.find((c) => c.id === actionData.cameraId) : null;
 	const showLensField = selectedCamera?.hasInterchangeableLens ?? true;
-	// Include the currently-selected lens even if sold, so reloading or continuing a film that
-	// references an archived lens still renders the Select with the correct value.
-	// Filter by camera mount when the selected camera has a mount defined.
-	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera).filter(
+	// Include the currently-selected lens even if sold or if its mount doesn't match the
+	// camera's mount, so reloading or continuing a film that references such a lens still
+	// renders the Select with the correct value (instead of blank / silently overwritten).
+	const visibleLenses = filterLensesByMount(data.lenses, selectedCamera, actionData.lensId).filter(
 		(l) => !l.soldAt || l.id === actionData.lensId,
 	);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,6 +122,8 @@ export interface Camera {
 	serial: string;
 	format: string;
 	hasInterchangeableBack: boolean;
+	hasInterchangeableLens?: boolean;
+	hasManualControls?: boolean;
 	photo?: string;
 	mount?: string | null;
 	shutterSpeedMin?: string | null;

--- a/src/utils/lens-helpers.ts
+++ b/src/utils/lens-helpers.ts
@@ -3,11 +3,19 @@ import type { Camera, Lens } from "@/types";
 /**
  * Keep only lenses whose mount matches the camera's mount. If the camera has no
  * mount defined, no filtering is applied (returns the original list).
+ *
+ * `preserveId` lets callers ensure the currently-selected lens stays in the
+ * result even if its mount doesn't match (or is unset), so that the Select
+ * value never points to a lens that's been filtered out of the options.
  */
-export function filterLensesByMount(lenses: Lens[], camera: Camera | null | undefined): Lens[] {
+export function filterLensesByMount(
+	lenses: Lens[],
+	camera: Camera | null | undefined,
+	preserveId?: string | null,
+): Lens[] {
 	const mount = camera?.mount?.trim();
 	if (!mount) return lenses;
-	return lenses.filter((l) => (l.mount?.trim() ?? "") === mount);
+	return lenses.filter((l) => (l.mount?.trim() ?? "") === mount || (preserveId != null && l.id === preserveId));
 }
 
 export function lensDisplayName(lens: Lens | undefined): string {

--- a/src/utils/lens-helpers.ts
+++ b/src/utils/lens-helpers.ts
@@ -1,4 +1,14 @@
-import type { Lens } from "@/types";
+import type { Camera, Lens } from "@/types";
+
+/**
+ * Keep only lenses whose mount matches the camera's mount. If the camera has no
+ * mount defined, no filtering is applied (returns the original list).
+ */
+export function filterLensesByMount(lenses: Lens[], camera: Camera | null | undefined): Lens[] {
+	const mount = camera?.mount?.trim();
+	if (!mount) return lenses;
+	return lenses.filter((l) => (l.mount?.trim() ?? "") === mount);
+}
 
 export function lensDisplayName(lens: Lens | undefined): string {
 	if (!lens) return "";

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,6 +1,6 @@
 import type { AppData } from "@/types";
 
-export const CURRENT_VERSION = 18;
+export const CURRENT_VERSION = 19;
 
 type MigrationFn = (data: Record<string, unknown>) => Record<string, unknown>;
 
@@ -249,6 +249,18 @@ function migrateV17toV18(data: Record<string, unknown>): Record<string, unknown>
 	return { ...data, version: 18 };
 }
 
+function migrateV18toV19(data: Record<string, unknown>): Record<string, unknown> {
+	// Add hasInterchangeableLens and hasManualControls to Camera. Default both to true
+	// for existing cameras to preserve current behavior (manual controls + lens fields visible).
+	const cameras = (data.cameras as Record<string, unknown>[]) || [];
+	const migratedCameras = cameras.map((cam) => ({
+		...cam,
+		hasInterchangeableLens: cam.hasInterchangeableLens ?? true,
+		hasManualControls: cam.hasManualControls ?? true,
+	}));
+	return { ...data, cameras: migratedCameras, version: 19 };
+}
+
 const migrations: Record<number, MigrationFn> = {
 	1: migrateV1toV2,
 	2: migrateV2toV3,
@@ -267,6 +279,7 @@ const migrations: Record<number, MigrationFn> = {
 	15: migrateV15toV16,
 	16: migrateV16toV17,
 	17: migrateV17toV18,
+	18: migrateV18toV19,
 };
 
 export function applyMigrations(data: Record<string, unknown>): AppData {


### PR DESCRIPTION
- New Camera flags hasInterchangeableLens & hasManualControls (default true).
- AddCameraDialog and CamerasTab edit modal expose them as switches and
  hide the mount input / exposure section when disabled.
- Lens dropdowns in EditModal, ShotNotesSection, QuickShotDialog and
  TransitionModals now filter by camera mount via filterLensesByMount,
  and hide the lens field entirely on fixed-lens cameras.
- Aperture / shutter speed inputs are hidden in shot dialogs for
  point-and-shoot cameras (no manual controls).
- CameraInfoSection displays both flags; migration v18 -> v19 backfills
  existing cameras with default true to preserve current behavior.