### PR TITLE
feat(fab): speed-dial menu for quick add + log a shot

### DIFF
--- a/src/components/FloatingActionMenu.tsx
+++ b/src/components/FloatingActionMenu.tsx
@@ -32,6 +32,10 @@ export function FloatingActionMenu({
 		return () => window.removeEventListener("keydown", onKey);
 	}, [open]);
 
+	useEffect(() => {
+		if (!visible) setOpen(false);
+	}, [visible]);
+
 	if (!visible) return null;
 
 	const run = (handler: () => void) => {
@@ -39,12 +43,12 @@ export function FloatingActionMenu({
 		handler();
 	};
 
-	const items: { icon: LucideIcon; label: string; onClick: () => void; primary?: boolean }[] = [
-		{ icon: NotebookPen, label: t("fab.quickShot"), onClick: () => run(onQuickShot), primary: true },
-		{ icon: FilmIcon, label: t("fab.film"), onClick: () => run(onAddFilm) },
-		{ icon: Camera, label: t("fab.camera"), onClick: () => run(onAddCamera) },
-		{ icon: Package, label: t("fab.back"), onClick: () => run(onAddBack) },
-		{ icon: Focus, label: t("fab.lens"), onClick: () => run(onAddLens) },
+	const items: { id: string; icon: LucideIcon; label: string; onClick: () => void; primary?: boolean }[] = [
+		{ id: "quickShot", icon: NotebookPen, label: t("fab.quickShot"), onClick: () => run(onQuickShot), primary: true },
+		{ id: "film", icon: FilmIcon, label: t("fab.film"), onClick: () => run(onAddFilm) },
+		{ id: "camera", icon: Camera, label: t("fab.camera"), onClick: () => run(onAddCamera) },
+		{ id: "back", icon: Package, label: t("fab.back"), onClick: () => run(onAddBack) },
+		{ id: "lens", icon: Focus, label: t("fab.lens"), onClick: () => run(onAddLens) },
 	];
 
 	return (
@@ -59,13 +63,10 @@ export function FloatingActionMenu({
 			)}
 
 			{open && (
-				<div
-					role="menu"
-					className="fixed z-40 right-4 md:right-6 bottom-[calc(5rem+env(safe-area-inset-bottom)+4rem)] md:bottom-[5.5rem] flex flex-col-reverse gap-3 items-end"
-				>
+				<div className="fixed z-40 right-4 md:right-6 bottom-[calc(5rem+env(safe-area-inset-bottom)+4rem)] md:bottom-[5.5rem] flex flex-col-reverse gap-3 items-end">
 					{items.map((item, i) => (
 						<SpeedDialItem
-							key={item.label}
+							key={item.id}
 							icon={item.icon}
 							label={item.label}
 							onClick={item.onClick}
@@ -81,7 +82,6 @@ export function FloatingActionMenu({
 				onClick={() => setOpen((v) => !v)}
 				aria-label={open ? t("aria.close") : t("fab.openMenu")}
 				aria-expanded={open}
-				aria-haspopup="menu"
 				className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 md:bottom-6 md:right-6 z-40 w-14 h-14 rounded-full bg-accent hover:bg-accent-hover shadow-lg flex items-center justify-center text-white transition-colors"
 			>
 				<Plus
@@ -106,7 +106,6 @@ function SpeedDialItem({ icon: Icon, label, onClick, primary, delayMs }: SpeedDi
 	return (
 		<button
 			type="button"
-			role="menuitem"
 			onClick={onClick}
 			className="flex items-center gap-3 animate-stagger-item"
 			style={{ animationDelay: `${delayMs}ms` }}

--- a/src/components/FloatingActionMenu.tsx
+++ b/src/components/FloatingActionMenu.tsx
@@ -1,7 +1,6 @@
 import { Camera, Film as FilmIcon, Focus, NotebookPen, Package, Plus } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import type { LucideIcon } from "@/types";
 
 interface FloatingActionMenuProps {
@@ -24,71 +23,104 @@ export function FloatingActionMenu({
 	const { t } = useTranslation();
 	const [open, setOpen] = useState(false);
 
+	useEffect(() => {
+		if (!open) return;
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === "Escape") setOpen(false);
+		};
+		window.addEventListener("keydown", onKey);
+		return () => window.removeEventListener("keydown", onKey);
+	}, [open]);
+
 	if (!visible) return null;
 
 	const run = (handler: () => void) => {
 		setOpen(false);
-		// Defer to next tick so the current Dialog finishes closing before the
-		// next one opens (prevents two Radix focus traps from fighting).
-		setTimeout(handler, 0);
+		handler();
 	};
+
+	const items: { icon: LucideIcon; label: string; onClick: () => void; primary?: boolean }[] = [
+		{ icon: NotebookPen, label: t("fab.quickShot"), onClick: () => run(onQuickShot), primary: true },
+		{ icon: FilmIcon, label: t("fab.film"), onClick: () => run(onAddFilm) },
+		{ icon: Camera, label: t("fab.camera"), onClick: () => run(onAddCamera) },
+		{ icon: Package, label: t("fab.back"), onClick: () => run(onAddBack) },
+		{ icon: Focus, label: t("fab.lens"), onClick: () => run(onAddLens) },
+	];
 
 	return (
 		<>
+			{open && (
+				<button
+					type="button"
+					aria-label={t("aria.close")}
+					onClick={() => setOpen(false)}
+					className="fixed inset-0 z-30 bg-black/30 backdrop-blur-sm animate-backdrop-fade-in cursor-default"
+				/>
+			)}
+
+			{open && (
+				<div
+					role="menu"
+					className="fixed z-40 right-4 md:right-6 bottom-[calc(5rem+env(safe-area-inset-bottom)+4rem)] md:bottom-[5.5rem] flex flex-col-reverse gap-3 items-end"
+				>
+					{items.map((item, i) => (
+						<SpeedDialItem
+							key={item.label}
+							icon={item.icon}
+							label={item.label}
+							onClick={item.onClick}
+							primary={item.primary}
+							delayMs={i * 30}
+						/>
+					))}
+				</div>
+			)}
+
 			<button
 				type="button"
-				onClick={() => setOpen(true)}
-				aria-label={t("fab.openMenu")}
+				onClick={() => setOpen((v) => !v)}
+				aria-label={open ? t("aria.close") : t("fab.openMenu")}
+				aria-expanded={open}
+				aria-haspopup="menu"
 				className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 md:bottom-6 md:right-6 z-40 w-14 h-14 rounded-full bg-accent hover:bg-accent-hover shadow-lg flex items-center justify-center text-white transition-colors"
 			>
-				<Plus size={24} strokeWidth={2.5} />
+				<Plus
+					size={24}
+					strokeWidth={2.5}
+					className={`transition-transform duration-200 ease-out ${open ? "rotate-45" : ""}`}
+				/>
 			</button>
-
-			<Dialog open={open} onOpenChange={setOpen}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>{t("fab.title")}</DialogTitle>
-						<DialogCloseButton />
-					</DialogHeader>
-
-					<div className="flex flex-col gap-3">
-						<div className="grid grid-cols-2 gap-3">
-							<GridCard icon={FilmIcon} label={t("fab.film")} onClick={() => run(onAddFilm)} />
-							<GridCard icon={Camera} label={t("fab.camera")} onClick={() => run(onAddCamera)} />
-							<GridCard icon={Package} label={t("fab.back")} onClick={() => run(onAddBack)} />
-							<GridCard icon={Focus} label={t("fab.lens")} onClick={() => run(onAddLens)} />
-						</div>
-
-						<button
-							type="button"
-							onClick={() => run(onQuickShot)}
-							className="w-full bg-accent hover:bg-accent-hover text-white rounded-lg p-4 flex items-center justify-center gap-2 transition-colors"
-						>
-							<NotebookPen size={18} />
-							<span className="text-[15px] font-semibold">{t("fab.quickShot")}</span>
-						</button>
-					</div>
-				</DialogContent>
-			</Dialog>
 		</>
 	);
 }
 
-interface GridCardProps {
+interface SpeedDialItemProps {
 	icon: LucideIcon;
 	label: string;
 	onClick: () => void;
+	primary?: boolean;
+	delayMs: number;
 }
 
-function GridCard({ icon: Icon, label, onClick }: GridCardProps) {
+function SpeedDialItem({ icon: Icon, label, onClick, primary, delayMs }: SpeedDialItemProps) {
 	return (
 		<button
 			type="button"
+			role="menuitem"
 			onClick={onClick}
-			className="aspect-square flex flex-col items-center justify-center gap-2 bg-surface-alt hover:bg-card-hover border border-border rounded-lg p-3 transition-colors"
+			className="flex items-center gap-3 animate-stagger-item"
+			style={{ animationDelay: `${delayMs}ms` }}
 		>
-			<Icon size={28} className="text-text-primary" />
-			<span className="text-[13px] font-semibold text-text-primary font-body">{label}</span>
+			<span className="bg-surface border border-border rounded-full px-3 py-1.5 text-sm font-semibold text-text-primary shadow-md whitespace-nowrap">
+				{label}
+			</span>
+			<span
+				className={`w-12 h-12 rounded-full shadow-md flex items-center justify-center ${
+					primary ? "bg-accent text-white" : "bg-surface-alt border border-border text-text-primary"
+				}`}
+			>
+				<Icon size={20} />
+			</span>
 		</button>
 	);
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -557,10 +557,10 @@ export const en = {
 	fab: {
 		openMenu: "Quick add menu",
 		title: "Add",
-		film: "Film",
-		camera: "Camera",
-		lens: "Lens",
-		back: "Back",
+		film: "Add a film",
+		camera: "Add a camera",
+		lens: "Add a lens",
+		back: "Add a back",
 		quickShot: "Log a shot",
 	},
 

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -557,11 +557,11 @@ export const fr = {
 	fab: {
 		openMenu: "Menu d'ajout rapide",
 		title: "Ajouter",
-		film: "Pellicule",
-		camera: "Appareil",
-		lens: "Objectif",
-		back: "Dos",
-		quickShot: "Noter une prise de vue",
+		film: "Ajouter une pellicule",
+		camera: "Ajouter un appareil",
+		lens: "Ajouter un objectif",
+		back: "Ajouter un dos",
+		quickShot: "Noter une prise",
 	},
 
 	// Quick shot dialog

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -166,7 +166,7 @@ export function MapScreen({ data, onOpenFilm, onOpenStock, filterFilmId, onClear
 				size="icon"
 				onClick={handleLocateMe}
 				disabled={locating}
-				className="absolute bottom-16 right-3 z-10 shadow-lg bg-card/90 backdrop-blur"
+				className="absolute bottom-3 left-3 z-10 shadow-lg bg-card/90 backdrop-blur"
 				aria-label={t("map.locateMe")}
 			>
 				{locating ? (


### PR DESCRIPTION
## Summary

Supersedes #116. Same feature scope, different visual layout (speed-dial instead of bottom-sheet grid) plus a small fix on the Map screen.

- New global FAB (bottom-right). Tapping it rotates the `+` into a `×` and fans out 5 mini-buttons above it, each with a chip label: **Noter une prise** (accent, closest to the thumb), Pellicule, Appareil, Dos, Objectif. Tap on the scrim or press `Escape` to close.
- `QuickShotDialog` records a `ShotNote` on any `loaded`/`partial` film, pre-fills frame number and lens from the film, supports a free-form lens input, falls back to `currentFilm.lens`, and offers an "Enregistrer + suivante" button to chain frames.
- Equipment add forms extracted into `AddCameraDialog` / `AddLensDialog` / `AddBackDialog` with a shared `LensForm`, so both the tab "Add" buttons and the FAB drive the same dialogs.
- `nowDateTimeLocal()` deduplicated into `utils/helpers`.
- Move the Map "Locate me" button from `bottom-16 right-3` to `bottom-3 left-3` so it's no longer glued to the FAB column.

## Test plan

- [ ] `npm run dev` on mobile viewport — tap the FAB, confirm the speed-dial fans out with stagger animation and the `+` rotates.
- [ ] Each mini-button opens the matching dialog (or `QuickShotDialog` for "Noter une prise").
- [ ] With no loaded/partial film, "Noter une prise" still opens the dialog and shows the empty-state with an "Ajouter une pellicule" prompt.
- [ ] With a loaded film, the dialog pre-fills frame n° and lens; "Enregistrer + suivante" persists and increments without closing.
- [ ] FAB hidden on `filmDetail`, `cameraDetail`, `settings`, `legal` and during the onboarding tour.
- [ ] Map screen — "Me localiser" button is in the bottom-left, no overlap with the FAB or its expanded items.
- [ ] `npm run lint` and `npm run build` pass.

https://claude.ai/code/session_01D8YM5JUz95V8SU9xyJCiBt

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8YM5JUz95V8SU9xyJCiBt)_