### PR TITLE
feat(lens): auto-fill sole compatible lens in pickers

### DIFF
--- a/src/components/QuickShotDialog.tsx
+++ b/src/components/QuickShotDialog.tsx
@@ -14,7 +14,7 @@ import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/
 import type { AppData, ShotNote } from "@/types";
 import { filmName } from "@/utils/film-helpers";
 import { nowDateTimeLocal, uid } from "@/utils/helpers";
-import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName, pickSoleCompatibleLens } from "@/utils/lens-helpers";
 
 interface QuickShotDialogProps {
 	open: boolean;
@@ -91,10 +91,13 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		}
 		const only = eligibleFilms.length === 1 ? eligibleFilms[0] : null;
 		if (only && !filmId) {
+			const onlyCam = only.cameraId ? data.cameras.find((c) => c.id === only.cameraId) : null;
+			const sole =
+				!only.lensId && onlyCam?.hasInterchangeableLens ? pickSoleCompatibleLens(data.lenses, onlyCam) : null;
 			setFilmId(only.id);
 			setFrameNumber(nextFrame(only.posesShot));
-			setLensId(only.lensId ?? "");
-			setLens(only.lens ?? "");
+			setLensId(sole ? sole.id : (only.lensId ?? ""));
+			setLens(sole ? lensDisplayName(sole) : (only.lens ?? ""));
 		}
 	}, [open]);
 
@@ -102,9 +105,11 @@ export function QuickShotDialog({ open, onOpenChange, data, setData, onAddFilm }
 		setFilmId(newId);
 		const film = data.films.find((f) => f.id === newId);
 		if (film) {
+			const cam = film.cameraId ? data.cameras.find((c) => c.id === film.cameraId) : null;
+			const sole = !film.lensId && cam?.hasInterchangeableLens ? pickSoleCompatibleLens(data.lenses, cam) : null;
 			setFrameNumber(nextFrame(film.posesShot));
-			setLensId(film.lensId ?? "");
-			setLens(film.lens ?? "");
+			setLensId(sole ? sole.id : (film.lensId ?? ""));
+			setLens(sole ? lensDisplayName(sole) : (film.lens ?? ""));
 			resetExposureFields();
 		}
 	};

--- a/src/components/ShotNotesSection.tsx
+++ b/src/components/ShotNotesSection.tsx
@@ -16,7 +16,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { type ExposureConfig, filterApertures, filterSpeeds } from "@/constants/photography";
 import type { Camera, Film, Lens, ShotNote } from "@/types";
 import { nowDateTimeLocal, uid } from "@/utils/helpers";
-import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName, pickSoleCompatibleLens } from "@/utils/lens-helpers";
 
 interface ShotNotesSectionProps {
 	film: Film;
@@ -164,16 +164,17 @@ function ShotNotesSection({
 	const [gpsLoading, setGpsLoading] = useState(false);
 
 	const openAdd = useCallback(() => {
+		const sole = !film.lensId && camera?.hasInterchangeableLens ? pickSoleCompatibleLens(lenses ?? [], camera) : null;
 		setEditingId(null);
 		setForm({
 			...emptyForm,
-			lens: film.lens ?? "",
-			lensId: film.lensId ?? "",
+			lens: sole ? lensDisplayName(sole) : (film.lens ?? ""),
+			lensId: sole ? sole.id : (film.lensId ?? ""),
 			frameNumber: nextFrameNumber(notes, film.posesTotal),
 			date: nowDateTimeLocal(),
 		});
 		setDialogOpen(true);
-	}, [film.lens, film.lensId, film.posesTotal, notes]);
+	}, [camera, lenses, film.lens, film.lensId, film.posesTotal, notes]);
 
 	useEffect(() => {
 		if (autoOpenShotNote) {

--- a/src/components/equipment/AddCameraDialog.tsx
+++ b/src/components/equipment/AddCameraDialog.tsx
@@ -1,7 +1,8 @@
 import { Plus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PhotoPicker } from "@/components/PhotoPicker";
+import { AutocompleteInput } from "@/components/ui/autocomplete-input";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { FormField } from "@/components/ui/form-field";
@@ -11,6 +12,7 @@ import { Switch } from "@/components/ui/switch";
 import { SHUTTER_SPEEDS } from "@/constants/photography";
 import { type AppData, type Camera as CameraType, INSTANT_FORMATS, type StopIncrement } from "@/types";
 import { uid } from "@/utils/helpers";
+import { collectMounts } from "@/utils/lens-helpers";
 
 interface AddCameraDialogProps {
 	open: boolean;
@@ -39,6 +41,7 @@ const emptyCam = {
 export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCameraDialogProps) {
 	const { t } = useTranslation();
 	const [newCam, setNewCam] = useState(emptyCam);
+	const mountSuggestions = useMemo(() => collectMounts(data.cameras, data.lenses), [data.cameras, data.lenses]);
 
 	useEffect(() => {
 		if (!open) setNewCam(emptyCam);
@@ -137,13 +140,14 @@ export function AddCameraDialog({ open, onOpenChange, data, setData }: AddCamera
 						/>
 					</div>
 					{newCam.hasInterchangeableLens && (
-						<FormField label={t("cameras.mount")}>
-							<Input
-								value={newCam.mount}
-								onChange={(e) => setNewCam({ ...newCam, mount: e.target.value })}
-								placeholder={t("cameras.mountPlaceholder")}
-							/>
-						</FormField>
+						<AutocompleteInput
+							label={t("cameras.mount")}
+							value={newCam.mount}
+							onChange={(v) => setNewCam({ ...newCam, mount: v })}
+							suggestions={mountSuggestions}
+							placeholder={t("cameras.mountPlaceholder")}
+							showAllOnFocus
+						/>
 					)}
 					<div className="flex items-center justify-between gap-3">
 						<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">

--- a/src/components/equipment/AddLensDialog.tsx
+++ b/src/components/equipment/AddLensDialog.tsx
@@ -10,9 +10,10 @@ interface AddLensDialogProps {
 	onOpenChange: (open: boolean) => void;
 	data: AppData;
 	setData: (data: AppData) => void;
+	mountSuggestions?: string[];
 }
 
-export function AddLensDialog({ open, onOpenChange, data, setData }: AddLensDialogProps) {
+export function AddLensDialog({ open, onOpenChange, data, setData, mountSuggestions }: AddLensDialogProps) {
 	const { t } = useTranslation();
 	const [newLens, setNewLens] = useState<LensFormData>(emptyLensForm);
 
@@ -34,7 +35,13 @@ export function AddLensDialog({ open, onOpenChange, data, setData }: AddLensDial
 					<DialogTitle>{t("lenses.newLens")}</DialogTitle>
 					<DialogCloseButton />
 				</DialogHeader>
-				<LensForm form={newLens} setForm={setNewLens} onSave={addLens} isEdit={false} />
+				<LensForm
+					form={newLens}
+					setForm={setNewLens}
+					onSave={addLens}
+					isEdit={false}
+					mountSuggestions={mountSuggestions}
+				/>
 			</DialogContent>
 		</Dialog>
 	);

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -1,9 +1,10 @@
 import { Camera, Check, Edit3, Eye, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
 import { PhotoPicker } from "@/components/PhotoPicker";
 import { PhotoViewer } from "@/components/PhotoViewer";
+import { AutocompleteInput } from "@/components/ui/autocomplete-input";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -20,6 +21,7 @@ import { alpha, T } from "@/constants/theme";
 import { type AppData, type Camera as CameraType, INSTANT_FORMATS, type StopIncrement } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { filmName } from "@/utils/film-helpers";
+import { collectMounts } from "@/utils/lens-helpers";
 import { AddCameraDialog } from "./AddCameraDialog";
 
 interface CamerasTabProps {
@@ -34,6 +36,7 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	const [editCam, setEditCam] = useState<(CameraType & { mount?: string | null }) | null>(null);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 	const [pendingHardDeleteId, setPendingHardDeleteId] = useState<string | null>(null);
+	const mountSuggestions = useMemo(() => collectMounts(data.cameras, data.lenses), [data.cameras, data.lenses]);
 
 	const activeCameras = data.cameras.filter((c) => !c.soldAt);
 	const soldCameras = data.cameras.filter((c) => c.soldAt);
@@ -367,13 +370,14 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 								/>
 							</div>
 							{(editCam.hasInterchangeableLens ?? true) && (
-								<FormField label={t("cameras.mount")}>
-									<Input
-										value={editCam.mount || ""}
-										onChange={(e) => setEditCam({ ...editCam, mount: e.target.value })}
-										placeholder={t("cameras.mountPlaceholder")}
-									/>
-								</FormField>
+								<AutocompleteInput
+									label={t("cameras.mount")}
+									value={editCam.mount || ""}
+									onChange={(v) => setEditCam({ ...editCam, mount: v })}
+									suggestions={mountSuggestions}
+									placeholder={t("cameras.mountPlaceholder")}
+									showAllOnFocus
+								/>
 							)}
 							<div className="flex items-center justify-between gap-3">
 								<label className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">

--- a/src/components/equipment/LensForm.tsx
+++ b/src/components/equipment/LensForm.tsx
@@ -1,6 +1,7 @@
 import { Check, PackageX, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { PhotoPicker } from "@/components/PhotoPicker";
+import { AutocompleteInput } from "@/components/ui/autocomplete-input";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -103,9 +104,10 @@ interface LensFormProps {
 	onSave: () => void;
 	isEdit: boolean;
 	onSell?: () => void;
+	mountSuggestions?: string[];
 }
 
-export function LensForm({ form, setForm, onSave, isEdit, onSell }: LensFormProps) {
+export function LensForm({ form, setForm, onSave, isEdit, onSell, mountSuggestions = [] }: LensFormProps) {
 	const { t } = useTranslation();
 
 	return (
@@ -146,13 +148,14 @@ export function LensForm({ form, setForm, onSave, isEdit, onSell }: LensFormProp
 					placeholder={t("lenses.serialPlaceholder")}
 				/>
 			</FormField>
-			<FormField label={t("lenses.mount")}>
-				<Input
-					value={form.mount}
-					onChange={(e) => setForm({ ...form, mount: e.target.value })}
-					placeholder={t("lenses.mountPlaceholder")}
-				/>
-			</FormField>
+			<AutocompleteInput
+				label={t("lenses.mount")}
+				value={form.mount}
+				onChange={(v) => setForm({ ...form, mount: v })}
+				suggestions={mountSuggestions}
+				placeholder={t("lenses.mountPlaceholder")}
+				showAllOnFocus
+			/>
 
 			<div className="border-t border-border pt-4 mt-1">
 				<span className="text-[11px] font-semibold text-text-sec font-body uppercase tracking-wide">

--- a/src/components/equipment/LensesTab.tsx
+++ b/src/components/equipment/LensesTab.tsx
@@ -12,7 +12,7 @@ import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } f
 import { PhotoImg } from "@/components/ui/photo-img";
 import { alpha, T } from "@/constants/theme";
 import type { AppData, Lens } from "@/types";
-import { lensApertureLabel, lensDisplayName, lensFocalLabel } from "@/utils/lens-helpers";
+import { collectMounts, lensApertureLabel, lensDisplayName, lensFocalLabel } from "@/utils/lens-helpers";
 import { AddLensDialog } from "./AddLensDialog";
 import { emptyLensForm, formToLens, LensForm, type LensFormData, lensToForm } from "./LensForm";
 
@@ -31,6 +31,7 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 
 	const activeLenses = data.lenses.filter((l) => !l.soldAt);
 	const soldLenses = data.lenses.filter((l) => l.soldAt);
+	const mountSuggestions = collectMounts(data.cameras, data.lenses);
 
 	const saveEditLens = () => {
 		if (!editLensId || (!editLens.brand && !editLens.model)) return;
@@ -248,7 +249,13 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 				)}
 			</div>
 
-			<AddLensDialog open={showAdd} onOpenChange={setShowAdd} data={data} setData={setData} />
+			<AddLensDialog
+				open={showAdd}
+				onOpenChange={setShowAdd}
+				data={data}
+				setData={setData}
+				mountSuggestions={mountSuggestions}
+			/>
 
 			{/* Edit lens modal */}
 			<Dialog open={!!editLensId} onOpenChange={(open) => !open && setEditLensId(null)}>
@@ -263,6 +270,7 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 						onSave={saveEditLens}
 						isEdit={true}
 						onSell={editLensId ? () => sellLens(editLensId) : undefined}
+						mountSuggestions={mountSuggestions}
 					/>
 				</DialogContent>
 			</Dialog>

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -16,6 +16,7 @@ import type { AppData, Film as FilmType } from "@/types";
 import { createNewFilm } from "@/utils/film-factory";
 import { filmIso, filmName, filmType } from "@/utils/film-helpers";
 import { today } from "@/utils/helpers";
+import { lensDisplayName, pickSoleCompatibleLens } from "@/utils/lens-helpers";
 import { useFilmSuggestions } from "@/utils/use-film-suggestions";
 import { DevScanModals } from "./film-detail/DevScanModals";
 import { EditModal } from "./film-detail/EditModal";
@@ -94,6 +95,9 @@ export function FilmDetailScreen({
 		);
 
 	const openEdit = () => {
+		const editCam = film.cameraId ? data.cameras.find((c) => c.id === film.cameraId) : null;
+		const soleLens =
+			!film.lensId && editCam?.hasInterchangeableLens ? pickSoleCompatibleLens(data.lenses, editCam) : null;
 		setEditData({
 			brand: film.brand || "",
 			model: film.model || "",
@@ -108,8 +112,8 @@ export function FilmDetailScreen({
 			shootIso: film.shootIso != null ? String(film.shootIso) : "",
 			cameraId: film.cameraId || "",
 			backId: film.backId || "",
-			lensId: film.lensId || "",
-			lens: film.lens || "",
+			lensId: soleLens ? soleLens.id : film.lensId || "",
+			lens: soleLens ? lensDisplayName(soleLens) : film.lens || "",
 			startDate: film.startDate || "",
 			posesTotal: film.posesTotal != null ? String(film.posesTotal) : "",
 			endDate: film.endDate || "",

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -181,12 +181,22 @@ export function EditModal({
 									value={editData.cameraId || ""}
 									onValueChange={(v) => {
 										const cam = data.cameras.find((c) => c.id === v) ?? null;
-										const sole = cam?.hasInterchangeableLens ? pickSoleCompatibleLens(data.lenses, cam) : null;
+										const compatible = cam?.hasInterchangeableLens
+											? filterLensesByMount(data.lenses, cam).filter((l) => !l.soldAt)
+											: [];
+										const keep = editData.lensId ? compatible.find((l) => l.id === editData.lensId) : null;
+										const sole = keep
+											? null
+											: cam?.hasInterchangeableLens
+												? pickSoleCompatibleLens(data.lenses, cam)
+												: null;
+										const picked = keep ?? sole;
 										setEditData({
 											...editData,
 											cameraId: v,
 											backId: "",
-											...(sole ? { lensId: sole.id, lens: lensDisplayName(sole) } : {}),
+											lensId: picked?.id ?? "",
+											lens: picked ? lensDisplayName(picked) : "",
 										});
 									}}
 								>

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -16,7 +16,7 @@ import { type AppData, type Back, type Camera, type Film, isInstantFormat } from
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 import { collectAllTags } from "@/utils/film-helpers";
 import { today } from "@/utils/helpers";
-import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
+import { filterLensesByMount, lensDisplayName, pickSoleCompatibleLens } from "@/utils/lens-helpers";
 import type { ActionType, EditData } from "./types";
 
 interface EditModalProps {
@@ -179,7 +179,16 @@ export function EditModal({
 							<FormField label={t("filmDetail.cameraField")}>
 								<Select
 									value={editData.cameraId || ""}
-									onValueChange={(v) => setEditData({ ...editData, cameraId: v, backId: "" })}
+									onValueChange={(v) => {
+										const cam = data.cameras.find((c) => c.id === v) ?? null;
+										const sole = cam?.hasInterchangeableLens ? pickSoleCompatibleLens(data.lenses, cam) : null;
+										setEditData({
+											...editData,
+											cameraId: v,
+											backId: "",
+											...(sole ? { lensId: sole.id, lens: lensDisplayName(sole) } : {}),
+										});
+									}}
 								>
 									<SelectTrigger>
 										<SelectValue placeholder={t("filmDetail.choosePlaceholder")} />

--- a/src/screens/film-detail/TransitionModals.tsx
+++ b/src/screens/film-detail/TransitionModals.tsx
@@ -1,4 +1,4 @@
-import { Camera, Check, Clock, RotateCcw } from "lucide-react";
+import { Camera as CameraIcon, Check, Clock, RotateCcw } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { PhotoPicker } from "@/components/PhotoPicker";
 import { Button } from "@/components/ui/button";
@@ -7,10 +7,27 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { T } from "@/constants/theme";
+import type { Camera, Lens } from "@/types";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
 import { today } from "@/utils/helpers";
-import { filterLensesByMount, lensDisplayName } from "@/utils/lens-helpers";
-import type { ModalBaseProps } from "./types";
+import { filterLensesByMount, lensDisplayName, pickSoleCompatibleLens } from "@/utils/lens-helpers";
+import type { ActionData, ModalBaseProps } from "./types";
+
+function pickCameraWithSoleLens(
+	actionData: ActionData,
+	cameraId: string,
+	camera: Camera | null,
+	lenses: Lens[],
+): ActionData {
+	const next: ActionData = { ...actionData, cameraId, backId: "" };
+	if (!camera?.hasInterchangeableLens) return next;
+	const sole = pickSoleCompatibleLens(lenses, camera);
+	if (sole) {
+		next.lensId = sole.id;
+		next.lens = lensDisplayName(sole);
+	}
+	return next;
+}
 
 export function TransitionModals({
 	film,
@@ -47,7 +64,10 @@ export function TransitionModals({
 						<FormField label={t("filmDetail.cameraField")}>
 							<Select
 								value={actionData.cameraId || ""}
-								onValueChange={(v) => setActionData({ ...actionData, cameraId: v, backId: "" })}
+								onValueChange={(v) => {
+									const cam = data.cameras.find((c) => c.id === v) ?? null;
+									setActionData(pickCameraWithSoleLens(actionData, v, cam, data.lenses));
+								}}
 							>
 								<SelectTrigger>
 									<SelectValue placeholder={t("filmDetail.choosePlaceholder")} />
@@ -189,7 +209,7 @@ export function TransitionModals({
 							}}
 							className="w-full justify-center"
 						>
-							<Camera size={16} /> {t("filmDetail.loadButton")}
+							<CameraIcon size={16} /> {t("filmDetail.loadButton")}
 						</Button>
 					</div>
 				</DialogContent>
@@ -327,7 +347,10 @@ export function TransitionModals({
 						<FormField label={t("filmDetail.cameraField")}>
 							<Select
 								value={actionData.cameraId || ""}
-								onValueChange={(v) => setActionData({ ...actionData, cameraId: v, backId: "" })}
+								onValueChange={(v) => {
+									const cam = data.cameras.find((c) => c.id === v) ?? null;
+									setActionData(pickCameraWithSoleLens(actionData, v, cam, data.lenses));
+								}}
 							>
 								<SelectTrigger>
 									<SelectValue placeholder={t("filmDetail.choosePlaceholder")} />

--- a/src/screens/film-detail/TransitionModals.tsx
+++ b/src/screens/film-detail/TransitionModals.tsx
@@ -19,8 +19,15 @@ function pickCameraWithSoleLens(
 	camera: Camera | null,
 	lenses: Lens[],
 ): ActionData {
-	const next: ActionData = { ...actionData, cameraId, backId: "" };
+	const next: ActionData = { ...actionData, cameraId, backId: "", lensId: "", lens: "" };
 	if (!camera?.hasInterchangeableLens) return next;
+	const compatible = filterLensesByMount(lenses, camera).filter((l) => !l.soldAt);
+	const keep = actionData.lensId ? compatible.find((l) => l.id === actionData.lensId) : null;
+	if (keep) {
+		next.lensId = keep.id;
+		next.lens = lensDisplayName(keep);
+		return next;
+	}
 	const sole = pickSoleCompatibleLens(lenses, camera);
 	if (sole) {
 		next.lensId = sole.id;

--- a/src/utils/lens-helpers.ts
+++ b/src/utils/lens-helpers.ts
@@ -24,7 +24,7 @@ export function filterLensesByMount(
  * unambiguous.
  */
 export function pickSoleCompatibleLens(lenses: Lens[], camera: Camera | null | undefined): Lens | null {
-	if (!camera) return null;
+	if (!camera?.mount?.trim()) return null;
 	const compatible = filterLensesByMount(lenses, camera).filter((l) => !l.soldAt);
 	return compatible.length === 1 ? (compatible[0] ?? null) : null;
 }

--- a/src/utils/lens-helpers.ts
+++ b/src/utils/lens-helpers.ts
@@ -18,6 +18,17 @@ export function filterLensesByMount(
 	return lenses.filter((l) => (l.mount?.trim() ?? "") === mount || (preserveId != null && l.id === preserveId));
 }
 
+/**
+ * Returns the camera's sole compatible (non-sold) lens, or null if there are
+ * zero or multiple options. Used to auto-fill lens pickers when the choice is
+ * unambiguous.
+ */
+export function pickSoleCompatibleLens(lenses: Lens[], camera: Camera | null | undefined): Lens | null {
+	if (!camera) return null;
+	const compatible = filterLensesByMount(lenses, camera).filter((l) => !l.soldAt);
+	return compatible.length === 1 ? (compatible[0] ?? null) : null;
+}
+
 export function lensDisplayName(lens: Lens | undefined): string {
 	if (!lens) return "";
 	const brandModel = [lens.brand, lens.model].filter(Boolean).join(" ");

--- a/src/utils/lens-helpers.ts
+++ b/src/utils/lens-helpers.ts
@@ -19,6 +19,23 @@ export function filterLensesByMount(
 }
 
 /**
+ * Returns the unique mounts already used across cameras and lenses, sorted
+ * alphabetically. Used to power autocomplete on mount fields.
+ */
+export function collectMounts(cameras: Camera[], lenses: Lens[]): string[] {
+	const set = new Set<string>();
+	for (const c of cameras) {
+		const m = c.mount?.trim();
+		if (m) set.add(m);
+	}
+	for (const l of lenses) {
+		const m = l.mount?.trim();
+		if (m) set.add(m);
+	}
+	return Array.from(set).sort((a, b) => a.localeCompare(b));
+}
+
+/**
  * Returns the camera's sole compatible (non-sold) lens, or null if there are
  * zero or multiple options. Used to auto-fill lens pickers when the choice is
  * unambiguous.


### PR DESCRIPTION
When a camera has a single non-sold lens matching its mount, pre-select
it in every lens picker (load, reload, edit, quick shot, shot notes) so
users don't have to manually pick the only option.

https://claude.ai/code/session_01NefFMKrfoPDXa1Ugf64d8R