### PR TITLE
refactor(ui): remove duplicate add buttons in favor of FAB

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -284,8 +284,6 @@ function AppContent({
 		}
 	}, [data, startTour]);
 
-	const onAddFilm = () => setShowAddFilm(true);
-
 	// Forward-navigation callbacks. Each one pushes onto the history stack so
 	// the back button can restore the previous screen (and its params).
 	const openFilm = useCallback((id: string) => navigate({ screen: "filmDetail", selectedFilm: id }), [navigate]);
@@ -324,20 +322,12 @@ function AppContent({
 						data={effectiveData}
 						onOpenFilm={openFilm}
 						onOpenCameras={openCamerasList}
-						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
 						onNavigateToStock={openStockFiltered}
 					/>
 				);
 			case "stock":
-				return (
-					<StockScreen
-						data={effectiveData}
-						onOpenFilm={openFilm}
-						onAddFilm={onAddFilm}
-						initialStateFilter={stockStateFilter ?? null}
-					/>
-				);
+				return <StockScreen data={effectiveData} onOpenFilm={openFilm} initialStateFilter={stockStateFilter ?? null} />;
 			case "filmDetail":
 				return (
 					<FilmDetailScreen
@@ -404,7 +394,6 @@ function AppContent({
 						data={effectiveData}
 						onOpenFilm={openFilm}
 						onOpenCameras={openCamerasList}
-						onAddFilm={onAddFilm}
 						setAutoOpenShotNote={setAutoOpenShotNote}
 						onNavigateToStock={openStockFiltered}
 					/>

--- a/src/components/equipment/BacksTab.tsx
+++ b/src/components/equipment/BacksTab.tsx
@@ -1,4 +1,4 @@
-import { Camera, Check, Edit3, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Camera, Check, Edit3, PackageX, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
@@ -19,7 +19,6 @@ import { alpha, T } from "@/constants/theme";
 import { type AppData, type Back, INSTANT_FORMATS } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { filmName } from "@/utils/film-helpers";
-import { AddBackDialog } from "./AddBackDialog";
 
 interface BacksTabProps {
 	data: AppData;
@@ -28,7 +27,6 @@ interface BacksTabProps {
 
 export function BacksTab({ data, setData }: BacksTabProps) {
 	const { t } = useTranslation();
-	const [showBackModal, setShowBackModal] = useState(false);
 	const [editBack, setEditBack] = useState<Back | null>(null);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 	const [pendingHardDeleteId, setPendingHardDeleteId] = useState<string | null>(null);
@@ -74,12 +72,7 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 	return (
 		<>
 			<div className="flex flex-col gap-4">
-				<div className="flex justify-between items-center">
-					<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("cameras.backsSection")}</h2>
-					<Button size="sm" onClick={() => setShowBackModal(true)}>
-						<Plus size={14} /> {t("cameras.add")}
-					</Button>
-				</div>
+				<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("cameras.backsSection")}</h2>
 
 				<div className="flex flex-col gap-2.5">
 					{activeBacks.map((b) => {
@@ -240,8 +233,6 @@ export function BacksTab({ data, setData }: BacksTabProps) {
 					</CollapsibleSection>
 				)}
 			</div>
-
-			<AddBackDialog open={showBackModal} onOpenChange={setShowBackModal} data={data} setData={setData} />
 
 			{/* Edit back modal */}
 			<Dialog open={!!editBack} onOpenChange={(open) => !open && setEditBack(null)}>

--- a/src/components/equipment/CamerasTab.tsx
+++ b/src/components/equipment/CamerasTab.tsx
@@ -1,4 +1,4 @@
-import { Camera, Check, Edit3, Eye, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Camera, Check, Edit3, Eye, PackageX, RotateCcw, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
@@ -22,7 +22,6 @@ import { type AppData, type Camera as CameraType, INSTANT_FORMATS } from "@/type
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { filmName } from "@/utils/film-helpers";
 import { collectMounts } from "@/utils/lens-helpers";
-import { AddCameraDialog } from "./AddCameraDialog";
 
 interface CamerasTabProps {
 	data: AppData;
@@ -32,7 +31,6 @@ interface CamerasTabProps {
 
 export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	const { t } = useTranslation();
-	const [showAdd, setShowAdd] = useState(false);
 	const [editCam, setEditCam] = useState<(CameraType & { mount?: string | null }) | null>(null);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
 	const [pendingHardDeleteId, setPendingHardDeleteId] = useState<string | null>(null);
@@ -92,12 +90,7 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 	return (
 		<>
 			<div className="flex flex-col gap-4">
-				<div className="flex justify-between items-center">
-					<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("cameras.title")}</h2>
-					<Button size="sm" onClick={() => setShowAdd(true)}>
-						<Plus size={14} /> {t("cameras.add")}
-					</Button>
-				</div>
+				<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("cameras.title")}</h2>
 
 				<div className="flex flex-col gap-2.5">
 					{activeCameras.map((cam) => {
@@ -307,8 +300,6 @@ export function CamerasTab({ data, setData, onCameraClick }: CamerasTabProps) {
 					</CollapsibleSection>
 				)}
 			</div>
-
-			<AddCameraDialog open={showAdd} onOpenChange={setShowAdd} data={data} setData={setData} />
 
 			{/* Edit camera modal */}
 			<Dialog open={!!editCam} onOpenChange={(open) => !open && setEditCam(null)}>

--- a/src/components/equipment/LensesTab.tsx
+++ b/src/components/equipment/LensesTab.tsx
@@ -1,4 +1,4 @@
-import { Edit3, Focus, PackageX, Plus, RotateCcw, Trash2 } from "lucide-react";
+import { Edit3, Focus, PackageX, RotateCcw, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
@@ -13,7 +13,6 @@ import { PhotoImg } from "@/components/ui/photo-img";
 import { alpha, T } from "@/constants/theme";
 import type { AppData, Lens } from "@/types";
 import { collectMounts, lensApertureLabel, lensDisplayName, lensFocalLabel } from "@/utils/lens-helpers";
-import { AddLensDialog } from "./AddLensDialog";
 import { emptyLensForm, formToLens, LensForm, type LensFormData, lensToForm } from "./LensForm";
 
 interface LensesTabProps {
@@ -23,7 +22,6 @@ interface LensesTabProps {
 
 export function LensesTab({ data, setData }: LensesTabProps) {
 	const { t } = useTranslation();
-	const [showAdd, setShowAdd] = useState(false);
 	const [editLensId, setEditLensId] = useState<string | null>(null);
 	const [editLens, setEditLens] = useState<LensFormData>(emptyLensForm);
 	const [viewerPhoto, setViewerPhoto] = useState<string | null>(null);
@@ -77,12 +75,7 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 	return (
 		<>
 			<div className="flex flex-col gap-4">
-				<div className="flex justify-between items-center">
-					<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("lenses.title")}</h2>
-					<Button size="sm" onClick={() => setShowAdd(true)}>
-						<Plus size={14} /> {t("lenses.add")}
-					</Button>
-				</div>
+				<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("lenses.title")}</h2>
 
 				<div className="flex flex-col gap-2.5">
 					{activeLenses.map((lens) => {
@@ -248,14 +241,6 @@ export function LensesTab({ data, setData }: LensesTabProps) {
 					</CollapsibleSection>
 				)}
 			</div>
-
-			<AddLensDialog
-				open={showAdd}
-				onOpenChange={setShowAdd}
-				data={data}
-				setData={setData}
-				mountSuggestions={mountSuggestions}
-			/>
 
 			{/* Edit lens modal */}
 			<Dialog open={!!editLensId} onOpenChange={(open) => !open && setEditLensId(null)}>

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,11 +1,10 @@
-import { Archive, Camera, Clock, Eye, Film, ListTodo, Plus, ScanLine, Snowflake } from "lucide-react";
+import { Archive, Camera, Clock, Eye, Film, ListTodo, ScanLine, Snowflake } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { ActiveRollCard } from "@/components/ActiveRollCard";
 import { EmptyState } from "@/components/EmptyState";
 import { EquipmentCard } from "@/components/EquipmentCard";
 import { StatChip } from "@/components/StatChip";
 import { TodoItem } from "@/components/TodoItem";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { alpha, T } from "@/constants/theme";
 import type { AppData, Back, Camera as CameraType, Film as FilmType } from "@/types";
@@ -15,7 +14,6 @@ interface DashboardScreenProps {
 	data: AppData;
 	onOpenFilm: (id: string) => void;
 	onOpenCameras: () => void;
-	onAddFilm: () => void;
 	setAutoOpenShotNote?: (open: boolean) => void;
 	onNavigateToStock: (stateFilter: string) => void;
 }
@@ -90,7 +88,6 @@ export function DashboardScreen({
 	data,
 	onOpenFilm,
 	onOpenCameras,
-	onAddFilm,
 	setAutoOpenShotNote,
 	onNavigateToStock,
 }: DashboardScreenProps) {
@@ -255,16 +252,7 @@ export function DashboardScreen({
 			)}
 
 			{films.length === 0 && (
-				<EmptyState
-					icon={Film}
-					title={t("dashboard.noFilms")}
-					subtitle={t("dashboard.noFilmsSubtitle")}
-					action={
-						<Button onClick={onAddFilm}>
-							<Plus size={14} /> {t("dashboard.addFilm")}
-						</Button>
-					}
-				/>
+				<EmptyState icon={Film} title={t("dashboard.noFilms")} subtitle={t("dashboard.noFilmsSubtitle")} />
 			)}
 		</div>
 	);

--- a/src/screens/StockScreen.tsx
+++ b/src/screens/StockScreen.tsx
@@ -1,4 +1,4 @@
-import { Film, Plus, Search, SlidersHorizontal } from "lucide-react";
+import { Film, Search, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ActiveFilterChips } from "@/components/ActiveFilterChips";
@@ -75,11 +75,10 @@ const SORT_OPTIONS: { value: SortOption; labelKey: string }[] = [
 interface StockScreenProps {
 	data: AppData;
 	onOpenFilm: (id: string) => void;
-	onAddFilm: () => void;
 	initialStateFilter?: string | null;
 }
 
-export function StockScreen({ data, onOpenFilm, onAddFilm, initialStateFilter }: StockScreenProps) {
+export function StockScreen({ data, onOpenFilm, initialStateFilter }: StockScreenProps) {
 	const { t } = useTranslation();
 	const [filterDialogOpen, setFilterDialogOpen] = useState(false);
 	const { films, cameras, backs } = data;
@@ -104,12 +103,7 @@ export function StockScreen({ data, onOpenFilm, onAddFilm, initialStateFilter }:
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="flex justify-between items-center">
-				<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("stock.title")}</h2>
-				<Button size="sm" onClick={onAddFilm}>
-					<Plus size={14} /> {t("stock.add")}
-				</Button>
-			</div>
+			<h2 className="font-display text-2xl text-text-primary m-0 italic">{t("stock.title")}</h2>
 
 			<div className="flex gap-2">
 				<div className="relative flex-1">


### PR DESCRIPTION
The FloatingActionMenu now serves as the single entry point for adding
films, cameras, lenses and backs. Removes redundant header/empty-state
buttons in Dashboard, Stock and Equipment tabs, along with their
orphaned dialog state and duplicate Add*Dialog renderings (already
mounted at the App root).

https://claude.ai/code/session_01HagYSuuKEZPBcKViu6LT3c