### PR TITLE
feat(auth): replace recovery codes with Magic Link account system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import type { Session } from "@supabase/supabase-js";
 import { Loader2 } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -21,13 +22,22 @@ import { LegalScreen } from "@/screens/LegalScreen";
 import { SettingsScreen } from "@/screens/SettingsScreen";
 import { StatsScreen } from "@/screens/StatsScreen";
 import { StockScreen } from "@/screens/StockScreen";
+import { WelcomeScreen } from "@/screens/WelcomeScreen";
 import { TourOverlay } from "@/tour/TourOverlay";
 import { hasCompletedTour, TourProvider, useTour } from "@/tour/TourProvider";
 import type { AppData, ScreenName } from "@/types";
 import { refreshCatalogs } from "@/utils/catalog";
 import { checkStorage, getInitialData, isStorageAvailable, loadData, saveData } from "@/utils/storage";
-import { ensureAnonSession, isSupabaseConfigured } from "@/utils/supabase";
-import { getRecoveryCode, pushToCloud, syncData } from "@/utils/sync";
+import { isLocalOnly, isSupabaseConfigured, setLocalOnly, signOut, supabase } from "@/utils/supabase";
+import {
+	clearLegacyRecoveryCode,
+	clearLocalSyncState,
+	ensureProfile,
+	getLegacyRecoveryCode,
+	linkRecoveryCode,
+	pushToCloud,
+	syncData,
+} from "@/utils/sync";
 import { useNavigationStack } from "@/utils/use-navigation-stack";
 
 const MapScreen = lazy(() => import("@/screens/MapScreen").then((m) => ({ default: m.MapScreen })));
@@ -38,6 +48,8 @@ const SUB_SCREENS: ReadonlySet<ScreenName> = new Set(["filmDetail", "cameraDetai
 function FilmVaultInner() {
 	const [data, setData] = useState<AppData | null>(null);
 	const [loading, setLoading] = useState(true);
+	const [showWelcome, setShowWelcome] = useState(false);
+	const [session, setSession] = useState<Session | null>(null);
 	const nav = useNavigationStack({ screen: "home" });
 	const [autoOpenShotNote, setAutoOpenShotNote] = useState(false);
 	const [showAddFilm, setShowAddFilm] = useState(false);
@@ -47,7 +59,6 @@ function FilmVaultInner() {
 	const [showQuickShot, setShowQuickShot] = useState(false);
 	const [persistent, setPersistent] = useState(false);
 	const [syncing, setSyncing] = useState(false);
-	const [recoveryCode, setRecoveryCodeState] = useState<string | null>(null);
 	const { toast } = useToast();
 	const { t } = useTranslation();
 	const dataRef = useRef<AppData | null>(null);
@@ -60,22 +71,20 @@ function FilmVaultInner() {
 				const ok = await saveData(newData);
 				if (!ok) toast(t("app.saveError"), "error");
 			}
-			// Background push to cloud
-			const code = getRecoveryCode();
-			if (code && isSupabaseConfigured) {
-				pushToCloud(code, newData).catch(() => {});
+			// Background push to cloud (only when signed in)
+			if (session && isSupabaseConfigured) {
+				pushToCloud(newData).catch(() => {});
 			}
 		},
-		[toast, t],
+		[toast, t, session],
 	);
 
 	const triggerSync = useCallback(async () => {
-		const code = getRecoveryCode();
 		const currentData = dataRef.current;
-		if (!code || !currentData || !isSupabaseConfigured) return;
+		if (!session || !currentData || !isSupabaseConfigured) return;
 		setSyncing(true);
 		try {
-			const result = await syncData(code, currentData);
+			const result = await syncData(currentData);
 			if (result.source === "cloud") {
 				setData(result.data);
 				dataRef.current = result.data;
@@ -87,16 +96,12 @@ function FilmVaultInner() {
 		} finally {
 			setSyncing(false);
 		}
-	}, [toast, t]);
+	}, [toast, t, session]);
 
+	// Bootstrap: load local data, decide whether to show welcome screen
 	useEffect(() => {
 		let cancelled = false;
 		(async () => {
-			// Ensure anonymous auth session before any cloud operations
-			if (isSupabaseConfigured && navigator.onLine) {
-				await ensureAnonSession();
-			}
-
 			const hasStorage = await checkStorage();
 			if (cancelled) return;
 			setPersistent(hasStorage);
@@ -109,30 +114,28 @@ function FilmVaultInner() {
 				appData = getInitialData();
 			}
 
-			// Sync with cloud on startup
-			const code = getRecoveryCode();
-			setRecoveryCodeState(code);
-			if (code && isSupabaseConfigured && navigator.onLine) {
-				try {
-					const result = await syncData(code, appData);
-					appData = result.data;
-					if (result.source === "cloud" && hasStorage) {
-						await saveData(appData);
-					}
-				} catch {
-					// Sync failed silently, use local data
-				}
-			}
-
-			// Refresh catalogs in background (non-blocking)
-			if (isSupabaseConfigured && navigator.onLine) {
-				refreshCatalogs().catch(() => {});
+			// Read current session (if any). supabase-js auto-detects the URL hash
+			// after a Magic Link redirect and persists the session in localStorage.
+			let currentSession: Session | null = null;
+			if (isSupabaseConfigured && supabase) {
+				const { data: sessionData } = await supabase.auth.getSession();
+				currentSession = sessionData.session;
 			}
 
 			if (!cancelled) {
+				setSession(currentSession);
 				setData(appData);
 				dataRef.current = appData;
 				setLoading(false);
+
+				// Decide if we should display the welcome screen.
+				// First-time visitors with no session and no local-only flag see it,
+				// unless they already have legacy data (recovery code) — those
+				// should land on the app and migrate from Settings.
+				const hasLegacy = !!getLegacyRecoveryCode();
+				if (!currentSession && !isLocalOnly() && !hasLegacy && isSupabaseConfigured) {
+					setShowWelcome(true);
+				}
 			}
 		})();
 		return () => {
@@ -140,15 +143,81 @@ function FilmVaultInner() {
 		};
 	}, []);
 
-	// Sync when coming back online (ensure auth session first)
+	// Subscribe to auth state changes (Magic Link callback, sign out from another tab, etc.)
 	useEffect(() => {
-		const handleOnline = async () => {
-			await ensureAnonSession();
+		if (!supabase) return;
+		const { data: sub } = supabase.auth.onAuthStateChange((_event, newSession) => {
+			setSession(newSession);
+			if (newSession) setShowWelcome(false);
+		});
+		return () => sub.subscription.unsubscribe();
+	}, []);
+
+	// On sign-in: bootstrap profile, migrate legacy recovery code if any, then sync.
+	useEffect(() => {
+		if (!session || !isSupabaseConfigured) return;
+		let cancelled = false;
+		(async () => {
+			// 1. If we have a legacy recovery code in localStorage, link it first
+			//    so ensure_profile finds the existing profile (instead of creating a new one).
+			const legacy = getLegacyRecoveryCode();
+			if (legacy) {
+				const linked = await linkRecoveryCode(legacy);
+				clearLegacyRecoveryCode();
+				if (linked) {
+					toast(t("account.migrated"), "success");
+				}
+			}
+
+			// 2. Ensure a profile exists for this session (idempotent).
+			await ensureProfile();
+
+			if (cancelled) return;
+
+			// 3. Sync local ↔ cloud.
+			const currentData = dataRef.current;
+			if (!currentData) return;
+			setSyncing(true);
+			try {
+				const result = await syncData(currentData);
+				if (result.source === "cloud") {
+					setData(result.data);
+					dataRef.current = result.data;
+					if (isStorageAvailable()) await saveData(result.data);
+				}
+			} catch {
+				// silent
+			} finally {
+				if (!cancelled) setSyncing(false);
+			}
+
+			// 4. Refresh catalogs (non-blocking).
+			refreshCatalogs().catch(() => {});
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [session, toast, t]);
+
+	// Sync when coming back online
+	useEffect(() => {
+		const handleOnline = () => {
 			triggerSync();
 		};
 		window.addEventListener("online", handleOnline);
 		return () => window.removeEventListener("online", handleOnline);
 	}, [triggerSync]);
+
+	const handleSignOut = useCallback(async () => {
+		await signOut();
+		clearLocalSyncState();
+		setSession(null);
+	}, []);
+
+	const handleContinueLocal = useCallback(() => {
+		setLocalOnly(true);
+		setShowWelcome(false);
+	}, []);
 
 	const { resetTo: navResetTo, replace: navReplace, current: navCurrent } = nav;
 
@@ -176,6 +245,10 @@ function FilmVaultInner() {
 		);
 	}
 
+	if (showWelcome) {
+		return <WelcomeScreen onContinueLocal={handleContinueLocal} />;
+	}
+
 	return (
 		<TourProvider setScreen={resetScreen} setSelectedFilm={tourSetSelectedFilm}>
 			<AppContent
@@ -196,8 +269,8 @@ function FilmVaultInner() {
 				showQuickShot={showQuickShot}
 				setShowQuickShot={setShowQuickShot}
 				syncing={syncing}
-				recoveryCode={recoveryCode}
-				setRecoveryCodeState={setRecoveryCodeState}
+				session={session}
+				onSignOut={handleSignOut}
 				triggerSync={triggerSync}
 				persistent={persistent}
 			/>
@@ -223,8 +296,8 @@ interface AppContentProps {
 	showQuickShot: boolean;
 	setShowQuickShot: (open: boolean) => void;
 	syncing: boolean;
-	recoveryCode: string | null;
-	setRecoveryCodeState: (code: string | null) => void;
+	session: Session | null;
+	onSignOut: () => Promise<void>;
 	triggerSync: () => Promise<void>;
 	persistent: boolean;
 }
@@ -247,8 +320,8 @@ function AppContent({
 	showQuickShot,
 	setShowQuickShot,
 	syncing,
-	recoveryCode,
-	setRecoveryCodeState,
+	session,
+	onSignOut,
 	triggerSync,
 	persistent,
 }: AppContentProps) {
@@ -379,8 +452,8 @@ function AppContent({
 						data={effectiveData}
 						setData={effectiveUpdateData}
 						syncing={syncing}
-						recoveryCode={recoveryCode}
-						onRecoveryCodeChange={setRecoveryCodeState}
+						session={session}
+						onSignOut={onSignOut}
 						onSyncNow={triggerSync}
 						persistent={persistent}
 						onOpenLegal={openLegal}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,11 +160,13 @@ function FilmVaultInner() {
 		(async () => {
 			// 1. If we have a legacy recovery code in localStorage, link it first
 			//    so ensure_profile finds the existing profile (instead of creating a new one).
+			//    Only clear the code on success — keeping it lets us retry on a
+			//    transient network/server failure on the next launch.
 			const legacy = getLegacyRecoveryCode();
 			if (legacy) {
 				const linked = await linkRecoveryCode(legacy);
-				clearLegacyRecoveryCode();
 				if (linked) {
+					clearLegacyRecoveryCode();
 					toast(t("account.migrated"), "success");
 				}
 			}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -473,6 +473,33 @@ export const en = {
 		hardDeleteBackConfirm: "This will remove all references to this back from your films. Continue?",
 	},
 
+	// Account / authentication
+	account: {
+		title: "Account",
+		welcomeTitle: "Welcome to FilmVault",
+		welcomeSubtitle: "Sync your films across all your devices.",
+		welcomeFooter: "Your data stays on this device until you turn on sync.",
+		signInWithEmail: "Sign in with email",
+		signInHelp: "Sign in to sync your data across all your devices.",
+		continueWithoutAccount: "Continue without an account",
+		emailHelp: "Get a magic link to sign in without a password.",
+		emailPlaceholder: "your@email.com",
+		sendMagicLink: "Send the link",
+		sendError: "Couldn't send the link. Check the address and your connection.",
+		checkInbox: "Check your inbox",
+		checkInboxHelp: "Click the link we just sent to {{email}}.",
+		useDifferentEmail: "Use a different address",
+		back: "Back",
+		signOut: "Sign out",
+		signedInAsLabel: "Signed in as",
+		exportCode: "Export code (recovery)",
+		exportCodeHelp: "Keep this code to recover your data if you lose access to your email.",
+		legacyMigrationLabel: "Import a legacy code",
+		legacyMigrationHelp:
+			"Were you using FilmVault with a recovery code? Paste it here to merge that data into this account.",
+		migrated: "Imported data from your legacy code",
+	},
+
 	// Settings screen
 	settings: {
 		cloudBackup: "Cloud backup",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -473,6 +473,33 @@ export const fr = {
 		hardDeleteBackConfirm: "Cette action supprimera toutes les références à ce dos sur vos pellicules. Continuer ?",
 	},
 
+	// Account / authentication
+	account: {
+		title: "Compte",
+		welcomeTitle: "Bienvenue sur FilmVault",
+		welcomeSubtitle: "Synchronise tes pellicules sur tous tes appareils.",
+		welcomeFooter: "Tes données restent sur ton appareil tant que tu n'actives pas la synchro.",
+		signInWithEmail: "Se connecter par email",
+		signInHelp: "Connecte-toi pour synchroniser tes données sur tous tes appareils.",
+		continueWithoutAccount: "Continuer sans compte",
+		emailHelp: "Reçois un lien magique pour te connecter sans mot de passe.",
+		emailPlaceholder: "ton@email.com",
+		sendMagicLink: "Recevoir le lien",
+		sendError: "Impossible d'envoyer le lien. Vérifie l'adresse et ta connexion.",
+		checkInbox: "Vérifie ta boîte mail",
+		checkInboxHelp: "Clique sur le lien que nous venons d'envoyer à {{email}}.",
+		useDifferentEmail: "Utiliser une autre adresse",
+		back: "Retour",
+		signOut: "Se déconnecter",
+		signedInAsLabel: "Connecté en tant que",
+		exportCode: "Code d'export (secours)",
+		exportCodeHelp: "Garde ce code pour récupérer tes données si tu perds l'accès à ton email.",
+		legacyMigrationLabel: "Importer un ancien code",
+		legacyMigrationHelp:
+			"Tu utilisais FilmVault avec un code de récupération ? Colle-le ici pour rapatrier tes données dans ce compte.",
+		migrated: "Données importées depuis ton ancien code",
+	},
+
 	// Settings screen
 	settings: {
 		cloudBackup: "Sauvegarde cloud",

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -136,9 +136,12 @@ export function SettingsScreen({
 		if (!code) return;
 		setRestoring(true);
 		try {
+			// linkRecoveryCode returns null both for invalid codes and for
+			// network/server failures, so surface a generic error rather than
+			// claiming the code was wrong.
 			const profileId = await linkRecoveryCode(code);
 			if (!profileId) {
-				setImportError(t("settings.noDataFound"));
+				setImportError(t("settings.restoreError"));
 				return;
 			}
 

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,10 +1,10 @@
+import type { Session } from "@supabase/supabase-js";
 import {
 	AlertTriangle,
 	BookOpen,
 	Camera as CameraIcon,
 	Check,
 	Cloud,
-	CloudOff,
 	Copy,
 	Database,
 	Download,
@@ -12,12 +12,14 @@ import {
 	Focus,
 	Globe,
 	Loader2,
+	LogOut,
+	Mail,
 	Package,
 	Play,
 	RefreshCw,
 	Upload,
 } from "lucide-react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -30,24 +32,15 @@ import type { AppData } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { lensDisplayName } from "@/utils/lens-helpers";
 import { exportData, parseImportFile } from "@/utils/storage";
-import { isSupabaseConfigured } from "@/utils/supabase";
-import {
-	activateCloud,
-	clearRecoveryCode,
-	generateRecoveryCode,
-	getLastSync,
-	linkRecoveryCode,
-	pullFromCloud,
-	pushToCloud,
-	setRecoveryCode,
-} from "@/utils/sync";
+import { isSupabaseConfigured, signInWithEmail } from "@/utils/supabase";
+import { fetchRecoveryCode, getLastSync, linkRecoveryCode, pullFromCloud } from "@/utils/sync";
 
 interface SettingsScreenProps {
 	data: AppData;
 	setData: (data: AppData) => void;
 	syncing: boolean;
-	recoveryCode: string | null;
-	onRecoveryCodeChange: (code: string | null) => void;
+	session: Session | null;
+	onSignOut: () => Promise<void>;
 	onSyncNow: () => void;
 	persistent: boolean;
 	onOpenLegal: () => void;
@@ -57,8 +50,8 @@ export function SettingsScreen({
 	data,
 	setData,
 	syncing,
-	recoveryCode,
-	onRecoveryCodeChange,
+	session,
+	onSignOut,
 	onSyncNow,
 	persistent,
 	onOpenLegal,
@@ -67,9 +60,28 @@ export function SettingsScreen({
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const [importPreview, setImportPreview] = useState<AppData | null>(null);
 	const [importError, setImportError] = useState<string | null>(null);
+	const [signInEmail, setSignInEmail] = useState("");
+	const [signInSubmitting, setSignInSubmitting] = useState(false);
+	const [signInSent, setSignInSent] = useState(false);
 	const [restoreCode, setRestoreCode] = useState("");
 	const [restoring, setRestoring] = useState(false);
+	const [exportCode, setExportCode] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
+
+	// Fetch the export/secours recovery code once signed in.
+	useEffect(() => {
+		if (!session) {
+			setExportCode(null);
+			return;
+		}
+		let cancelled = false;
+		fetchRecoveryCode().then((code) => {
+			if (!cancelled) setExportCode(code);
+		});
+		return () => {
+			cancelled = true;
+		};
+	}, [session]);
 
 	const handleImportClick = () => {
 		fileInputRef.current?.click();
@@ -98,20 +110,17 @@ export function SettingsScreen({
 		}
 	};
 
-	const handleActivateCloud = async () => {
-		const code = generateRecoveryCode();
-		try {
-			const profileId = await activateCloud(code);
-			if (!profileId) {
-				setImportError(t("settings.pushFailed"));
-				return;
-			}
-			await pushToCloud(code, data);
-			setRecoveryCode(code);
-			onRecoveryCodeChange(code);
-		} catch {
-			setImportError(t("settings.pushFailed"));
+	const handleSendMagicLink = async () => {
+		const trimmed = signInEmail.trim();
+		if (!trimmed) return;
+		setSignInSubmitting(true);
+		const { error } = await signInWithEmail(trimmed);
+		setSignInSubmitting(false);
+		if (error) {
+			setImportError(t("account.sendError"));
+			return;
 		}
+		setSignInSent(true);
 	};
 
 	const pullErrorKey: Record<string, string> = {
@@ -121,24 +130,25 @@ export function SettingsScreen({
 		supabase_not_configured: "settings.cloudNotConfigured",
 	};
 
-	const handleRestore = async () => {
+	// Import a legacy recovery code into the currently signed-in account.
+	const handleRestoreLegacy = async () => {
 		const code = restoreCode.trim().toUpperCase();
 		if (!code) return;
 		setRestoring(true);
 		try {
-			// Link the recovery code to the current anonymous session
 			const profileId = await linkRecoveryCode(code);
 			if (!profileId) {
 				setImportError(t("settings.noDataFound"));
 				return;
 			}
 
-			const result = await pullFromCloud(code);
+			const result = await pullFromCloud();
 			if ("data" in result) {
-				setRecoveryCode(code);
-				onRecoveryCodeChange(code);
 				setData(result.data);
 				setRestoreCode("");
+				// Refresh the export code now that the profile changed.
+				const newCode = await fetchRecoveryCode();
+				setExportCode(newCode);
 			} else {
 				setImportError(t(pullErrorKey[result.error] ?? "settings.restoreError"));
 			}
@@ -149,15 +159,10 @@ export function SettingsScreen({
 		}
 	};
 
-	const handleDisconnect = () => {
-		clearRecoveryCode();
-		onRecoveryCodeChange(null);
-	};
-
 	const handleCopyCode = async () => {
-		if (!recoveryCode) return;
+		if (!exportCode) return;
 		try {
-			await navigator.clipboard.writeText(recoveryCode);
+			await navigator.clipboard.writeText(exportCode);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		} catch {
@@ -168,6 +173,7 @@ export function SettingsScreen({
 	const { startTour } = useTour();
 	const lastSync = getLastSync();
 	const currentLang = i18n.language;
+	const userEmail = session?.user.email;
 
 	return (
 		<div className="flex flex-col gap-5">
@@ -207,36 +213,21 @@ export function SettingsScreen({
 				</Button>
 			</Card>
 
-			{/* Cloud backup section */}
+			{/* Account section */}
 			{isSupabaseConfigured && (
 				<Card>
 					<div className="flex items-center gap-3 mb-4">
 						<Cloud size={18} className="text-accent" />
-						<span className="text-sm font-bold text-text-primary font-body">{t("settings.cloudBackup")}</span>
+						<span className="text-sm font-bold text-text-primary font-body">{t("account.title")}</span>
 					</div>
 
-					{recoveryCode ? (
+					{session ? (
 						<div className="flex flex-col gap-3">
-							<div className="flex flex-col gap-1.5">
+							<div className="flex flex-col gap-1">
 								<span className="text-[10px] font-bold text-text-muted font-body uppercase tracking-wide">
-									{t("settings.recoveryCode")}
+									{t("account.signedInAsLabel")}
 								</span>
-								<div className="flex items-center gap-2">
-									<span className="text-sm font-mono text-accent tracking-wider">{recoveryCode}</span>
-									<Button
-										variant="ghost"
-										onClick={handleCopyCode}
-										className="!p-1 !min-h-0"
-										aria-label={t("aria.copyRecoveryCode")}
-									>
-										{copied ? (
-											<Check size={14} className="text-green" />
-										) : (
-											<Copy size={14} className="text-text-muted" />
-										)}
-									</Button>
-								</div>
-								<span className="text-[11px] text-text-muted font-body">{t("settings.recoveryCodeHelp")}</span>
+								<span className="text-sm text-text-primary font-body break-all">{userEmail}</span>
 							</div>
 
 							{lastSync && (
@@ -259,22 +250,41 @@ export function SettingsScreen({
 									{syncing ? <Loader2 size={16} className="animate-spin" /> : <RefreshCw size={16} />}
 									{syncing ? t("settings.syncing") : t("settings.sync")}
 								</Button>
-								<Button variant="outline" onClick={handleDisconnect} className="w-full justify-center">
-									<CloudOff size={16} /> {t("settings.disconnect")}
+								<Button variant="outline" onClick={onSignOut} className="w-full justify-center">
+									<LogOut size={16} /> {t("account.signOut")}
 								</Button>
 							</div>
-						</div>
-					) : (
-						<div className="flex flex-col gap-3">
-							<span className="text-xs text-text-sec font-body">{t("settings.cloudInfo")}</span>
 
-							<Button variant="outline" onClick={handleActivateCloud} className="w-full justify-center">
-								<Cloud size={16} /> {t("settings.enableCloud")}
-							</Button>
+							{exportCode && (
+								<div className="border-t border-border pt-3 mt-1 flex flex-col gap-1.5">
+									<span className="text-[10px] font-bold text-text-muted font-body uppercase tracking-wide">
+										{t("account.exportCode")}
+									</span>
+									<div className="flex items-center gap-2">
+										<span className="text-sm font-mono text-accent tracking-wider">{exportCode}</span>
+										<Button
+											variant="ghost"
+											onClick={handleCopyCode}
+											className="!p-1 !min-h-0"
+											aria-label={t("aria.copyRecoveryCode")}
+										>
+											{copied ? (
+												<Check size={14} className="text-green" />
+											) : (
+												<Copy size={14} className="text-text-muted" />
+											)}
+										</Button>
+									</div>
+									<span className="text-[11px] text-text-muted font-body">{t("account.exportCodeHelp")}</span>
+								</div>
+							)}
 
-							<div className="border-t border-border pt-3">
+							<div className="border-t border-border pt-3 mt-1">
 								<span className="text-[10px] font-bold text-text-muted font-body uppercase tracking-wide block mb-2">
-									{t("settings.haveCode")}
+									{t("account.legacyMigrationLabel")}
+								</span>
+								<span className="text-[11px] text-text-muted font-body block mb-2">
+									{t("account.legacyMigrationHelp")}
 								</span>
 								<div className="flex gap-2">
 									<Input
@@ -285,7 +295,7 @@ export function SettingsScreen({
 									/>
 									<Button
 										variant="outline"
-										onClick={handleRestore}
+										onClick={handleRestoreLegacy}
 										disabled={restoring || !restoreCode.trim()}
 										className="shrink-0"
 									>
@@ -293,6 +303,46 @@ export function SettingsScreen({
 									</Button>
 								</div>
 							</div>
+						</div>
+					) : signInSent ? (
+						<div className="flex flex-col gap-3">
+							<span className="text-xs text-text-sec font-body">
+								{t("account.checkInboxHelp", { email: signInEmail.trim() })}
+							</span>
+							<Button
+								variant="outline"
+								onClick={() => {
+									setSignInSent(false);
+									setSignInEmail("");
+								}}
+								className="w-full justify-center"
+							>
+								{t("account.useDifferentEmail")}
+							</Button>
+						</div>
+					) : (
+						<div className="flex flex-col gap-3">
+							<span className="text-xs text-text-sec font-body">{t("account.signInHelp")}</span>
+							<Input
+								type="email"
+								autoComplete="email"
+								inputMode="email"
+								value={signInEmail}
+								onChange={(e) => setSignInEmail(e.target.value)}
+								placeholder={t("account.emailPlaceholder")}
+								disabled={signInSubmitting}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleSendMagicLink();
+								}}
+							/>
+							<Button
+								onClick={handleSendMagicLink}
+								disabled={signInSubmitting || !signInEmail.trim()}
+								className="w-full justify-center"
+							>
+								{signInSubmitting ? <Loader2 size={16} className="animate-spin" /> : <Mail size={16} />}
+								{t("account.sendMagicLink")}
+							</Button>
 						</div>
 					)}
 				</Card>

--- a/src/screens/WelcomeScreen.tsx
+++ b/src/screens/WelcomeScreen.tsx
@@ -1,0 +1,130 @@
+import { ArrowRight, CheckCircle2, Cloud, Loader2, Mail } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { signInWithEmail } from "@/utils/supabase";
+
+interface WelcomeScreenProps {
+	onContinueLocal: () => void;
+}
+
+type Step = "intro" | "email" | "sent";
+
+export function WelcomeScreen({ onContinueLocal }: WelcomeScreenProps) {
+	const { t } = useTranslation();
+	const [step, setStep] = useState<Step>("intro");
+	const [email, setEmail] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const handleSendLink = async () => {
+		const trimmed = email.trim();
+		if (!trimmed) return;
+		setSubmitting(true);
+		setError(null);
+		const { error: err } = await signInWithEmail(trimmed);
+		setSubmitting(false);
+		if (err) {
+			setError(t("account.sendError"));
+			return;
+		}
+		setStep("sent");
+	};
+
+	return (
+		<div className="min-h-[100dvh] bg-bg text-text-primary flex flex-col items-center justify-center p-6">
+			<div className="w-full max-w-sm flex flex-col gap-6">
+				{step === "intro" && (
+					<>
+						<div className="flex flex-col items-center gap-3 text-center">
+							<div className="w-16 h-16 rounded-2xl bg-accent-soft flex items-center justify-center">
+								<Cloud size={28} className="text-accent" />
+							</div>
+							<h1 className="text-xl font-bold font-body">{t("account.welcomeTitle")}</h1>
+							<p className="text-sm text-text-sec font-body">{t("account.welcomeSubtitle")}</p>
+						</div>
+
+						<div className="flex flex-col gap-2.5 mt-2">
+							<Button onClick={() => setStep("email")} className="w-full justify-center">
+								<Mail size={16} /> {t("account.signInWithEmail")}
+								<ArrowRight size={14} />
+							</Button>
+							<Button variant="ghost" onClick={onContinueLocal} className="w-full justify-center">
+								{t("account.continueWithoutAccount")}
+							</Button>
+						</div>
+						<p className="text-[11px] text-text-muted font-body text-center">{t("account.welcomeFooter")}</p>
+					</>
+				)}
+
+				{step === "email" && (
+					<>
+						<div className="flex flex-col items-center gap-3 text-center">
+							<div className="w-16 h-16 rounded-2xl bg-accent-soft flex items-center justify-center">
+								<Mail size={28} className="text-accent" />
+							</div>
+							<h1 className="text-xl font-bold font-body">{t("account.signInWithEmail")}</h1>
+							<p className="text-sm text-text-sec font-body">{t("account.emailHelp")}</p>
+						</div>
+
+						<div className="flex flex-col gap-3">
+							<Input
+								type="email"
+								autoComplete="email"
+								inputMode="email"
+								value={email}
+								onChange={(e) => {
+									setEmail(e.target.value);
+									setError(null);
+								}}
+								placeholder={t("account.emailPlaceholder")}
+								disabled={submitting}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleSendLink();
+								}}
+							/>
+							{error && <span className="text-xs text-accent font-body">{error}</span>}
+							<Button onClick={handleSendLink} disabled={submitting || !email.trim()} className="w-full justify-center">
+								{submitting ? <Loader2 size={16} className="animate-spin" /> : <Mail size={16} />}
+								{t("account.sendMagicLink")}
+							</Button>
+							<Button
+								variant="ghost"
+								onClick={() => setStep("intro")}
+								disabled={submitting}
+								className="w-full justify-center"
+							>
+								{t("account.back")}
+							</Button>
+						</div>
+					</>
+				)}
+
+				{step === "sent" && (
+					<>
+						<div className="flex flex-col items-center gap-3 text-center">
+							<div className="w-16 h-16 rounded-2xl bg-accent-soft flex items-center justify-center">
+								<CheckCircle2 size={28} className="text-accent" />
+							</div>
+							<h1 className="text-xl font-bold font-body">{t("account.checkInbox")}</h1>
+							<p className="text-sm text-text-sec font-body">{t("account.checkInboxHelp", { email: email.trim() })}</p>
+						</div>
+
+						<div className="flex flex-col gap-2.5">
+							<Button
+								variant="outline"
+								onClick={() => {
+									setStep("email");
+								}}
+								className="w-full justify-center"
+							>
+								{t("account.useDifferentEmail")}
+							</Button>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,7 +166,8 @@ export type ScreenName =
 	| "stats"
 	| "settings"
 	| "legal"
-	| "map";
+	| "map"
+	| "welcome";
 
 export interface NavigationEntry {
 	screen: ScreenName;

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type Session, type User } from "@supabase/supabase-js";
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
@@ -7,22 +7,68 @@ export const isSupabaseConfigured = Boolean(supabaseUrl && supabaseAnonKey);
 
 export const supabase = isSupabaseConfigured ? createClient(supabaseUrl!, supabaseAnonKey!) : null;
 
-/**
- * Ensure an anonymous auth session exists.
- * Called once at app startup when Supabase is configured.
- * If a session already exists (persisted by supabase-js in localStorage), this is a no-op.
- */
-export async function ensureAnonSession(): Promise<void> {
-	if (!supabase) return;
+const LOCAL_ONLY_KEY = "filmvault-local-only";
 
+/**
+ * Get the current Supabase session (null if signed out or Supabase not configured).
+ */
+export async function getCurrentSession(): Promise<Session | null> {
+	if (!supabase) return null;
 	const {
 		data: { session },
 	} = await supabase.auth.getSession();
+	return session;
+}
 
-	if (session) return;
+/**
+ * Get the current authenticated user.
+ */
+export async function getCurrentUser(): Promise<User | null> {
+	const session = await getCurrentSession();
+	return session?.user ?? null;
+}
 
-	const { error } = await supabase.auth.signInAnonymously();
-	if (error) {
-		console.error("Anonymous sign-in failed:", error.message);
+/**
+ * Send a Magic Link to the given email. The user clicks the link and is
+ * redirected back to the app with a session in the URL fragment, which
+ * supabase-js auto-detects.
+ */
+export async function signInWithEmail(email: string): Promise<{ error: string | null }> {
+	if (!supabase) return { error: "supabase_not_configured" };
+	const redirectTo = window.location.origin + import.meta.env.BASE_URL;
+	const { error } = await supabase.auth.signInWithOtp({
+		email,
+		options: { emailRedirectTo: redirectTo },
+	});
+	return { error: error?.message ?? null };
+}
+
+/**
+ * Sign the current user out. Clears the local session.
+ */
+export async function signOut(): Promise<void> {
+	if (!supabase) return;
+	await supabase.auth.signOut();
+}
+
+// --- Local-only mode ---
+//
+// User chose "Continue without an account" on the welcome screen. Persisted
+// so we don't show the welcome screen again on this device.
+
+export function isLocalOnly(): boolean {
+	try {
+		return localStorage.getItem(LOCAL_ONLY_KEY) === "1";
+	} catch {
+		return false;
+	}
+}
+
+export function setLocalOnly(value: boolean): void {
+	try {
+		if (value) localStorage.setItem(LOCAL_ONLY_KEY, "1");
+		else localStorage.removeItem(LOCAL_ONLY_KEY);
+	} catch {
+		// ignore
 	}
 }

--- a/src/utils/sync.ts
+++ b/src/utils/sync.ts
@@ -3,11 +3,11 @@ import { applyMigrations, CURRENT_VERSION, validateAppData } from "@/utils/migra
 import { clearUrlCache, extractAndUploadPhotos, hasBase64Photos } from "@/utils/photo-sync";
 import { isSupabaseConfigured, supabase } from "@/utils/supabase";
 
-const RECOVERY_CODE_KEY = "filmvault-recovery-code";
+const LEGACY_RECOVERY_CODE_KEY = "filmvault-recovery-code";
 const LAST_SYNC_KEY = "filmvault-last-sync";
 const LAST_MODIFIED_KEY = "filmvault-last-modified";
 
-// --- Recovery code management ---
+// --- Legacy recovery code (read-only, for migration) ---
 
 export function generateRecoveryCode(): string {
 	const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"; // no I/O/0/1 to avoid confusion
@@ -16,21 +16,33 @@ export function generateRecoveryCode(): string {
 	return `FILM-${code.slice(0, 4)}-${code.slice(4)}`;
 }
 
-export function getRecoveryCode(): string | null {
+export function getLegacyRecoveryCode(): string | null {
 	try {
-		return localStorage.getItem(RECOVERY_CODE_KEY);
+		return localStorage.getItem(LEGACY_RECOVERY_CODE_KEY);
 	} catch {
 		return null;
 	}
 }
 
-export function setRecoveryCode(code: string): void {
-	localStorage.setItem(RECOVERY_CODE_KEY, code);
+export function clearLegacyRecoveryCode(): void {
+	try {
+		localStorage.removeItem(LEGACY_RECOVERY_CODE_KEY);
+	} catch {
+		// ignore
+	}
 }
 
-export function clearRecoveryCode(): void {
-	localStorage.removeItem(RECOVERY_CODE_KEY);
-	localStorage.removeItem(LAST_SYNC_KEY);
+/**
+ * Clear all local sync-related state (legacy code, last-sync timestamp, URL cache).
+ * Called on sign-out.
+ */
+export function clearLocalSyncState(): void {
+	clearLegacyRecoveryCode();
+	try {
+		localStorage.removeItem(LAST_SYNC_KEY);
+	} catch {
+		// ignore
+	}
 	clearUrlCache();
 }
 
@@ -60,34 +72,46 @@ function setLastSync(): void {
 	localStorage.setItem(LAST_SYNC_KEY, new Date().toISOString());
 }
 
-// --- Cloud activation / restore ---
+// --- Profile bootstrap ---
 
 /**
- * Activate cloud sync: creates a user profile linked to the current anonymous session.
- * Returns the profile UUID on success, or null on failure.
+ * Ensure a user_profiles row exists for the current authenticated session.
+ * Idempotent. Returns the profile UUID on success, or null on failure.
  */
-export async function activateCloud(recoveryCode: string): Promise<string | null> {
+export async function ensureProfile(): Promise<string | null> {
 	if (!supabase) return null;
 	try {
-		const { data, error } = await supabase.rpc("activate_cloud", {
-			p_recovery_code: recoveryCode,
-		});
+		const { data, error } = await supabase.rpc("ensure_profile");
 		if (error) {
-			console.error("activate_cloud failed:", error.message);
+			console.error("ensure_profile failed:", error.message);
 			return null;
 		}
-		// Reset caches so subsequent operations use the new profile
 		clearUrlCache();
 		return data as string;
 	} catch (e) {
-		console.error("activate_cloud failed:", e);
+		console.error("ensure_profile failed:", e);
 		return null;
 	}
 }
 
 /**
- * Link an existing recovery code to the current anonymous session (for restore).
- * Returns the profile UUID on success, or null on failure.
+ * Fetch the recovery code (export/secours token) for the current authenticated user.
+ * Returns null if no profile is linked yet.
+ */
+export async function fetchRecoveryCode(): Promise<string | null> {
+	if (!supabase) return null;
+	try {
+		const { data, error } = await supabase.rpc("get_recovery_code");
+		if (error) return null;
+		return (data as string) ?? null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Link a legacy recovery code to the current authenticated session (one-shot migration).
+ * Re-points the existing profile from any previous auth.uid() to the new one.
  */
 export async function linkRecoveryCode(recoveryCode: string): Promise<string | null> {
 	if (!supabase) return null;
@@ -99,7 +123,6 @@ export async function linkRecoveryCode(recoveryCode: string): Promise<string | n
 			console.error("link_recovery_code failed:", error.message);
 			return null;
 		}
-		// Reset caches so subsequent operations use the new profile
 		clearUrlCache();
 		return data as string;
 	} catch (e) {
@@ -108,9 +131,9 @@ export async function linkRecoveryCode(recoveryCode: string): Promise<string | n
 	}
 }
 
-// --- Cloud operations (v3: auth.uid() based) ---
+// --- Cloud operations (auth.uid()-based; no recovery code argument) ---
 
-export async function pushToCloud(_code: string, data: AppData): Promise<boolean> {
+export async function pushToCloud(data: AppData): Promise<boolean> {
 	if (!supabase) return false;
 	try {
 		// Upload photos to Storage, replace base64 with paths in the cloud copy
@@ -136,7 +159,7 @@ export async function pushToCloud(_code: string, data: AppData): Promise<boolean
 export type PullError = "supabase_not_configured" | "not_found" | "network_error" | "invalid_data";
 export type PullResult = { data: AppData } | { error: PullError };
 
-export async function pullFromCloud(_code: string): Promise<PullResult> {
+export async function pullFromCloud(): Promise<PullResult> {
 	if (!supabase) return { error: "supabase_not_configured" };
 	try {
 		const { data: rows, error } = await supabase.rpc("get_user_data_v3");
@@ -173,38 +196,24 @@ export async function pullFromCloud(_code: string): Promise<PullResult> {
  * - If local is newer → pushes to cloud, returns local data
  * - If no cloud data → pushes local to cloud, returns local data
  */
-export async function syncData(
-	code: string,
-	localData: AppData,
-): Promise<{ data: AppData; source: "local" | "cloud" }> {
+export async function syncData(localData: AppData): Promise<{ data: AppData; source: "local" | "cloud" }> {
 	if (!isSupabaseConfigured || !supabase) {
 		return { data: localData, source: "local" };
 	}
 
 	try {
-		let { data: rows, error } = await supabase.rpc("get_user_data_v3");
+		const { data: rows, error } = await supabase.rpc("get_user_data_v3");
 
-		// If no data found, the profile may exist but auth_uid is not linked yet
-		// (existing user upgrading from v2). Try to link automatically.
-		if (!error && (!rows || rows.length === 0)) {
-			const linked = await linkRecoveryCode(code);
-			if (linked) {
-				const retry = await supabase.rpc("get_user_data_v3");
-				rows = retry.data;
-				error = retry.error;
-			}
-		}
-
-		// No cloud data yet or error → push local
+		// Push local on any error
 		if (error) {
 			console.error("Sync check failed:", error.message);
-			await pushToCloud(code, localData);
+			await pushToCloud(localData);
 			return { data: localData, source: "local" };
 		}
 
 		const row = rows?.[0];
 		if (!row) {
-			await pushToCloud(code, localData);
+			await pushToCloud(localData);
 			return { data: localData, source: "local" };
 		}
 
@@ -222,14 +231,14 @@ export async function syncData(
 				setLastSync();
 				// If cloud data has base64 photos, push to migrate them to Storage
 				if (hasBase64Photos(migrated)) {
-					void pushToCloud(code, migrated);
+					void pushToCloud(migrated);
 				}
 				return { data: migrated, source: "cloud" };
 			}
 		}
 
 		// Local is newer or same → push to cloud
-		await pushToCloud(code, localData);
+		await pushToCloud(localData);
 		return { data: localData, source: "local" };
 	} catch (e) {
 		console.error("Sync failed:", e);

--- a/supabase/migrations/20260429000000_account_auth.sql
+++ b/supabase/migrations/20260429000000_account_auth.sql
@@ -9,28 +9,33 @@
 --   auth.uid() regardless of provider.
 -- ============================================================================
 
--- Idempotent recovery code generator using the same alphabet as the client
--- (no I/O/0/1 to avoid confusion). Returns a unique code in the form
--- FILM-XXXX-XXXX. Retries on (extremely unlikely) collision.
+-- Collision-resistant recovery code generator using the same alphabet as the
+-- client (no I/O/0/1 to avoid confusion). Returns a unique code in the form
+-- FILM-XXXX-XXXX. Uses pgcrypto's CSPRNG (gen_random_bytes) since the code
+-- doubles as a secret for account recovery / export. Internal helper, not
+-- exposed to client roles.
 CREATE OR REPLACE FUNCTION public.generate_recovery_code()
 RETURNS TEXT
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public
+SET search_path = public, extensions
 AS $$
 DECLARE
     v_alphabet TEXT := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    v_alpha_len INTEGER := length(v_alphabet);
     v_code TEXT;
+    v_bytes BYTEA;
     v_attempts INTEGER := 0;
 BEGIN
     LOOP
+        v_bytes := gen_random_bytes(8);
         v_code := 'FILM-';
-        FOR i IN 1..4 LOOP
-            v_code := v_code || substr(v_alphabet, 1 + (random() * (length(v_alphabet) - 1))::int, 1);
+        FOR i IN 0..3 LOOP
+            v_code := v_code || substr(v_alphabet, 1 + (get_byte(v_bytes, i) % v_alpha_len), 1);
         END LOOP;
         v_code := v_code || '-';
-        FOR i IN 1..4 LOOP
-            v_code := v_code || substr(v_alphabet, 1 + (random() * (length(v_alphabet) - 1))::int, 1);
+        FOR i IN 4..7 LOOP
+            v_code := v_code || substr(v_alphabet, 1 + (get_byte(v_bytes, i) % v_alpha_len), 1);
         END LOOP;
 
         EXIT WHEN NOT EXISTS (SELECT 1 FROM user_profiles WHERE recovery_code = v_code);
@@ -45,10 +50,13 @@ BEGIN
 END;
 $$;
 
--- ensure_profile: idempotently returns the user_profiles.id for the current
--- authenticated session, creating the row on first call. Used by clients
--- after Magic Link / OAuth sign-in to bootstrap the profile without exposing
--- a recovery code in the UI.
+-- Lock down the helper: never callable by clients (PUBLIC, anon, authenticated).
+REVOKE EXECUTE ON FUNCTION public.generate_recovery_code() FROM PUBLIC;
+
+-- ensure_profile: returns the user_profiles.id for the current authenticated
+-- session, creating the row on first call. Idempotent and safe under
+-- concurrent calls thanks to the unique index on auth_uid: a race that loses
+-- the INSERT falls back to a SELECT.
 CREATE OR REPLACE FUNCTION public.ensure_profile()
 RETURNS UUID
 LANGUAGE plpgsql
@@ -59,12 +67,13 @@ DECLARE
     v_user_id UUID;
     v_uid UUID := auth.uid();
     v_code TEXT;
+    v_attempts INTEGER := 0;
 BEGIN
     IF v_uid IS NULL THEN
         RAISE EXCEPTION 'not_authenticated';
     END IF;
 
-    -- Already linked to a profile?
+    -- Fast path: already linked to a profile.
     SELECT id INTO v_user_id
     FROM user_profiles
     WHERE auth_uid = v_uid
@@ -74,14 +83,34 @@ BEGIN
         RETURN v_user_id;
     END IF;
 
-    -- Create a new profile with an auto-generated recovery code
-    v_code := public.generate_recovery_code();
+    -- Insert with retry. unique_violation can come from either:
+    --   - auth_uid: a concurrent ensure_profile() call won the race → re-select.
+    --   - recovery_code: rare collision → retry with a freshly generated code.
+    LOOP
+        v_code := public.generate_recovery_code();
 
-    INSERT INTO user_profiles (recovery_code, auth_uid, schema_version, updated_at)
-    VALUES (v_code, v_uid, 16, now())
-    RETURNING id INTO v_user_id;
+        BEGIN
+            INSERT INTO user_profiles (recovery_code, auth_uid, schema_version, updated_at)
+            VALUES (v_code, v_uid, 16, now())
+            RETURNING id INTO v_user_id;
 
-    RETURN v_user_id;
+            RETURN v_user_id;
+        EXCEPTION WHEN unique_violation THEN
+            SELECT id INTO v_user_id
+            FROM user_profiles
+            WHERE auth_uid = v_uid
+            LIMIT 1;
+
+            IF v_user_id IS NOT NULL THEN
+                RETURN v_user_id;
+            END IF;
+
+            v_attempts := v_attempts + 1;
+            IF v_attempts > 5 THEN
+                RAISE;
+            END IF;
+        END;
+    END LOOP;
 END;
 $$;
 

--- a/supabase/migrations/20260429000000_account_auth.sql
+++ b/supabase/migrations/20260429000000_account_auth.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Migration: Account-based authentication (Magic Link / OAuth)
+-- - Adds ensure_profile() RPC: creates a user_profiles row on first sign-in
+--   for any authenticated session (Magic Link, OAuth, anonymous).
+-- - Auto-generates a recovery_code that serves as a one-time export/secours
+--   token (kept hidden by default; surfaceable from Settings).
+-- - Other RPCs (link_recovery_code, upsert_user_data_v3, get_user_data_v3,
+--   activate_cloud, get_profile_id) are reused unchanged: they all work off
+--   auth.uid() regardless of provider.
+-- ============================================================================
+
+-- Idempotent recovery code generator using the same alphabet as the client
+-- (no I/O/0/1 to avoid confusion). Returns a unique code in the form
+-- FILM-XXXX-XXXX. Retries on (extremely unlikely) collision.
+CREATE OR REPLACE FUNCTION public.generate_recovery_code()
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_alphabet TEXT := 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+    v_code TEXT;
+    v_attempts INTEGER := 0;
+BEGIN
+    LOOP
+        v_code := 'FILM-';
+        FOR i IN 1..4 LOOP
+            v_code := v_code || substr(v_alphabet, 1 + (random() * (length(v_alphabet) - 1))::int, 1);
+        END LOOP;
+        v_code := v_code || '-';
+        FOR i IN 1..4 LOOP
+            v_code := v_code || substr(v_alphabet, 1 + (random() * (length(v_alphabet) - 1))::int, 1);
+        END LOOP;
+
+        EXIT WHEN NOT EXISTS (SELECT 1 FROM user_profiles WHERE recovery_code = v_code);
+
+        v_attempts := v_attempts + 1;
+        IF v_attempts > 10 THEN
+            RAISE EXCEPTION 'recovery_code_generation_failed';
+        END IF;
+    END LOOP;
+
+    RETURN v_code;
+END;
+$$;
+
+-- ensure_profile: idempotently returns the user_profiles.id for the current
+-- authenticated session, creating the row on first call. Used by clients
+-- after Magic Link / OAuth sign-in to bootstrap the profile without exposing
+-- a recovery code in the UI.
+CREATE OR REPLACE FUNCTION public.ensure_profile()
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id UUID;
+    v_uid UUID := auth.uid();
+    v_code TEXT;
+BEGIN
+    IF v_uid IS NULL THEN
+        RAISE EXCEPTION 'not_authenticated';
+    END IF;
+
+    -- Already linked to a profile?
+    SELECT id INTO v_user_id
+    FROM user_profiles
+    WHERE auth_uid = v_uid
+    LIMIT 1;
+
+    IF v_user_id IS NOT NULL THEN
+        RETURN v_user_id;
+    END IF;
+
+    -- Create a new profile with an auto-generated recovery code
+    v_code := public.generate_recovery_code();
+
+    INSERT INTO user_profiles (recovery_code, auth_uid, schema_version, updated_at)
+    VALUES (v_code, v_uid, 16, now())
+    RETURNING id INTO v_user_id;
+
+    RETURN v_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.ensure_profile() TO authenticated;
+
+-- get_recovery_code: returns the recovery code of the current authenticated
+-- user. Surfaced in Settings as an "export / secours" token. Returns NULL
+-- if no profile is linked yet.
+CREATE OR REPLACE FUNCTION public.get_recovery_code()
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+    SELECT recovery_code
+    FROM public.user_profiles
+    WHERE auth_uid = auth.uid()
+    LIMIT 1;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_recovery_code() TO authenticated;


### PR DESCRIPTION
- New WelcomeScreen prompting sign-in or local-only mode on first launch
- Supabase Auth via Magic Link (email): no password, free, multi-device
- ensure_profile RPC bootstraps the profile on first sign-in (idempotent)
- get_recovery_code RPC exposes a server-generated export/secours token
- Legacy recovery codes auto-migrate via link_recovery_code on sign-in
- SettingsScreen exposes the signed-in email, sign-out, and migration UI
- Removed automatic anonymous sessions; sync now requires an explicit account

https://claude.ai/code/session_013mTRS7umpaD43qSgtofaPe