### PR TITLE
feat(stock): adaptive grouping levels based on inventory size

### DIFF
--- a/src/screens/stock/StockBreadcrumb.tsx
+++ b/src/screens/stock/StockBreadcrumb.tsx
@@ -32,7 +32,7 @@ export function StockBreadcrumb({ path, onNavigate, disabled }: StockBreadcrumbP
 	];
 	for (const level of HIERARCHY_ORDER) {
 		const value = path[level];
-		if (!value) break;
+		if (!value) continue;
 		segments.push({ level, label: resolveSegmentLabel(level, value, t) });
 	}
 

--- a/src/screens/stock/StockTab.tsx
+++ b/src/screens/stock/StockTab.tsx
@@ -10,6 +10,7 @@ import {
 	type HierarchyLevel,
 	type HierarchyPath,
 	isLeaf,
+	STOCK_FLAT_THRESHOLD,
 	setPathLevel,
 	truncatePath,
 } from "@/utils/stock-hierarchy";
@@ -41,21 +42,25 @@ export function StockTab({
 	const { t } = useTranslation();
 	const locale = t("dateLocale");
 
+	// Small inventories collapse to a flat expiration-grouped list — the multi-level navigation
+	// adds friction without value when there are only a handful of films.
+	const flatMode = !searchActive && films.length < STOCK_FLAT_THRESHOLD;
+
 	const flatGroups = useMemo(
-		() => (searchActive ? groupByExpiration(filteredFilms, locale) : []),
-		[filteredFilms, searchActive, locale],
+		() => (searchActive || flatMode ? groupByExpiration(filteredFilms, locale) : []),
+		[filteredFilms, searchActive, flatMode, locale],
 	);
 
-	const reachedLeaf = isLeaf(path);
+	const reachedLeaf = !searchActive && !flatMode && isLeaf(films, path);
 
 	const nodes = useMemo(
-		() => (!searchActive && !reachedLeaf ? buildHierarchy(films, path) : []),
-		[films, path, searchActive, reachedLeaf],
+		() => (!searchActive && !flatMode && !reachedLeaf ? buildHierarchy(films, path) : []),
+		[films, path, searchActive, flatMode, reachedLeaf],
 	);
 
 	const leafGroups = useMemo(
-		() => (!searchActive && reachedLeaf ? groupByExpiration(filterByPath(films, path), locale) : []),
-		[films, path, locale, searchActive, reachedLeaf],
+		() => (reachedLeaf ? groupByExpiration(filterByPath(films, path), locale) : []),
+		[films, path, locale, reachedLeaf],
 	);
 
 	const handleBreadcrumb = (lvl: HierarchyLevel | null) => {
@@ -70,11 +75,13 @@ export function StockTab({
 		return <EmptyState icon={Package} title={t("stock.emptyStock")} subtitle={t("stock.emptyStockSubtitle")} />;
 	}
 
+	const showBreadcrumb = !flatMode;
+
 	return (
 		<div className="flex flex-col gap-3" data-tour="stock-list">
-			<StockBreadcrumb path={path} onNavigate={handleBreadcrumb} disabled={searchActive} />
+			{showBreadcrumb && <StockBreadcrumb path={path} onNavigate={handleBreadcrumb} disabled={searchActive} />}
 
-			{searchActive ? (
+			{searchActive || flatMode ? (
 				flatGroups.length === 0 ? (
 					<EmptyState icon={Package} title={t("stock.nothingFound")} subtitle={t("stock.noMatch")} />
 				) : (

--- a/src/screens/stock/StockTab.tsx
+++ b/src/screens/stock/StockTab.tsx
@@ -1,15 +1,14 @@
 import { Package } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyState } from "@/components/EmptyState";
 import type { Back, Camera, Film } from "@/types";
 import {
-	buildHierarchy,
-	filterByPath,
+	buildHierarchyNodes,
 	groupByExpiration,
 	type HierarchyLevel,
 	type HierarchyPath,
-	isLeaf,
+	resolveDisplayLevel,
 	STOCK_FLAT_THRESHOLD,
 	setPathLevel,
 	truncatePath,
@@ -46,21 +45,35 @@ export function StockTab({
 	// adds friction without value when there are only a handful of films.
 	const flatMode = !searchActive && films.length < STOCK_FLAT_THRESHOLD;
 
+	// Single resolution shared by leaf detection, hierarchy nodes and leaf grouping —
+	// avoids re-filtering the film list multiple times per render.
+	const resolution = useMemo(() => resolveDisplayLevel(films, path), [films, path]);
+
+	const reachedLeaf = !searchActive && !flatMode && resolution.level === null && resolution.filtered.length > 0;
+
+	// Stale path: persisted from localStorage but no film matches anymore (e.g. last matching
+	// film was deleted). Reset to root so the user lands on a valid view.
+	const stalePath = !searchActive && !flatMode && resolution.filtered.length === 0 && films.length > 0;
+	useEffect(() => {
+		if (stalePath) onPathChange({});
+	}, [stalePath, onPathChange]);
+
 	const flatGroups = useMemo(
 		() => (searchActive || flatMode ? groupByExpiration(filteredFilms, locale) : []),
 		[filteredFilms, searchActive, flatMode, locale],
 	);
 
-	const reachedLeaf = !searchActive && !flatMode && isLeaf(films, path);
-
 	const nodes = useMemo(
-		() => (!searchActive && !flatMode && !reachedLeaf ? buildHierarchy(films, path) : []),
-		[films, path, searchActive, flatMode, reachedLeaf],
+		() =>
+			!searchActive && !flatMode && resolution.level !== null
+				? buildHierarchyNodes(resolution.level, resolution.filtered)
+				: [],
+		[searchActive, flatMode, resolution.level, resolution.filtered],
 	);
 
 	const leafGroups = useMemo(
-		() => (reachedLeaf ? groupByExpiration(filterByPath(films, path), locale) : []),
-		[films, path, locale, reachedLeaf],
+		() => (reachedLeaf ? groupByExpiration(resolution.filtered, locale) : []),
+		[reachedLeaf, resolution.filtered, locale],
 	);
 
 	const handleBreadcrumb = (lvl: HierarchyLevel | null) => {

--- a/src/utils/stock-hierarchy.ts
+++ b/src/utils/stock-hierarchy.ts
@@ -64,16 +64,30 @@ export function pathDepth(path: HierarchyPath): number {
 }
 
 /**
+ * Result of resolving the next hierarchy level worth showing for a path.
+ * `filtered` is always returned so callers don't have to recompute it.
+ */
+export interface DisplayResolution {
+	/** Next level to display, or null when there is no further navigation. */
+	level: HierarchyLevel | null;
+	/** Films matching the current path. Empty means the path is stale. */
+	filtered: Film[];
+}
+
+/**
  * Find the next hierarchy level worth showing for the current path, considering auto-skip:
  * a level that yields a single group is silently skipped (its only value is implicit) so the
  * user goes straight to the next meaningful choice.
  *
- * Returns null when there's no further navigation — either every remaining level was
- * auto-skipped or the user has set them all (i.e. we're at a leaf).
+ * `level` is null when there's no further navigation. Combined with `filtered.length` callers
+ * can distinguish three cases:
+ *  - `level !== null` → render the hierarchy nodes for that level
+ *  - `level === null && filtered.length > 0` → leaf reached
+ *  - `level === null && filtered.length === 0` → stale path (e.g. films were deleted)
  */
-export function resolveDisplayLevel(films: Film[], path: HierarchyPath): HierarchyLevel | null {
+export function resolveDisplayLevel(films: Film[], path: HierarchyPath): DisplayResolution {
 	const filtered = filterByPath(films, path);
-	if (filtered.length === 0) return null;
+	if (filtered.length === 0) return { level: null, filtered };
 
 	for (const level of HIERARCHY_ORDER) {
 		if (path[level] != null) continue;
@@ -82,13 +96,14 @@ export function resolveDisplayLevel(films: Film[], path: HierarchyPath): Hierarc
 			distinct.add(getValueAtLevel(f, level));
 			if (distinct.size > 1) break;
 		}
-		if (distinct.size > 1) return level;
+		if (distinct.size > 1) return { level, filtered };
 	}
-	return null;
+	return { level: null, filtered };
 }
 
 export function isLeaf(films: Film[], path: HierarchyPath): boolean {
-	return resolveDisplayLevel(films, path) === null;
+	const { level, filtered } = resolveDisplayLevel(films, path);
+	return level === null && filtered.length > 0;
 }
 
 export function setPathLevel(path: HierarchyPath, level: HierarchyLevel, value: string): HierarchyPath {
@@ -127,11 +142,7 @@ interface ChildAggregate {
 	grandChildren: Set<string>;
 }
 
-export function buildHierarchy(films: Film[], path: HierarchyPath): HierarchyNode[] {
-	const level = resolveDisplayLevel(films, path);
-	if (level === null) return [];
-
-	const filtered = filterByPath(films, path);
+export function buildHierarchyNodes(level: HierarchyLevel, filtered: Film[]): HierarchyNode[] {
 	const grandLevel = nextLevel(level);
 	const map = new Map<string, ChildAggregate>();
 
@@ -167,6 +178,12 @@ export function buildHierarchy(films: Film[], path: HierarchyPath): HierarchyNod
 		return a.label.localeCompare(b.label);
 	});
 	return nodes;
+}
+
+export function buildHierarchy(films: Film[], path: HierarchyPath): HierarchyNode[] {
+	const { level, filtered } = resolveDisplayLevel(films, path);
+	if (level === null) return [];
+	return buildHierarchyNodes(level, filtered);
 }
 
 /**

--- a/src/utils/stock-hierarchy.ts
+++ b/src/utils/stock-hierarchy.ts
@@ -6,6 +6,10 @@ export type HierarchyLevel = "format" | "type" | "brand" | "model";
 
 export const HIERARCHY_ORDER: HierarchyLevel[] = ["format", "type", "brand", "model"];
 
+// Below this number of stock films, the stock view collapses to a flat list grouped by expiration
+// instead of the multi-level navigation — fewer clicks for small inventories.
+export const STOCK_FLAT_THRESHOLD = 20;
+
 export interface HierarchyPath {
 	format?: string;
 	type?: string;
@@ -51,25 +55,40 @@ export function nextLevel(level: HierarchyLevel | null): HierarchyLevel | null {
 	return HIERARCHY_ORDER[idx + 1] ?? null;
 }
 
-export function currentLevel(path: HierarchyPath): HierarchyLevel | null {
-	if (!path.format) return "format";
-	if (!path.type) return "type";
-	if (!path.brand) return "brand";
-	if (!path.model) return "model";
+export function pathDepth(path: HierarchyPath): number {
+	let d = 0;
+	for (const lvl of HIERARCHY_ORDER) {
+		if (path[lvl]) d++;
+	}
+	return d;
+}
+
+/**
+ * Find the next hierarchy level worth showing for the current path, considering auto-skip:
+ * a level that yields a single group is silently skipped (its only value is implicit) so the
+ * user goes straight to the next meaningful choice.
+ *
+ * Returns null when there's no further navigation — either every remaining level was
+ * auto-skipped or the user has set them all (i.e. we're at a leaf).
+ */
+export function resolveDisplayLevel(films: Film[], path: HierarchyPath): HierarchyLevel | null {
+	const filtered = filterByPath(films, path);
+	if (filtered.length === 0) return null;
+
+	for (const level of HIERARCHY_ORDER) {
+		if (path[level] != null) continue;
+		const distinct = new Set<string>();
+		for (const f of filtered) {
+			distinct.add(getValueAtLevel(f, level));
+			if (distinct.size > 1) break;
+		}
+		if (distinct.size > 1) return level;
+	}
 	return null;
 }
 
-export function isLeaf(path: HierarchyPath): boolean {
-	return Boolean(path.format && path.type && path.brand && path.model);
-}
-
-export function pathDepth(path: HierarchyPath): number {
-	let d = 0;
-	if (path.format) d++;
-	if (path.type) d++;
-	if (path.brand) d++;
-	if (path.model) d++;
-	return d;
+export function isLeaf(films: Film[], path: HierarchyPath): boolean {
+	return resolveDisplayLevel(films, path) === null;
 }
 
 export function setPathLevel(path: HierarchyPath, level: HierarchyLevel, value: string): HierarchyPath {
@@ -109,7 +128,7 @@ interface ChildAggregate {
 }
 
 export function buildHierarchy(films: Film[], path: HierarchyPath): HierarchyNode[] {
-	const level = currentLevel(path);
+	const level = resolveDisplayLevel(films, path);
 	if (level === null) return [];
 
 	const filtered = filterByPath(films, path);


### PR DESCRIPTION
Stock navigation now adapts to the user's collection:
- Below 20 stock films, the hierarchy collapses to a flat list grouped by
  expiration (same rendering as the search/filter view) — no breadcrumb,
  no drill-down.
- Above the threshold, levels with a single value are auto-skipped: if every
  film is 35mm the format level is silently bypassed and we land directly
  on type/brand/model. Skipped levels are not added to the breadcrumb.

Implementation:
- New `resolveDisplayLevel` walks `HIERARCHY_ORDER` and returns the first
  unset level whose distinct value count is > 1. `buildHierarchy` and
  `isLeaf` delegate to it.
- `STOCK_FLAT_THRESHOLD` exported (default 20) for easy tuning.
- `StockBreadcrumb` now `continue`s on missing path entries instead of
  breaking, so sparse paths (with skipped ancestors) render correctly.

https://claude.ai/code/session_01QBBUQjorCp8Kf6uSBWYgix