### PR TITLE
feat(add-film): support unknown expiration and direct entry to advanced states

### DIFF
--- a/src/components/AddFilmDialog.tsx
+++ b/src/components/AddFilmDialog.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FilmFormatSelect, FilmTypeSelect } from "@/components/FilmTypeFormatFields";
 import { useToast } from "@/components/Toast";
@@ -64,7 +64,8 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 	const [devDate, setDevDate] = useState("");
 	const [scanRef, setScanRef] = useState("");
 
-	const availableCameras = useMemo(() => data.cameras.filter((c) => !c.soldAt), [data.cameras]);
+	const advanced = isAfterStock(state);
+	const availableCameras = data.cameras.filter((c) => !c.soldAt);
 
 	useEffect(() => {
 		if (!open) {
@@ -106,9 +107,8 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 	};
 
 	const handleSave = () => {
-		const advanced = isAfterStock(state);
 		const qty = advanced ? 1 : Number.parseInt(quantity, 10) || 1;
-		const camera = cameraId ? data.cameras.find((c) => c.id === cameraId) : null;
+		const camera = cameraId ? (data.cameras.find((c) => c.id === cameraId) ?? null) : null;
 		const isoValue = Number.parseInt(iso, 10) || 0;
 		const shootIsoValue = shootIso.trim() ? Number.parseInt(shootIso, 10) || isoValue : null;
 		const params = {
@@ -131,7 +131,7 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 			lab: advanced && hasDevFields(state) ? lab.trim() || null : null,
 			devDate: advanced && hasDevFields(state) ? devDate || endDate || today() : null,
 			scanRef: state === "scanned" ? scanRef.trim() || null : null,
-			cameraDisplayName: camera ? cameraDisplayName(camera) : null,
+			camera,
 		};
 		const newFilms = Array.from({ length: qty }, () => createNewFilm(params));
 		const updated = { ...data, films: [...data.films, ...newFilms] };
@@ -140,7 +140,6 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 		onOpenChange(false);
 	};
 
-	const advanced = isAfterStock(state);
 	const qty = advanced ? 1 : Number.parseInt(quantity, 10) || 1;
 
 	return (

--- a/src/components/AddFilmDialog.tsx
+++ b/src/components/AddFilmDialog.tsx
@@ -1,5 +1,5 @@
 import { Plus } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FilmFormatSelect, FilmTypeSelect } from "@/components/FilmTypeFormatFields";
 import { useToast } from "@/components/Toast";
@@ -9,11 +9,13 @@ import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } f
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { MonthYearPicker } from "@/components/ui/month-year-picker";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { TagInput } from "@/components/ui/tag-input";
-import { type AppData, isInstantFormat } from "@/types";
+import { type AppData, type FilmState, isInstantFormat } from "@/types";
+import { cameraDisplayName } from "@/utils/camera-helpers";
 import { createNewFilm } from "@/utils/film-factory";
 import { collectAllTags } from "@/utils/film-helpers";
-import { currentMonthYear } from "@/utils/helpers";
+import { today } from "@/utils/helpers";
 import { useFilmSuggestions } from "@/utils/use-film-suggestions";
 
 interface AddFilmDialogProps {
@@ -21,6 +23,20 @@ interface AddFilmDialogProps {
 	onOpenChange: (open: boolean) => void;
 	data: AppData;
 	setData: (data: AppData) => void;
+}
+
+const STATE_OPTIONS: FilmState[] = ["stock", "loaded", "partial", "exposed", "developed", "scanned"];
+
+function isAfterStock(state: FilmState): boolean {
+	return state !== "stock";
+}
+
+function hasEndDate(state: FilmState): boolean {
+	return state === "exposed" || state === "developed" || state === "scanned";
+}
+
+function hasDevFields(state: FilmState): boolean {
+	return state === "developed" || state === "scanned";
 }
 
 export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDialogProps) {
@@ -32,12 +48,23 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 	const [iso, setIso] = useState("");
 	const [type, setType] = useState("Couleur");
 	const [format, setFormat] = useState("35mm");
-	const [expDate, setExpDate] = useState(currentMonthYear());
+	const [expDate, setExpDate] = useState("");
 	const [quantity, setQuantity] = useState("1");
 	const [storageLocation, setStorageLocation] = useState("");
 	const [price, setPrice] = useState("");
 	const [comment, setComment] = useState("");
 	const [tags, setTags] = useState<string[]>([]);
+	const [state, setState] = useState<FilmState>("stock");
+	const [cameraId, setCameraId] = useState("");
+	const [startDate, setStartDate] = useState("");
+	const [endDate, setEndDate] = useState("");
+	const [shootIso, setShootIso] = useState("");
+	const [posesShot, setPosesShot] = useState("");
+	const [lab, setLab] = useState("");
+	const [devDate, setDevDate] = useState("");
+	const [scanRef, setScanRef] = useState("");
+
+	const availableCameras = useMemo(() => data.cameras.filter((c) => !c.soldAt), [data.cameras]);
 
 	useEffect(() => {
 		if (!open) {
@@ -46,12 +73,21 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 			setIso("");
 			setType("Couleur");
 			setFormat("35mm");
-			setExpDate(currentMonthYear());
+			setExpDate("");
 			setQuantity("1");
 			setPrice("");
 			setStorageLocation("");
 			setComment("");
 			setTags([]);
+			setState("stock");
+			setCameraId("");
+			setStartDate("");
+			setEndDate("");
+			setShootIso("");
+			setPosesShot("");
+			setLab("");
+			setDevDate("");
+			setScanRef("");
 		}
 	}, [open]);
 
@@ -64,12 +100,21 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 		}
 	};
 
+	const handleStateChange = (next: FilmState) => {
+		setState(next);
+		if (next !== "stock") setQuantity("1");
+	};
+
 	const handleSave = () => {
-		const qty = Number.parseInt(quantity, 10) || 1;
+		const advanced = isAfterStock(state);
+		const qty = advanced ? 1 : Number.parseInt(quantity, 10) || 1;
+		const camera = cameraId ? data.cameras.find((c) => c.id === cameraId) : null;
+		const isoValue = Number.parseInt(iso, 10) || 0;
+		const shootIsoValue = shootIso.trim() ? Number.parseInt(shootIso, 10) || isoValue : null;
 		const params = {
 			brand: brand.trim(),
 			model: model.trim(),
-			iso: Number.parseInt(iso, 10) || 0,
+			iso: isoValue,
 			type,
 			format,
 			expDate: expDate || null,
@@ -77,6 +122,16 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 			price: price.trim() ? Number.parseFloat(price) : null,
 			storageLocation: storageLocation.trim() || null,
 			tags: tags.length > 0 ? tags : undefined,
+			state,
+			cameraId: advanced && cameraId ? cameraId : null,
+			startDate: advanced ? startDate || today() : null,
+			endDate: advanced && hasEndDate(state) ? endDate || startDate || today() : null,
+			shootIso: advanced ? shootIsoValue : null,
+			posesShot: state === "partial" && posesShot.trim() ? Number.parseInt(posesShot, 10) || 0 : null,
+			lab: advanced && hasDevFields(state) ? lab.trim() || null : null,
+			devDate: advanced && hasDevFields(state) ? devDate || endDate || today() : null,
+			scanRef: state === "scanned" ? scanRef.trim() || null : null,
+			cameraDisplayName: camera ? cameraDisplayName(camera) : null,
 		};
 		const newFilms = Array.from({ length: qty }, () => createNewFilm(params));
 		const updated = { ...data, films: [...data.films, ...newFilms] };
@@ -85,7 +140,8 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 		onOpenChange(false);
 	};
 
-	const qty = Number.parseInt(quantity, 10) || 1;
+	const advanced = isAfterStock(state);
+	const qty = advanced ? 1 : Number.parseInt(quantity, 10) || 1;
 
 	return (
 		<Dialog open={open} onOpenChange={(v) => !v && onOpenChange(false)}>
@@ -133,16 +189,33 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 						<FilmTypeSelect value={type} onValueChange={setType} format={format} />
 					</div>
 
-					<FormField label={t("addFilm.quantity")}>
-						<Input
-							type="number"
-							value={quantity}
-							onChange={(e) => setQuantity(e.target.value)}
-							min="1"
-							max="50"
-							className="font-mono"
-						/>
+					<FormField label={t("addFilm.initialState")}>
+						<Select value={state} onValueChange={(v) => handleStateChange(v as FilmState)}>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{STATE_OPTIONS.map((s) => (
+									<SelectItem key={s} value={s}>
+										{t(`states.${s}`)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
 					</FormField>
+
+					{!advanced && (
+						<FormField label={t("addFilm.quantity")}>
+							<Input
+								type="number"
+								value={quantity}
+								onChange={(e) => setQuantity(e.target.value)}
+								min="1"
+								max="50"
+								className="font-mono"
+							/>
+						</FormField>
+					)}
 
 					<FormField label={t("addFilm.price")}>
 						<Input
@@ -180,6 +253,95 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 						suggestions={collectAllTags(data.films)}
 						placeholder={t("addFilm.tagsPlaceholder")}
 					/>
+
+					{advanced && (
+						<div className="flex flex-col gap-3 rounded-xl border border-border bg-card/50 p-3.5">
+							<span className="text-xs font-semibold uppercase tracking-wide text-text-secondary">
+								{t("addFilm.contextualSection")}
+							</span>
+							<FormField label={t("filmDetail.cameraField")}>
+								<Select value={cameraId || "__none__"} onValueChange={(v) => setCameraId(v === "__none__" ? "" : v)}>
+									<SelectTrigger>
+										<SelectValue placeholder={t("filmDetail.choosePlaceholder")} />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="__none__">{t("addFilm.noInfo")}</SelectItem>
+										{availableCameras.map((c) => (
+											<SelectItem key={c.id} value={c.id}>
+												{cameraDisplayName(c)}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</FormField>
+							<FormField label={t("filmDetail.shootIsoField")}>
+								<Input
+									type="number"
+									value={shootIso}
+									onChange={(e) => setShootIso(e.target.value)}
+									placeholder={iso || "400"}
+									className="font-mono"
+								/>
+							</FormField>
+							<FormField label={t("filmDetail.startDateField")}>
+								<Input
+									type="date"
+									value={startDate}
+									onChange={(e) => setStartDate(e.target.value)}
+									className="font-mono"
+								/>
+							</FormField>
+							{state === "partial" && (
+								<FormField label={t("filmDetail.posesField")}>
+									<Input
+										type="number"
+										value={posesShot}
+										onChange={(e) => setPosesShot(e.target.value)}
+										placeholder="0"
+										className="font-mono"
+									/>
+								</FormField>
+							)}
+							{hasEndDate(state) && (
+								<FormField label={t("filmDetail.endDateField")}>
+									<Input
+										type="date"
+										value={endDate}
+										onChange={(e) => setEndDate(e.target.value)}
+										className="font-mono"
+									/>
+								</FormField>
+							)}
+							{hasDevFields(state) && (
+								<>
+									<FormField label={t("filmDetail.labField")}>
+										<Input
+											value={lab}
+											onChange={(e) => setLab(e.target.value)}
+											placeholder={t("filmDetail.labPlaceholder")}
+										/>
+									</FormField>
+									<FormField label={t("filmDetail.devDateField")}>
+										<Input
+											type="date"
+											value={devDate}
+											onChange={(e) => setDevDate(e.target.value)}
+											className="font-mono"
+										/>
+									</FormField>
+								</>
+							)}
+							{state === "scanned" && (
+								<FormField label={t("filmDetail.scanRefField")}>
+									<Input
+										value={scanRef}
+										onChange={(e) => setScanRef(e.target.value)}
+										placeholder={t("filmDetail.scanRefPlaceholder")}
+									/>
+								</FormField>
+							)}
+						</div>
+					)}
 
 					<Button onClick={handleSave} disabled={!brand || !model} className="w-full justify-center py-3.5 px-5">
 						<Plus size={16} /> {t("addFilm.addButton", { count: qty })}

--- a/src/components/ui/month-year-picker.tsx
+++ b/src/components/ui/month-year-picker.tsx
@@ -33,8 +33,6 @@ export function MonthYearPicker({ value, onChange, className }: MonthYearPickerP
 		}
 	};
 
-	const showClear = Boolean(value);
-
 	return (
 		<div className={cn("flex items-center gap-2", className)}>
 			<div className="grid grid-cols-2 gap-2 flex-1">
@@ -66,7 +64,7 @@ export function MonthYearPicker({ value, onChange, className }: MonthYearPickerP
 					</SelectContent>
 				</Select>
 			</div>
-			{showClear && (
+			{value && (
 				<button
 					type="button"
 					onClick={() => onChange("")}

--- a/src/components/ui/month-year-picker.tsx
+++ b/src/components/ui/month-year-picker.tsx
@@ -1,3 +1,4 @@
+import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
@@ -32,35 +33,49 @@ export function MonthYearPicker({ value, onChange, className }: MonthYearPickerP
 		}
 	};
 
+	const showClear = Boolean(value);
+
 	return (
-		<div className={cn("grid grid-cols-2 gap-2", className)}>
-			<Select value={monthStr || undefined} onValueChange={handleMonthChange}>
-				<SelectTrigger className="font-mono">
-					<SelectValue placeholder={t("monthPlaceholder")} />
-				</SelectTrigger>
-				<SelectContent>
-					{months.map((label, i) => {
-						const val = String(i + 1).padStart(2, "0");
-						return (
-							<SelectItem key={val} value={val}>
-								{label}
+		<div className={cn("flex items-center gap-2", className)}>
+			<div className="grid grid-cols-2 gap-2 flex-1">
+				<Select value={monthStr || undefined} onValueChange={handleMonthChange}>
+					<SelectTrigger className="font-mono">
+						<SelectValue placeholder={t("monthPlaceholder")} />
+					</SelectTrigger>
+					<SelectContent>
+						{months.map((label, i) => {
+							const val = String(i + 1).padStart(2, "0");
+							return (
+								<SelectItem key={val} value={val}>
+									{label}
+								</SelectItem>
+							);
+						})}
+					</SelectContent>
+				</Select>
+				<Select value={yearStr || undefined} onValueChange={handleYearChange}>
+					<SelectTrigger className="font-mono">
+						<SelectValue placeholder={t("yearPlaceholder")} />
+					</SelectTrigger>
+					<SelectContent>
+						{YEARS.map((y) => (
+							<SelectItem key={y} value={String(y)}>
+								{y}
 							</SelectItem>
-						);
-					})}
-				</SelectContent>
-			</Select>
-			<Select value={yearStr || undefined} onValueChange={handleYearChange}>
-				<SelectTrigger className="font-mono">
-					<SelectValue placeholder={t("yearPlaceholder")} />
-				</SelectTrigger>
-				<SelectContent>
-					{YEARS.map((y) => (
-						<SelectItem key={y} value={String(y)}>
-							{y}
-						</SelectItem>
-					))}
-				</SelectContent>
-			</Select>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+			{showClear && (
+				<button
+					type="button"
+					onClick={() => onChange("")}
+					aria-label={t("aria.clearDate")}
+					className="shrink-0 size-9 rounded-lg border border-border bg-card text-text-secondary hover:text-text-primary hover:bg-surface flex items-center justify-center transition-colors"
+				>
+					<X size={16} />
+				</button>
+			)}
 		</div>
 	);
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -174,6 +174,9 @@ export const en = {
 		tags: "Tags",
 		tagsPlaceholder: "E.g. Japan trip 2025, Portrait…",
 		createTag: 'Create "{{value}}"',
+		initialState: "Initial state",
+		contextualSection: "Details (optional)",
+		noInfo: "No info",
 	},
 
 	// Film types (display labels)
@@ -675,6 +678,7 @@ export const en = {
 		openPhoto: "Open photo {{index}}",
 		copyRecoveryCode: "Copy recovery code",
 		dismissBanner: "Dismiss banner",
+		clearDate: "Clear date",
 	},
 
 	// Map screen

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -174,6 +174,9 @@ export const fr = {
 		tags: "Tags",
 		tagsPlaceholder: "Ex : Voyage Japon 2025, Portrait…",
 		createTag: 'Créer "{{value}}"',
+		initialState: "État initial",
+		contextualSection: "Détails (optionnels)",
+		noInfo: "Pas d'info",
 	},
 
 	// Film types (display labels)
@@ -675,6 +678,7 @@ export const fr = {
 		openPhoto: "Ouvrir la photo {{index}}",
 		copyRecoveryCode: "Copier le code de récupération",
 		dismissBanner: "Fermer la bannière",
+		clearDate: "Effacer la date",
 	},
 
 	// Map screen

--- a/src/utils/film-factory.ts
+++ b/src/utils/film-factory.ts
@@ -1,4 +1,4 @@
-import type { Film } from "@/types";
+import type { Film, FilmState, HistoryEntry } from "@/types";
 import { today, uid } from "@/utils/helpers";
 
 const DEFAULT_POSES: Record<string, number> = {
@@ -25,9 +25,99 @@ interface NewFilmParams {
 	posesTotal?: number;
 	storageLocation?: string | null;
 	tags?: string[];
+	state?: FilmState;
+	cameraId?: string | null;
+	backId?: string | null;
+	lens?: string | null;
+	lensId?: string | null;
+	startDate?: string | null;
+	endDate?: string | null;
+	shootIso?: number | null;
+	posesShot?: number | null;
+	lab?: string | null;
+	labRef?: string | null;
+	devDate?: string | null;
+	devCost?: number | null;
+	scanRef?: string | null;
+	scanCost?: number | null;
+	devScanPackage?: boolean;
+	cameraDisplayName?: string | null;
+}
+
+const STATE_RANK: Record<FilmState, number> = {
+	stock: 0,
+	loaded: 1,
+	partial: 2,
+	exposed: 3,
+	developed: 4,
+	scanned: 5,
+};
+
+function reachedStock(target: FilmState, threshold: FilmState): boolean {
+	return STATE_RANK[target] >= STATE_RANK[threshold];
+}
+
+function buildHistory(params: NewFilmParams, addedDate: string, posesTotal: number): HistoryEntry[] {
+	const state = params.state ?? "stock";
+	const history: HistoryEntry[] = [{ date: addedDate, action: "", actionCode: "added" }];
+
+	if (state === "stock") return history;
+
+	const loadDate = params.startDate || addedDate;
+	const cameraLabel = params.cameraDisplayName ?? "?";
+	history.push({
+		date: loadDate,
+		action: "",
+		actionCode: "loaded",
+		params: { camera: cameraLabel },
+	});
+
+	if (state === "partial") {
+		history.push({
+			date: loadDate,
+			action: "",
+			actionCode: "removed_partial",
+			params: {
+				posesShot: params.posesShot ?? 0,
+				posesTotal,
+			},
+		});
+		return history;
+	}
+
+	if (reachedStock(state, "exposed")) {
+		const exposedDate = params.endDate || loadDate;
+		history.push({ date: exposedDate, action: "", actionCode: "exposed" });
+	}
+
+	if (reachedStock(state, "developed")) {
+		const devDate = params.devDate || params.endDate || loadDate;
+		history.push({
+			date: devDate,
+			action: "",
+			actionCode: "developed",
+			params: { lab: params.lab ?? null },
+		});
+	}
+
+	if (reachedStock(state, "scanned")) {
+		history.push({
+			date: params.devDate || params.endDate || loadDate,
+			action: "",
+			actionCode: "scanned",
+			params: { ref: params.scanRef ?? null },
+		});
+	}
+
+	return history;
 }
 
 export function createNewFilm(params: NewFilmParams): Film {
+	const state = params.state ?? "stock";
+	const addedDate = today();
+	const posesTotal = params.posesTotal ?? DEFAULT_POSES[params.format] ?? 36;
+	const isAfterStock = state !== "stock";
+
 	return {
 		id: uid(),
 		brand: params.brand,
@@ -35,24 +125,29 @@ export function createNewFilm(params: NewFilmParams): Film {
 		iso: params.iso,
 		type: params.type,
 		format: params.format,
-		state: "stock",
+		state,
 		expDate: params.expDate,
 		comment: params.comment,
 		price: params.price ?? null,
-		addedDate: today(),
-		shootIso: null,
-		cameraId: null,
-		backId: null,
-		lens: null,
-		startDate: null,
-		endDate: null,
-		posesShot: null,
-		posesTotal: params.posesTotal ?? DEFAULT_POSES[params.format] ?? 36,
-		lab: null,
-		labRef: null,
-		devDate: null,
+		addedDate,
+		shootIso: params.shootIso ?? (isAfterStock ? params.iso : null),
+		cameraId: params.cameraId ?? null,
+		backId: params.backId ?? null,
+		lens: params.lens ?? null,
+		lensId: params.lensId ?? null,
+		startDate: isAfterStock ? (params.startDate ?? addedDate) : null,
+		endDate: reachedStock(state, "exposed") ? (params.endDate ?? params.startDate ?? addedDate) : null,
+		posesShot: state === "partial" ? (params.posesShot ?? 0) : reachedStock(state, "exposed") ? posesTotal : null,
+		posesTotal,
+		lab: params.lab ?? null,
+		labRef: params.labRef ?? null,
+		devDate: reachedStock(state, "developed") ? (params.devDate ?? params.endDate ?? addedDate) : null,
+		devCost: params.devCost ?? null,
+		scanRef: params.scanRef ?? null,
+		scanCost: params.scanCost ?? null,
+		devScanPackage: params.devScanPackage || undefined,
 		storageLocation: params.storageLocation ?? null,
-		history: [{ date: today(), action: "", actionCode: "added" }],
+		history: buildHistory(params, addedDate, posesTotal),
 		tags: params.tags && params.tags.length > 0 ? [...params.tags] : undefined,
 	};
 }

--- a/src/utils/film-factory.ts
+++ b/src/utils/film-factory.ts
@@ -1,4 +1,5 @@
-import type { Film, FilmState, HistoryEntry } from "@/types";
+import type { Camera, Film, FilmState, HistoryEntry } from "@/types";
+import { cameraDisplayName } from "@/utils/camera-helpers";
 import { today, uid } from "@/utils/helpers";
 
 const DEFAULT_POSES: Record<string, number> = {
@@ -41,7 +42,7 @@ interface NewFilmParams {
 	scanRef?: string | null;
 	scanCost?: number | null;
 	devScanPackage?: boolean;
-	cameraDisplayName?: string | null;
+	camera?: Camera | null;
 }
 
 const STATE_RANK: Record<FilmState, number> = {
@@ -57,6 +58,12 @@ function reachedStock(target: FilmState, threshold: FilmState): boolean {
 	return STATE_RANK[target] >= STATE_RANK[threshold];
 }
 
+function derivePosesShot(state: FilmState, posesShot: number | null | undefined, posesTotal: number): number | null {
+	if (state === "partial") return posesShot ?? 0;
+	if (reachedStock(state, "exposed")) return posesTotal;
+	return null;
+}
+
 function buildHistory(params: NewFilmParams, addedDate: string, posesTotal: number): HistoryEntry[] {
 	const state = params.state ?? "stock";
 	const history: HistoryEntry[] = [{ date: addedDate, action: "", actionCode: "added" }];
@@ -64,7 +71,7 @@ function buildHistory(params: NewFilmParams, addedDate: string, posesTotal: numb
 	if (state === "stock") return history;
 
 	const loadDate = params.startDate || addedDate;
-	const cameraLabel = params.cameraDisplayName ?? "?";
+	const cameraLabel = params.camera ? cameraDisplayName(params.camera) : "?";
 	history.push({
 		date: loadDate,
 		action: "",
@@ -137,7 +144,7 @@ export function createNewFilm(params: NewFilmParams): Film {
 		lensId: params.lensId ?? null,
 		startDate: isAfterStock ? (params.startDate ?? addedDate) : null,
 		endDate: reachedStock(state, "exposed") ? (params.endDate ?? params.startDate ?? addedDate) : null,
-		posesShot: state === "partial" ? (params.posesShot ?? 0) : reachedStock(state, "exposed") ? posesTotal : null,
+		posesShot: derivePosesShot(state, params.posesShot, posesTotal),
 		posesTotal,
 		lab: params.lab ?? null,
 		labRef: params.labRef ?? null,
@@ -145,7 +152,7 @@ export function createNewFilm(params: NewFilmParams): Film {
 		devCost: params.devCost ?? null,
 		scanRef: params.scanRef ?? null,
 		scanCost: params.scanCost ?? null,
-		devScanPackage: params.devScanPackage || undefined,
+		devScanPackage: params.devScanPackage,
 		storageLocation: params.storageLocation ?? null,
 		history: buildHistory(params, addedDate, posesTotal),
 		tags: params.tags && params.tags.length > 0 ? [...params.tags] : undefined,


### PR DESCRIPTION
User feedback: filling stock manually exposed two frictions — pellicules
without an expiration date had to be filled with a placeholder, and
already-loaded/exposed/developed films forced a stock entry plus successive
transitions through FilmDetail. This adds a "simplified" entry mode in the
add dialog so users can record what they actually know.

- MonthYearPicker: clear button (x) appears when a value is set, lets the
  user explicitly mark expiration as unknown. Default is now empty.
- AddFilmDialog: new "État initial" selector exposing the 6 FilmStates.
  When state ≠ stock, an optional contextual block lets the user fill
  camera, dates, lab, scan ref, etc. — all optional. Quantity is forced to
  1 when an advanced state is chosen since each film has a unique history.
- film-factory: createNewFilm now accepts state + contextual params and
  builds a cumulative history (added → loaded → exposed → developed →
  scanned) using provided dates or falling back to addedDate. Reuses the
  same actionCode/params shape as TransitionModals/DevScanModals so the
  history renders identically.
- i18n: added addFilm.{initialState, contextualSection, noInfo} and
  aria.clearDate (FR/EN). State labels reuse the existing states.* keys.