### PR TITLE
Fix magic link redirect URL for GitHub Pages sub-path deployments

### DIFF
--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -35,7 +35,15 @@ export async function getCurrentUser(): Promise<User | null> {
  */
 export async function signInWithEmail(email: string): Promise<{ error: string | null }> {
 	if (!supabase) return { error: "supabase_not_configured" };
-	const redirectTo = window.location.origin + import.meta.env.BASE_URL;
+	// Redirect back to the exact app URL (origin + current pathname) so the
+	// Magic Link works on GitHub Pages where the app is served under a
+	// sub-path (e.g. /film-vault/). import.meta.env.BASE_URL is unreliable
+	// here because vite's `base: './'` resolves it to a relative value that
+	// doesn't combine cleanly with origin.
+	const path = window.location.pathname.endsWith("/")
+		? window.location.pathname
+		: window.location.pathname.replace(/\/[^/]*$/, "/");
+	const redirectTo = `${window.location.origin}${path}`;
 	const { error } = await supabase.auth.signInWithOtp({
 		email,
 		options: { emailRedirectTo: redirectTo },


### PR DESCRIPTION
## Summary
Fixed the magic link redirect URL in the email sign-in flow to work correctly when the app is deployed to a sub-path on GitHub Pages (e.g., `/film-vault/`).

## Key Changes
- Replaced `import.meta.env.BASE_URL` with dynamic pathname detection for the redirect URL
- The redirect URL now uses `window.location.origin` combined with the current pathname, ensuring magic links work correctly regardless of deployment path
- Added logic to normalize the pathname to always end with `/` for consistent redirect behavior

## Implementation Details
The previous implementation relied on `import.meta.env.BASE_URL`, which resolves to a relative value when Vite is configured with `base: './'`. This caused issues on GitHub Pages where the app is served under a sub-path, as the relative value doesn't combine cleanly with the origin.

The new approach:
- Extracts the current pathname from `window.location.pathname`
- Normalizes it to ensure it ends with `/` (either keeps existing trailing slash or removes the last path segment)
- Combines it with `window.location.origin` to create an absolute URL that matches the actual app location

This ensures magic links redirect to the correct URL regardless of the deployment environment.

https://claude.ai/code/session_013mTRS7umpaD43qSgtofaPe