### PR TITLE
fix(add-film): skip format prefill when model has multiple formats

### DIFF
--- a/src/components/AddFilmDialog.tsx
+++ b/src/components/AddFilmDialog.tsx
@@ -60,7 +60,7 @@ export function AddFilmDialog({ open, onOpenChange, data, setData }: AddFilmDial
 		if (info) {
 			setIso(String(info.iso));
 			setType(info.type);
-			setFormat(info.format);
+			if (info.format !== null) setFormat(info.format);
 		}
 	};
 

--- a/src/screens/film-detail/EditModal.tsx
+++ b/src/screens/film-detail/EditModal.tsx
@@ -36,7 +36,7 @@ interface EditModalProps {
 	showScan: boolean;
 	brands: string[];
 	modelsForBrand: (brand: string) => string[];
-	filmDataFor: (brand: string, model: string) => { iso: number; type: string; format: string } | undefined;
+	filmDataFor: (brand: string, model: string) => { iso: number; type: string; format: string | null } | undefined;
 }
 
 export function EditModal({
@@ -98,7 +98,7 @@ export function EditModal({
 									model: selectedModel,
 									iso: String(fd.iso),
 									type: fd.type,
-									format: fd.format,
+									format: fd.format !== null ? fd.format : prev.format,
 								}));
 							}
 						}}

--- a/src/utils/use-film-suggestions.ts
+++ b/src/utils/use-film-suggestions.ts
@@ -6,7 +6,7 @@ import { normalizeBrand } from "@/utils/film-helpers";
 interface FilmData {
 	iso: number;
 	type: string;
-	format: string;
+	format: string | null;
 }
 
 export function useFilmSuggestions(films: Film[]) {
@@ -44,27 +44,37 @@ export function useFilmSuggestions(films: Film[]) {
 			const lowerBrand = brand.trim().toLowerCase();
 			const lowerModel = model.trim().toLowerCase();
 
-			// Search user stock first (priority)
-			const fromStock = films.find(
+			const stockMatches = films.filter(
 				(f) => f.brand?.toLowerCase() === lowerBrand && f.model?.toLowerCase() === lowerModel,
 			);
+			const catalogMatches = getFilmCatalog().filter(
+				(c) => c.brand.toLowerCase() === lowerBrand && c.model.toLowerCase() === lowerModel,
+			);
+
+			const formats = new Set<string>();
+			for (const f of stockMatches) {
+				if (f.format) formats.add(f.format);
+			}
+			for (const c of catalogMatches) {
+				formats.add(c.format);
+			}
+
+			// Prefer stock data for iso/type (user's recorded values), fallback to catalog
+			const fromStock = stockMatches.find((f) => f.iso);
 			if (fromStock?.iso) {
 				return {
 					iso: fromStock.iso,
 					type: fromStock.type || "Couleur",
-					format: fromStock.format || "35mm",
+					format: formats.size === 1 ? fromStock.format || [...formats][0] || null : null,
 				};
 			}
 
-			// Fallback to catalog
-			const fromCatalog = getFilmCatalog().find(
-				(c) => c.brand.toLowerCase() === lowerBrand && c.model.toLowerCase() === lowerModel,
-			);
+			const fromCatalog = catalogMatches[0];
 			if (fromCatalog) {
 				return {
 					iso: fromCatalog.iso,
 					type: fromCatalog.type,
-					format: fromCatalog.format,
+					format: formats.size === 1 ? fromCatalog.format : null,
 				};
 			}
 


### PR DESCRIPTION
When the same brand+model exists in multiple formats (in user stock or
catalog), filmDataFor used Array.find and returned the first format
match (typically 35mm). For films like Kodak Portra 160 or Gold which
exist in both 35mm and 120, the format had to be corrected manually
half the time. Now filmDataFor returns format: null when the formats
are ambiguous, and callers preserve their current format selection.