### PR TITLE
feat(carnet): year-grouped Notebook with last-action date stamps

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -373,11 +373,6 @@ function AppContent({
 		(filmId?: string) => navigate({ screen: "map", mapFilterFilmId: filmId ?? null }),
 		[navigate],
 	);
-	const openStockFiltered = useCallback(
-		(stateFilter: string) => navigate({ screen: "stock", stockStateFilter: stateFilter }),
-		[navigate],
-	);
-	const openCamerasList = useCallback(() => navigate({ screen: "cameras" }), [navigate]);
 	const openSettings = useCallback(() => navigate({ screen: "settings" }), [navigate]);
 	const openLegal = useCallback(() => navigate({ screen: "legal" }), [navigate]);
 
@@ -398,16 +393,7 @@ function AppContent({
 	const renderScreen = () => {
 		switch (screen) {
 			case "home":
-				return (
-					<DashboardScreen
-						data={effectiveData}
-						onOpenFilm={openFilm}
-						onOpenCameras={openCamerasList}
-						onOpenSettings={openSettings}
-						setAutoOpenShotNote={setAutoOpenShotNote}
-						onNavigateToStock={openStockFiltered}
-					/>
-				);
+				return <DashboardScreen data={effectiveData} onOpenFilm={openFilm} onOpenSettings={openSettings} />;
 			case "stock":
 				return <StockScreen data={effectiveData} onOpenFilm={openFilm} initialStateFilter={stockStateFilter ?? null} />;
 			case "filmDetail":
@@ -473,16 +459,7 @@ function AppContent({
 			case "legal":
 				return <LegalScreen onBack={goBack} />;
 			default:
-				return (
-					<DashboardScreen
-						data={effectiveData}
-						onOpenFilm={openFilm}
-						onOpenCameras={openCamerasList}
-						onOpenSettings={openSettings}
-						setAutoOpenShotNote={setAutoOpenShotNote}
-						onNavigateToStock={openStockFiltered}
-					/>
-				);
+				return <DashboardScreen data={effectiveData} onOpenFilm={openFilm} onOpenSettings={openSettings} />;
 		}
 	};
 

--- a/src/components/ActiveRollCard.tsx
+++ b/src/components/ActiveRollCard.tsx
@@ -26,7 +26,7 @@ export function ActiveRollCard({ film, camera, back, onShotClick, onClick, class
 	const loadedDate = getLoadedDate(film);
 
 	const formattedDate = loadedDate
-		? new Date(`${loadedDate}T00:00:00`).toLocaleDateString(i18n.language === "fr" ? "fr-FR" : "en-US", {
+		? new Date(`${loadedDate}T00:00:00`).toLocaleDateString(i18n.language.startsWith("fr") ? "fr-FR" : "en-US", {
 				day: "numeric",
 				month: "long",
 				year: "numeric",

--- a/src/components/CarnetFilmCard.tsx
+++ b/src/components/CarnetFilmCard.tsx
@@ -79,7 +79,7 @@ function describeState(
 	}
 	if (film.state === "scanned") {
 		return {
-			state: { key: "scanned", label: t("states.scanned") || "scannée" },
+			state: { key: "scanned", label: t("states.scanned") },
 			description: t("dashboard.state.scanned"),
 		};
 	}
@@ -107,7 +107,7 @@ export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: 
 
 	const lastActionISO = filmLastActionDate(film);
 	const lastActionLabel = lastActionISO
-		? new Date(lastActionISO).toLocaleDateString(i18n.language === "fr" ? "fr-FR" : "en-US", {
+		? new Date(lastActionISO).toLocaleDateString(i18n.language.startsWith("fr") ? "fr-FR" : "en-US", {
 				day: "numeric",
 				month: "short",
 			})

--- a/src/components/CarnetFilmCard.tsx
+++ b/src/components/CarnetFilmCard.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import type { Camera, Film } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
 import { pickRotation, pickWashiColor, pickWashiPosition } from "@/utils/card-decorations";
+import { filmLastActionDate } from "@/utils/film-helpers";
 
 interface CarnetFilmCardProps {
 	film: Film;
@@ -23,6 +24,7 @@ const STATE_BG: Record<string, string> = {
 	exposed: "bg-ink text-kodak-yellow",
 	atLab: "bg-kodak-teal text-paper",
 	developed: "bg-kodak-gold text-ink",
+	scanned: "bg-paper-dark text-ink-soft border border-ink-faded/60",
 };
 
 interface StateInfo {
@@ -75,6 +77,12 @@ function describeState(
 			description: t("dashboard.state.toScan"),
 		};
 	}
+	if (film.state === "scanned") {
+		return {
+			state: { key: "scanned", label: t("states.scanned") || "scannée" },
+			description: t("dashboard.state.scanned"),
+		};
+	}
 	return {
 		state: { key: "exposed", label: film.state },
 		description: "",
@@ -82,7 +90,7 @@ function describeState(
 }
 
 export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: CarnetFilmCardProps) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const variant = filmTypeToVariant(film.type);
 	const rotation = pickRotation(index);
 	const washiPos = pickWashiPosition(index);
@@ -96,6 +104,14 @@ export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: 
 	const displayName = film.customName || `${film.brand ?? ""} ${film.model ?? ""}`.trim() || "—";
 	const labRef = film.labRef?.trim() || null;
 	const sub = film.type ? `${film.type.toLowerCase()}` : "";
+
+	const lastActionISO = filmLastActionDate(film);
+	const lastActionLabel = lastActionISO
+		? new Date(lastActionISO).toLocaleDateString(i18n.language === "fr" ? "fr-FR" : "en-US", {
+				day: "numeric",
+				month: "short",
+			})
+		: null;
 
 	return (
 		<button
@@ -140,7 +156,16 @@ export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: 
 					)}
 				</div>
 
-				{description && <div className="font-caveat text-[17px] leading-[1.3] text-ink-soft mt-2">{description}</div>}
+				{(description || lastActionLabel) && (
+					<div className="mt-2">
+						{description && <div className="font-caveat text-[17px] leading-[1.3] text-ink-soft">{description}</div>}
+						{lastActionLabel && (
+							<div className="font-typewriter text-[9px] tracking-[0.12em] uppercase text-ink-faded mt-1">
+								{lastActionLabel}
+							</div>
+						)}
+					</div>
+				)}
 
 				<div className="flex items-center gap-2.5 mt-2.5 pt-2.5 border-t border-dashed border-ink-faded/35">
 					<span

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -49,17 +49,6 @@ export const en = {
 	// Dashboard / Carnet
 	dashboard: {
 		title: "Notebook",
-		filter: {
-			all: "All",
-			loaded: "Loaded",
-			toDev: "To develop",
-			toScan: "To scan",
-		},
-		stats: {
-			loaded: "loaded",
-			toDev: "to develop",
-			toScan: "to scan",
-		},
 		emptyMoving: "Your notebook is empty",
 		emptyMovingSubtitle: "Load a film to see it appear here",
 		typeSuffix: "neg",
@@ -70,6 +59,7 @@ export const en = {
 			exposed: "Exposed — finished",
 			atLab: "At the lab — {{lab}}",
 			toScan: "Developed — to scan",
+			scanned: "Scanned — archived",
 			noCamera: "Loaded",
 		},
 		inStock: "In stock",
@@ -786,9 +776,9 @@ export const en = {
 			description: "This is your film notebook — a quick tour of the key screens. You can skip at any time.",
 		},
 		carnetFilters: {
-			title: "The Notebook, your daily feed",
+			title: "The Notebook, year by year",
 			description:
-				"The Notebook gathers your in-flight rolls: loaded, ready to develop, ready to scan. Use the filter chips to zoom into one stage.",
+				"The Notebook lists your rolls year by year — in-flight and finished, newest first. Switch years to flip through your history.",
 		},
 		carnetCard: {
 			title: "A roll at a glance",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -49,17 +49,6 @@ export const fr = {
 	// Dashboard / Carnet
 	dashboard: {
 		title: "Carnet",
-		filter: {
-			all: "Toutes",
-			loaded: "Chargées",
-			toDev: "À développer",
-			toScan: "À scanner",
-		},
-		stats: {
-			loaded: "chargées",
-			toDev: "à développer",
-			toScan: "à scanner",
-		},
 		emptyMoving: "Le carnet est vide",
 		emptyMovingSubtitle: "Charge une pellicule pour qu'elle apparaisse ici",
 		typeSuffix: "neg",
@@ -70,6 +59,7 @@ export const fr = {
 			exposed: "Exposée — terminée",
 			atLab: "Au labo — {{lab}}",
 			toScan: "Développée — à scanner",
+			scanned: "Scannée — archivée",
 			noCamera: "Chargée",
 		},
 		inStock: "En stock",
@@ -787,9 +777,9 @@ export const fr = {
 				"Voici ton carnet de pellicules — un mini-guide pour découvrir les écrans clés. Tu peux passer à tout moment.",
 		},
 		carnetFilters: {
-			title: "Le carnet, ton fil du jour",
+			title: "Le carnet, année par année",
 			description:
-				"Le Carnet rassemble les pellicules en cours : chargées, à développer, à scanner. Bascule entre les filtres pour zoomer sur une étape.",
+				"Le Carnet liste tes pellicules de l'année : en cours et finies, de la plus récente à la plus ancienne. Bascule sur une autre année pour feuilleter ton historique.",
 		},
 		carnetCard: {
 			title: "Une pellicule en un coup d'œil",

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,5 +1,5 @@
 import { Film as FilmIcon, Settings } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CarnetFilmCard } from "@/components/CarnetFilmCard";
 import { EmptyState } from "@/components/EmptyState";
@@ -43,6 +43,16 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 		const currentYear = new Date().getFullYear().toString();
 		return yearBuckets.some(([y]) => y === currentYear) ? currentYear : (yearBuckets[0]?.[0] ?? null);
 	});
+
+	useEffect(() => {
+		if (yearBuckets.length === 0) {
+			if (selectedYear !== null) setSelectedYear(null);
+			return;
+		}
+		if (!selectedYear || !yearBuckets.some(([y]) => y === selectedYear)) {
+			setSelectedYear(yearBuckets[0][0]);
+		}
+	}, [yearBuckets, selectedYear]);
 
 	const visible = useMemo(() => {
 		if (!selectedYear) return [];

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from "@/components/EmptyState";
 import { Chip } from "@/components/ui/chip";
 import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/utils";
-import type { AppData, Film } from "@/types";
+import type { AppData, Film, FilmState } from "@/types";
 import { filmLastActionDate } from "@/utils/film-helpers";
 
 interface DashboardScreenProps {
@@ -15,6 +15,8 @@ interface DashboardScreenProps {
 	onOpenSettings?: () => void;
 }
 
+const CARNET_STATES: ReadonlySet<FilmState> = new Set(["loaded", "partial", "exposed", "developed", "scanned"]);
+
 export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardScreenProps) {
 	const { t } = useTranslation();
 	const { films, cameras } = data;
@@ -22,7 +24,7 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 	const datedFilms = useMemo(() => {
 		const list: Array<{ film: Film; lastDate: string }> = [];
 		for (const film of films) {
-			if (!film.startDate) continue;
+			if (!CARNET_STATES.has(film.state)) continue;
 			const lastDate = filmLastActionDate(film);
 			if (lastDate) list.push({ film, lastDate });
 		}

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,60 +1,62 @@
 import { Film as FilmIcon, Settings } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CarnetFilmCard } from "@/components/CarnetFilmCard";
 import { EmptyState } from "@/components/EmptyState";
 import { Chip } from "@/components/ui/chip";
 import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/utils";
-import type { AppData, Film as FilmType } from "@/types";
+import type { AppData, Film } from "@/types";
+import { filmLastActionDate } from "@/utils/film-helpers";
 
 interface DashboardScreenProps {
 	data: AppData;
 	onOpenFilm: (id: string) => void;
-	onOpenCameras?: () => void;
 	onOpenSettings?: () => void;
-	setAutoOpenShotNote?: (open: boolean) => void;
-	onNavigateToStock?: (stateFilter: string) => void;
-}
-
-type CarnetFilter = "all" | "loaded" | "toDev" | "toScan";
-
-const MOVING_STATES: ReadonlySet<FilmType["state"]> = new Set(["loaded", "partial", "exposed", "developed"]);
-
-function matchesFilter(state: FilmType["state"], filter: CarnetFilter): boolean {
-	if (filter === "all") return MOVING_STATES.has(state);
-	if (filter === "loaded") return state === "loaded" || state === "partial";
-	if (filter === "toDev") return state === "exposed";
-	return state === "developed";
 }
 
 export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardScreenProps) {
 	const { t } = useTranslation();
 	const { films, cameras } = data;
-	const [filter, setFilter] = useState<CarnetFilter>("all");
 
-	const moving = films.filter((f) => MOVING_STATES.has(f.state));
-	const counts = {
-		all: moving.length,
-		loaded: moving.filter((f) => f.state === "loaded" || f.state === "partial").length,
-		toDev: moving.filter((f) => f.state === "exposed").length,
-		toScan: moving.filter((f) => f.state === "developed").length,
-	};
+	const datedFilms = useMemo(() => {
+		const list: Array<{ film: Film; lastDate: string }> = [];
+		for (const film of films) {
+			if (!film.startDate) continue;
+			const lastDate = filmLastActionDate(film);
+			if (lastDate) list.push({ film, lastDate });
+		}
+		return list;
+	}, [films]);
 
-	const visible = moving.filter((f) => matchesFilter(f.state, filter));
+	const yearBuckets = useMemo(() => {
+		const map = new Map<string, number>();
+		for (const { lastDate } of datedFilms) {
+			const year = lastDate.slice(0, 4);
+			map.set(year, (map.get(year) ?? 0) + 1);
+		}
+		return [...map.entries()].sort((a, b) => b[0].localeCompare(a[0]));
+	}, [datedFilms]);
 
-	const filterDefs: { id: CarnetFilter; label: string; count: number }[] = [
-		{ id: "all", label: t("dashboard.filter.all"), count: counts.all },
-		{ id: "loaded", label: t("dashboard.filter.loaded"), count: counts.loaded },
-		{ id: "toDev", label: t("dashboard.filter.toDev"), count: counts.toDev },
-		{ id: "toScan", label: t("dashboard.filter.toScan"), count: counts.toScan },
-	];
+	const [selectedYear, setSelectedYear] = useState<string | null>(() => {
+		if (yearBuckets.length === 0) return null;
+		const currentYear = new Date().getFullYear().toString();
+		return yearBuckets.some(([y]) => y === currentYear) ? currentYear : (yearBuckets[0]?.[0] ?? null);
+	});
+
+	const visible = useMemo(() => {
+		if (!selectedYear) return [];
+		return datedFilms
+			.filter(({ lastDate }) => lastDate.startsWith(selectedYear))
+			.sort((a, b) => b.lastDate.localeCompare(a.lastDate))
+			.map(({ film }) => film);
+	}, [datedFilms, selectedYear]);
 
 	return (
 		<div className="-mx-4 md:-mx-8 -mt-5 md:-mt-[max(1.25rem,env(safe-area-inset-top))]">
 			<PageHeader
 				title={t("dashboard.title")}
-				count={counts.all}
+				count={visible.length}
 				right={
 					onOpenSettings ? (
 						<button
@@ -68,25 +70,32 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 					) : undefined
 				}
 			>
-				<nav
-					className="flex gap-2 overflow-x-auto px-[18px] pb-2.5 fv-noscroll"
-					aria-label={t("dashboard.title")}
-					data-tour="carnet-filters"
-				>
-					{filterDefs.map((f) => (
-						<Chip key={f.id} active={filter === f.id} onClick={() => setFilter(f.id)} className="flex-none">
-							{f.label}
-							<span
-								className={cn(
-									"font-archivo-black text-[9px] px-1.5 py-px",
-									filter === f.id ? "bg-ink/20 text-ink" : "bg-ink/10 text-ink",
-								)}
+				{yearBuckets.length > 0 && (
+					<nav
+						className="flex gap-2 overflow-x-auto px-[18px] pb-2.5 fv-noscroll"
+						aria-label={t("dashboard.title")}
+						data-tour="carnet-filters"
+					>
+						{yearBuckets.map(([year, count]) => (
+							<Chip
+								key={year}
+								active={selectedYear === year}
+								onClick={() => setSelectedYear(year)}
+								className="flex-none"
 							>
-								{f.count}
-							</span>
-						</Chip>
-					))}
-				</nav>
+								{year}
+								<span
+									className={cn(
+										"font-archivo-black text-[9px] px-1.5 py-px",
+										selectedYear === year ? "bg-ink/20 text-ink" : "bg-ink/10 text-ink",
+									)}
+								>
+									{count}
+								</span>
+							</Chip>
+						))}
+					</nav>
+				)}
 			</PageHeader>
 
 			<main className="px-[18px] pt-8 pb-32 flex flex-col gap-[18px]">

--- a/src/utils/film-helpers.ts
+++ b/src/utils/film-helpers.ts
@@ -28,8 +28,13 @@ export const filmType = (film: Film): string => film.type || "?";
 
 export const filmIso = (film: Film): number | string => film.iso || "?";
 
-export const filmLastActionDate = (film: Film): string | null =>
-	film.history[film.history.length - 1]?.date ?? film.startDate ?? null;
+export const filmLastActionDate = (film: Film): string | null => {
+	let latest: string | null = null;
+	for (const entry of film.history) {
+		if (entry.date && (latest === null || entry.date > latest)) latest = entry.date;
+	}
+	return latest ?? film.startDate ?? null;
+};
 
 export const collectAllTags = (films: Film[]): string[] => {
 	const canonical = new Map<string, string>();

--- a/src/utils/film-helpers.ts
+++ b/src/utils/film-helpers.ts
@@ -28,6 +28,9 @@ export const filmType = (film: Film): string => film.type || "?";
 
 export const filmIso = (film: Film): number | string => film.iso || "?";
 
+export const filmLastActionDate = (film: Film): string | null =>
+	film.history[film.history.length - 1]?.date ?? film.startDate ?? null;
+
 export const collectAllTags = (films: Film[]): string[] => {
 	const canonical = new Map<string, string>();
 	for (const f of films) {


### PR DESCRIPTION
## Contexte

Le but originel de l'app est de remplacer le carnet papier où je note les pellicules shootées chaque année. Le Dashboard actuel ne donnait que la vue « en mouvement » — pas moyen de feuilleter ce qui a été shooté en 2024, 2025, etc.

## Summary

- **Sélecteur d'année** en remplacement des chips d'état (toutes / chargées / à développer / à scanner). Une chip par année non vide, la plus récente d'abord.
- **Bucket par année de dernière action** (et non par `startDate`) : une pellicule chargée fin déc 2025 mais scannée en janv 2026 apparaît bien dans **2026**.
- **Tri par date de dernière action décroissante** dans chaque année.
- **Inclut maintenant les pellicules `scanned`** (auparavant masquées) avec un nouveau badge sépia/papier-foncé sur `CarnetFilmCard`.
- **Tampon de date** (font-typewriter) sous la description handwritten — `12 MARS`, `28 FÉVR.`, etc. Sans année, puisque l'année est déjà donnée par la chip active.
- Stock pur (`state === "stock"`, jamais chargé) reste **exclu** du carnet.
- Helper `filmLastActionDate(film)` extrait dans `src/utils/film-helpers.ts`, partagé entre l'écran et la carte pour garantir que le bucket et le tampon soient toujours alignés.
- Nettoyage : suppression des props et callbacks devenus inutiles côté `App.tsx` (`onOpenCameras`, `setAutoOpenShotNote`, `onNavigateToStock`, `openStockFiltered`, `openCamerasList`) ; suppression des clés i18n `dashboard.filter.*` et `dashboard.stats.*` devenues mortes ; mise à jour de la copy du tour `tour.carnetFilters` pour parler d'années.

## Test plan

- [ ] L'onglet Carnet affiche par défaut l'année courante (2026), avec chips d'années plus récente → plus ancienne, ne listant que celles qui ont des pellicules
- [ ] Cliquer sur une chip d'année antérieure (2025, 2024…) met à jour la liste, triée par dernière action desc
- [ ] Une pellicule chargée en 2025 et scannée en 2026 apparaît bien dans la chip 2026 (pas 2025)
- [ ] Une pellicule en `stock` (jamais chargée) n'apparaît jamais dans le carnet
- [ ] Une pellicule en `scanned` apparaît dans son année avec le nouveau badge sépia/papier-foncé (pas le fallback exposed)
- [ ] Tampon de date affiché sous la description handwritten, au format `12 MARS` (sans année), cohérent entre toutes les cartes
- [ ] Le tour guidé sur la home (étapes carnet-filters / carnet-card) cible toujours les bons éléments et le texte parle bien d'années

🤖 Generated with [Claude Code](https://claude.com/claude-code)