### PR TITLE
feat(feedback): in-app feedback module with Supabase + Resend

### DIFF
--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,0 +1,122 @@
+import { Send } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "@/components/Toast";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { type FeedbackCategory, submitFeedback } from "@/utils/feedback";
+
+const MESSAGE_MAX = 4000;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface FeedbackModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
+	const { t } = useTranslation();
+	const { toast } = useToast();
+
+	const [category, setCategory] = useState<FeedbackCategory>("bug");
+	const [message, setMessage] = useState("");
+	const [email, setEmail] = useState("");
+	const [sending, setSending] = useState(false);
+
+	const trimmedMessage = message.trim();
+	const trimmedEmail = email.trim();
+	const emailInvalid = trimmedEmail.length > 0 && !EMAIL_REGEX.test(trimmedEmail);
+	const canSubmit = !sending && trimmedMessage.length > 0 && trimmedMessage.length <= MESSAGE_MAX && !emailInvalid;
+
+	function reset() {
+		setCategory("bug");
+		setMessage("");
+		setEmail("");
+		setSending(false);
+	}
+
+	function handleOpenChange(next: boolean) {
+		if (!next) reset();
+		onOpenChange(next);
+	}
+
+	async function handleSubmit() {
+		if (!canSubmit) return;
+		setSending(true);
+		const { ok } = await submitFeedback({
+			category,
+			message: trimmedMessage,
+			contactEmail: trimmedEmail || undefined,
+		});
+		setSending(false);
+		if (ok) {
+			toast(t("feedback.submissionSuccess"), "success");
+			reset();
+			onOpenChange(false);
+		} else {
+			toast(t("feedback.submissionError"), "error");
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleOpenChange}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>{t("feedback.title")}</DialogTitle>
+					<DialogCloseButton />
+				</DialogHeader>
+				<div className="flex flex-col gap-4">
+					<p className="text-xs text-text-muted -mt-2">{t("feedback.subtitle")}</p>
+
+					<FormField label={t("feedback.categoryLabel")}>
+						<Select value={category} onValueChange={(v) => setCategory(v as FeedbackCategory)}>
+							<SelectTrigger>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="bug">{t("feedback.categoryBug")}</SelectItem>
+								<SelectItem value="suggestion">{t("feedback.categorySuggestion")}</SelectItem>
+								<SelectItem value="other">{t("feedback.categoryOther")}</SelectItem>
+							</SelectContent>
+						</Select>
+					</FormField>
+
+					<FormField label={t("feedback.messageLabel")}>
+						<Textarea
+							value={message}
+							onChange={(e) => setMessage(e.target.value)}
+							placeholder={t("feedback.messagePlaceholder")}
+							rows={6}
+							maxLength={MESSAGE_MAX}
+						/>
+						<div className="text-[10px] text-text-muted text-right font-mono">
+							{trimmedMessage.length}/{MESSAGE_MAX}
+						</div>
+					</FormField>
+
+					<FormField label={t("feedback.emailLabel")}>
+						<Input
+							type="email"
+							value={email}
+							onChange={(e) => setEmail(e.target.value)}
+							placeholder={t("feedback.emailPlaceholder")}
+							autoComplete="email"
+						/>
+						<div className="text-[11px] text-text-muted">
+							{emailInvalid ? t("feedback.emailInvalid") : t("feedback.emailHelper")}
+						</div>
+					</FormField>
+
+					<Button onClick={handleSubmit} disabled={!canSubmit} className="w-full justify-center">
+						<Send size={16} />
+						{sending ? t("feedback.sending") : t("feedback.sendButton")}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -25,6 +25,7 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 	const [category, setCategory] = useState<FeedbackCategory>("bug");
 	const [message, setMessage] = useState("");
 	const [email, setEmail] = useState("");
+	const [honeypot, setHoneypot] = useState("");
 	const [sending, setSending] = useState(false);
 
 	const trimmedMessage = message.trim();
@@ -36,6 +37,7 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 		setCategory("bug");
 		setMessage("");
 		setEmail("");
+		setHoneypot("");
 		setSending(false);
 	}
 
@@ -51,6 +53,7 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 			category,
 			message: trimmedMessage,
 			contactEmail: trimmedEmail || undefined,
+			honeypot,
 		});
 		setSending(false);
 		if (ok) {
@@ -71,6 +74,21 @@ export function FeedbackModal({ open, onOpenChange }: FeedbackModalProps) {
 				</DialogHeader>
 				<div className="flex flex-col gap-4">
 					<p className="text-xs text-text-muted -mt-2">{t("feedback.subtitle")}</p>
+
+					{/* Honeypot: real users never fill this — bots usually do. */}
+					<div aria-hidden="true" className="absolute -left-[9999px] top-auto h-0 w-0 overflow-hidden">
+						<label>
+							Website
+							<input
+								type="text"
+								name="website"
+								tabIndex={-1}
+								autoComplete="off"
+								value={honeypot}
+								onChange={(e) => setHoneypot(e.target.value)}
+							/>
+						</label>
+					</div>
 
 					<FormField label={t("feedback.categoryLabel")}>
 						<Select value={category} onValueChange={(v) => setCategory(v as FeedbackCategory)}>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -779,6 +779,27 @@ export const en = {
 			"For any questions about your data or to exercise your rights, you can contact the publisher via GitHub: github.com/benji07/film-vault/issues.",
 	},
 
+	// Feedback module
+	feedback: {
+		entryTitle: "Send feedback",
+		title: "Your feedback",
+		subtitle: "Bug, suggestion or quick note — every message gets read.",
+		categoryLabel: "Type",
+		categoryBug: "Report a bug",
+		categorySuggestion: "Suggest a feature",
+		categoryOther: "Other",
+		messageLabel: "Message",
+		messagePlaceholder: "Tell us what's not working, or what you'd like to see…",
+		emailLabel: "Email (optional)",
+		emailPlaceholder: "your@email.com",
+		emailHelper: "So we can reply.",
+		emailInvalid: "Invalid email format.",
+		sendButton: "Send",
+		sending: "Sending…",
+		submissionSuccess: "Thanks for your feedback!",
+		submissionError: "Sending failed. Please try again later.",
+	},
+
 	// Tour / Guide
 	tour: {
 		welcome: {

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -779,6 +779,27 @@ export const fr = {
 			"Pour toute question relative à vos données ou pour exercer vos droits, vous pouvez contacter l'éditeur via GitHub : github.com/benji07/film-vault/issues.",
 	},
 
+	// Feedback module
+	feedback: {
+		entryTitle: "Envoyer un feedback",
+		title: "Ton retour",
+		subtitle: "Bug, suggestion ou simple retour — tout est lu, promis.",
+		categoryLabel: "Type",
+		categoryBug: "Signaler un bug",
+		categorySuggestion: "Proposer une fonctionnalité",
+		categoryOther: "Autre",
+		messageLabel: "Message",
+		messagePlaceholder: "Décris ce qui ne va pas, ou ce que tu aimerais voir…",
+		emailLabel: "Email (optionnel)",
+		emailPlaceholder: "ton@email.com",
+		emailHelper: "Pour qu'on puisse te répondre.",
+		emailInvalid: "Format d'email invalide.",
+		sendButton: "Envoyer",
+		sending: "Envoi…",
+		submissionSuccess: "Merci pour ton retour !",
+		submissionError: "L'envoi a échoué. Réessaye plus tard.",
+	},
+
 	// Tour / Guide
 	tour: {
 		welcome: {

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import {
 	Loader2,
 	LogOut,
 	Mail,
+	MessageCircle,
 	Package,
 	Play,
 	RefreshCw,
@@ -22,6 +23,7 @@ import {
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { FeedbackModal } from "@/components/FeedbackModal";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -77,6 +79,7 @@ export function SettingsScreen({
 	const [restoring, setRestoring] = useState(false);
 	const [exportCode, setExportCode] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
+	const [feedbackOpen, setFeedbackOpen] = useState(false);
 
 	// Fetch the export/secours recovery code once signed in.
 	useEffect(() => {
@@ -539,9 +542,19 @@ export function SettingsScreen({
 				</Card>
 			)}
 
+			<Button
+				variant="ghost"
+				onClick={() => setFeedbackOpen(true)}
+				className="w-full justify-center text-text-muted text-xs"
+			>
+				<MessageCircle size={14} /> {t("feedback.entryTitle")}
+			</Button>
+
 			<Button variant="ghost" onClick={onOpenLegal} className="w-full justify-center text-text-muted text-xs">
 				{t("settings.legalNotices")}
 			</Button>
+
+			<FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
 
 			<div className="flex flex-col gap-2.5">
 				<Button variant="outline" onClick={() => exportData(data)} className="w-full justify-center">

--- a/src/utils/feedback.ts
+++ b/src/utils/feedback.ts
@@ -1,0 +1,26 @@
+import i18n from "@/utils/i18n";
+import { supabase } from "@/utils/supabase";
+
+export type FeedbackCategory = "bug" | "suggestion" | "other";
+
+export interface FeedbackPayload {
+	category: FeedbackCategory;
+	message: string;
+	contactEmail?: string;
+}
+
+export async function submitFeedback(payload: FeedbackPayload): Promise<{ ok: boolean }> {
+	if (!supabase) return { ok: false };
+
+	const { error } = await supabase.functions.invoke("submit-feedback", {
+		body: {
+			category: payload.category,
+			message: payload.message,
+			contactEmail: payload.contactEmail?.trim() || null,
+			locale: i18n.language ?? null,
+			userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
+		},
+	});
+
+	return { ok: !error };
+}

--- a/src/utils/feedback.ts
+++ b/src/utils/feedback.ts
@@ -7,6 +7,8 @@ export interface FeedbackPayload {
 	category: FeedbackCategory;
 	message: string;
 	contactEmail?: string;
+	/** Honeypot value — must stay empty; bots tend to fill every input. */
+	honeypot?: string;
 }
 
 export async function submitFeedback(payload: FeedbackPayload): Promise<{ ok: boolean }> {
@@ -17,7 +19,9 @@ export async function submitFeedback(payload: FeedbackPayload): Promise<{ ok: bo
 			category: payload.category,
 			message: payload.message,
 			contactEmail: payload.contactEmail?.trim() || null,
+			honeypot: payload.honeypot ?? "",
 			locale: i18n.language ?? null,
+			appVersion: __APP_VERSION__,
 			userAgent: typeof navigator !== "undefined" ? navigator.userAgent : null,
 		},
 	});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,4 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/react" />
+
+declare const __APP_VERSION__: string;

--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -4,6 +4,8 @@
 // role bypasses the table's locked-down RLS), and notifies the admin via
 // Resend. Email failure is logged but does not fail the request — the row in
 // the DB is the source of truth.
+//
+// Anti-abuse: honeypot field + per-IP throttle (5 inserts / 5 min).
 
 // @ts-expect-error Deno-only import
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
@@ -19,25 +21,39 @@ type Category = (typeof CATEGORIES)[number];
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MESSAGE_MAX = 4000;
 
-const CORS_HEADERS = {
-	"Access-Control-Allow-Origin": "*",
-	"Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-	"Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+const ALLOWED_ORIGINS = new Set<string>([
+	"https://benji07.github.io",
+	"http://localhost:5173",
+	"http://localhost:4173",
+]);
+
+const RATE_LIMIT_WINDOW_MIN = 5;
+const RATE_LIMIT_MAX = 5;
+
+function corsHeaders(origin: string): Record<string, string> {
+	const allowed = ALLOWED_ORIGINS.has(origin) ? origin : "";
+	return {
+		"Access-Control-Allow-Origin": allowed,
+		"Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+		"Access-Control-Allow-Methods": "POST, OPTIONS",
+		Vary: "Origin",
+	};
+}
 
 interface FeedbackBody {
 	category?: string;
 	message?: string;
 	contactEmail?: string | null;
+	honeypot?: string | null;
 	locale?: string | null;
 	appVersion?: string | null;
 	userAgent?: string | null;
 }
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(body: unknown, status: number, origin: string): Response {
 	return new Response(JSON.stringify(body), {
 		status,
-		headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+		headers: { ...corsHeaders(origin), "Content-Type": "application/json" },
 	});
 }
 
@@ -50,43 +66,87 @@ function escapeHtml(value: string): string {
 		.replace(/'/g, "&#39;");
 }
 
+async function sha256Hex(input: string): Promise<string> {
+	const buf = new TextEncoder().encode(input);
+	const digest = await crypto.subtle.digest("SHA-256", buf);
+	return Array.from(new Uint8Array(digest))
+		.map((b) => b.toString(16).padStart(2, "0"))
+		.join("");
+}
+
+function clientIp(req: Request): string | null {
+	const forwarded = req.headers.get("x-forwarded-for");
+	if (forwarded) return forwarded.split(",")[0]?.trim() || null;
+	return req.headers.get("cf-connecting-ip") ?? req.headers.get("x-real-ip");
+}
+
 Deno.serve(async (req) => {
+	const origin = req.headers.get("Origin") ?? "";
+
 	if (req.method === "OPTIONS") {
-		return new Response(null, { headers: CORS_HEADERS });
+		return new Response(null, { headers: corsHeaders(origin) });
 	}
 	if (req.method !== "POST") {
-		return jsonResponse({ error: "method_not_allowed" }, 405);
+		return jsonResponse({ error: "method_not_allowed" }, 405, origin);
 	}
 
 	let body: FeedbackBody;
 	try {
 		body = await req.json();
 	} catch {
-		return jsonResponse({ error: "invalid_json" }, 400);
+		return jsonResponse({ error: "invalid_json" }, 400, origin);
+	}
+
+	// Honeypot: legitimate UI never fills this; bots usually do.
+	if ((body.honeypot ?? "").trim().length > 0) {
+		// Pretend success to avoid signalling the trap.
+		return jsonResponse({ ok: true }, 200, origin);
 	}
 
 	const category = (body.category ?? "").trim();
 	if (!CATEGORIES.includes(category as Category)) {
-		return jsonResponse({ error: "invalid_category" }, 400);
+		return jsonResponse({ error: "invalid_category" }, 400, origin);
 	}
 	const message = (body.message ?? "").trim();
 	if (message.length < 1 || message.length > MESSAGE_MAX) {
-		return jsonResponse({ error: "invalid_message" }, 400);
+		return jsonResponse({ error: "invalid_message" }, 400, origin);
 	}
 	const contactEmailRaw = body.contactEmail?.trim() ?? "";
 	const contactEmail = contactEmailRaw.length > 0 ? contactEmailRaw : null;
 	if (contactEmail && !EMAIL_REGEX.test(contactEmail)) {
-		return jsonResponse({ error: "invalid_email" }, 400);
+		return jsonResponse({ error: "invalid_email" }, 400, origin);
 	}
 
 	const supabaseUrl = Deno.env.get("SUPABASE_URL");
 	const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 	if (!supabaseUrl || !serviceRoleKey) {
-		return jsonResponse({ error: "server_misconfigured" }, 500);
+		return jsonResponse({ error: "server_misconfigured" }, 500, origin);
 	}
 	const admin = createClient(supabaseUrl, serviceRoleKey, {
 		auth: { persistSession: false },
 	});
+
+	// Per-IP throttle. Salt is required — without it, the hash table would be
+	// trivially reversible by hashing the IPv4 space.
+	const ipSalt = Deno.env.get("FEEDBACK_IP_SALT") ?? "";
+	const ip = clientIp(req);
+	let ipHash: string | null = null;
+	if (ip && ipSalt) {
+		ipHash = await sha256Hex(`${ip}:${ipSalt}`);
+		const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MIN * 60_000).toISOString();
+		const { count: recentCount, error: throttleError } = await admin
+			.from("feedback")
+			.select("id", { count: "exact", head: true })
+			.eq("ip_hash", ipHash)
+			.gte("created_at", since);
+		if (throttleError) {
+			console.error("throttle lookup failed", throttleError);
+		} else if ((recentCount ?? 0) >= RATE_LIMIT_MAX) {
+			return jsonResponse({ error: "rate_limited" }, 429, origin);
+		}
+	} else if (!ipSalt) {
+		console.warn("FEEDBACK_IP_SALT missing — throttle disabled");
+	}
 
 	let userId: string | null = null;
 	const authHeader = req.headers.get("Authorization") ?? "";
@@ -118,20 +178,21 @@ Deno.serve(async (req) => {
 			locale,
 			app_version: appVersion,
 			user_agent: userAgent,
+			ip_hash: ipHash,
 		})
 		.select("id, created_at")
 		.single();
 
 	if (insertError) {
 		console.error("feedback insert failed", insertError);
-		return jsonResponse({ error: "insert_failed" }, 500);
+		return jsonResponse({ error: "insert_failed" }, 500, origin);
 	}
 
 	const resendKey = Deno.env.get("RESEND_API_KEY");
 	const toEmail = Deno.env.get("FEEDBACK_TO_EMAIL");
 	const fromEmail = Deno.env.get("FEEDBACK_FROM_EMAIL");
 	if (resendKey && toEmail && fromEmail) {
-		const summary = message.length > 60 ? `${message.slice(0, 60)}…` : message;
+		const summary = message.replace(/\s+/g, " ").trim().slice(0, 60);
 		const subject = `[FilmVault feedback / ${category}] ${summary}`;
 		const html = [
 			`<p><strong>Catégorie :</strong> ${escapeHtml(category)}</p>`,
@@ -171,5 +232,5 @@ Deno.serve(async (req) => {
 		console.warn("Resend secrets missing — feedback stored but no email sent");
 	}
 
-	return jsonResponse({ ok: true, id: inserted?.id });
+	return jsonResponse({ ok: true, id: inserted?.id }, 200, origin);
 });

--- a/supabase/functions/submit-feedback/index.ts
+++ b/supabase/functions/submit-feedback/index.ts
@@ -1,0 +1,175 @@
+// Edge Function: submit-feedback
+//
+// Validates a feedback payload, inserts it into `public.feedback` (service
+// role bypasses the table's locked-down RLS), and notifies the admin via
+// Resend. Email failure is logged but does not fail the request — the row in
+// the DB is the source of truth.
+
+// @ts-expect-error Deno-only import
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.4";
+
+declare const Deno: {
+	env: { get(key: string): string | undefined };
+	serve(handler: (req: Request) => Response | Promise<Response>): void;
+};
+
+const CATEGORIES = ["bug", "suggestion", "other"] as const;
+type Category = (typeof CATEGORIES)[number];
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MESSAGE_MAX = 4000;
+
+const CORS_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+	"Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+interface FeedbackBody {
+	category?: string;
+	message?: string;
+	contactEmail?: string | null;
+	locale?: string | null;
+	appVersion?: string | null;
+	userAgent?: string | null;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+	});
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+}
+
+Deno.serve(async (req) => {
+	if (req.method === "OPTIONS") {
+		return new Response(null, { headers: CORS_HEADERS });
+	}
+	if (req.method !== "POST") {
+		return jsonResponse({ error: "method_not_allowed" }, 405);
+	}
+
+	let body: FeedbackBody;
+	try {
+		body = await req.json();
+	} catch {
+		return jsonResponse({ error: "invalid_json" }, 400);
+	}
+
+	const category = (body.category ?? "").trim();
+	if (!CATEGORIES.includes(category as Category)) {
+		return jsonResponse({ error: "invalid_category" }, 400);
+	}
+	const message = (body.message ?? "").trim();
+	if (message.length < 1 || message.length > MESSAGE_MAX) {
+		return jsonResponse({ error: "invalid_message" }, 400);
+	}
+	const contactEmailRaw = body.contactEmail?.trim() ?? "";
+	const contactEmail = contactEmailRaw.length > 0 ? contactEmailRaw : null;
+	if (contactEmail && !EMAIL_REGEX.test(contactEmail)) {
+		return jsonResponse({ error: "invalid_email" }, 400);
+	}
+
+	const supabaseUrl = Deno.env.get("SUPABASE_URL");
+	const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+	if (!supabaseUrl || !serviceRoleKey) {
+		return jsonResponse({ error: "server_misconfigured" }, 500);
+	}
+	const admin = createClient(supabaseUrl, serviceRoleKey, {
+		auth: { persistSession: false },
+	});
+
+	let userId: string | null = null;
+	const authHeader = req.headers.get("Authorization") ?? "";
+	const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
+	if (token) {
+		const { data: userData } = await admin.auth.getUser(token);
+		const authUid = userData?.user?.id;
+		if (authUid) {
+			const { data: profile } = await admin
+				.from("user_profiles")
+				.select("id")
+				.eq("auth_uid", authUid)
+				.maybeSingle();
+			userId = profile?.id ?? null;
+		}
+	}
+
+	const locale = body.locale?.toString().slice(0, 16) ?? null;
+	const appVersion = body.appVersion?.toString().slice(0, 64) ?? null;
+	const userAgent = body.userAgent?.toString().slice(0, 512) ?? null;
+
+	const { data: inserted, error: insertError } = await admin
+		.from("feedback")
+		.insert({
+			user_id: userId,
+			category,
+			message,
+			contact_email: contactEmail,
+			locale,
+			app_version: appVersion,
+			user_agent: userAgent,
+		})
+		.select("id, created_at")
+		.single();
+
+	if (insertError) {
+		console.error("feedback insert failed", insertError);
+		return jsonResponse({ error: "insert_failed" }, 500);
+	}
+
+	const resendKey = Deno.env.get("RESEND_API_KEY");
+	const toEmail = Deno.env.get("FEEDBACK_TO_EMAIL");
+	const fromEmail = Deno.env.get("FEEDBACK_FROM_EMAIL");
+	if (resendKey && toEmail && fromEmail) {
+		const summary = message.length > 60 ? `${message.slice(0, 60)}…` : message;
+		const subject = `[FilmVault feedback / ${category}] ${summary}`;
+		const html = [
+			`<p><strong>Catégorie :</strong> ${escapeHtml(category)}</p>`,
+			contactEmail ? `<p><strong>Email :</strong> ${escapeHtml(contactEmail)}</p>` : "",
+			userId ? `<p><strong>User ID :</strong> ${escapeHtml(userId)}</p>` : "<p><em>Utilisateur anonyme</em></p>",
+			locale ? `<p><strong>Langue :</strong> ${escapeHtml(locale)}</p>` : "",
+			appVersion ? `<p><strong>Version :</strong> ${escapeHtml(appVersion)}</p>` : "",
+			userAgent ? `<p><strong>UA :</strong> ${escapeHtml(userAgent)}</p>` : "",
+			"<hr/>",
+			`<pre style="white-space:pre-wrap;font-family:inherit">${escapeHtml(message)}</pre>`,
+		]
+			.filter(Boolean)
+			.join("\n");
+
+		try {
+			const resendRes = await fetch("https://api.resend.com/emails", {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${resendKey}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					from: fromEmail,
+					to: toEmail,
+					subject,
+					html,
+					reply_to: contactEmail ?? undefined,
+				}),
+			});
+			if (!resendRes.ok) {
+				console.error("resend send failed", resendRes.status, await resendRes.text());
+			}
+		} catch (err) {
+			console.error("resend request threw", err);
+		}
+	} else {
+		console.warn("Resend secrets missing — feedback stored but no email sent");
+	}
+
+	return jsonResponse({ ok: true, id: inserted?.id });
+});

--- a/supabase/migrations/20260502000000_feedback.sql
+++ b/supabase/migrations/20260502000000_feedback.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- Migration: Feedback module
+-- Adds a `feedback` table written exclusively by the `submit-feedback` Edge
+-- Function (service role). RLS is enabled with no policies so anon and
+-- authenticated roles cannot read or write directly — they go through the
+-- Edge Function, which validates input and also notifies the admin via
+-- Resend before returning.
+-- ============================================================================
+
+CREATE TABLE public.feedback (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES public.user_profiles(id) ON DELETE SET NULL,
+    category TEXT NOT NULL CHECK (category IN ('bug', 'suggestion', 'other')),
+    message TEXT NOT NULL CHECK (length(message) BETWEEN 1 AND 4000),
+    contact_email TEXT CHECK (contact_email IS NULL OR contact_email ~* '^[^@]+@[^@]+\.[^@]+$'),
+    locale TEXT,
+    app_version TEXT,
+    user_agent TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX feedback_created_at_idx ON public.feedback (created_at DESC);
+CREATE INDEX feedback_category_idx ON public.feedback (category);
+
+ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
+
+-- No policies: only service_role (Edge Function) can read/write.
+REVOKE ALL ON public.feedback FROM PUBLIC;
+REVOKE ALL ON public.feedback FROM anon;
+REVOKE ALL ON public.feedback FROM authenticated;

--- a/supabase/migrations/20260502000000_feedback.sql
+++ b/supabase/migrations/20260502000000_feedback.sql
@@ -16,11 +16,14 @@ CREATE TABLE public.feedback (
     locale TEXT,
     app_version TEXT,
     user_agent TEXT,
+    -- SHA-256(ip + FEEDBACK_IP_SALT) — used for per-IP rate limiting without storing the raw IP.
+    ip_hash TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX feedback_created_at_idx ON public.feedback (created_at DESC);
 CREATE INDEX feedback_category_idx ON public.feedback (category);
+CREATE INDEX feedback_ip_hash_recent_idx ON public.feedback (ip_hash, created_at DESC) WHERE ip_hash IS NOT NULL;
 
 ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,12 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version),
+	},
 	plugins: [
 		react(),
 		tailwindcss(),


### PR DESCRIPTION
## Summary
- Adds a categorized feedback form (bug / suggestion / other) with optional contact email, exposed via a discreet entry in Settings just above "Mentions légales".
- New `submit-feedback` Supabase Edge Function persists each submission to a locked-down `feedback` table (service role only — anon/authenticated have no direct access) and sends a notification to the admin via Resend in the same round-trip. Email failure does not block persistence; the DB row is the source of truth.
- Free tier of both Supabase (500 MB DB) and Resend (3000 mails/mo) absorb this volume; no new external dependency.

## Files
- `supabase/migrations/20260502000000_feedback.sql` — table + indexes + RLS lockdown
- `supabase/functions/submit-feedback/index.ts` — validate → insert → Resend email
- `src/utils/feedback.ts` — client wrapper around `supabase.functions.invoke`
- `src/components/FeedbackModal.tsx` — Dialog with Select / Textarea / Input + toast
- `src/screens/SettingsScreen.tsx` — ghost button entry above legal notices
- `src/locales/{fr,en}.ts` — new `feedback` namespace

> Branch is stacked on `feat/carnet-yearly-view`. Targets that branch so the diff stays scoped to feedback work.

## Deploy steps (after merge)
```bash
supabase db push
supabase functions deploy submit-feedback
supabase secrets set RESEND_API_KEY=re_xxx \
                     FEEDBACK_TO_EMAIL=benjamin.leveque@elao.com \
                     FEEDBACK_FROM_EMAIL=feedback@<verified-resend-domain>
```

## Test plan
- [ ] `npm run dev` → Settings → "Envoyer un feedback" opens the modal
- [ ] Submit a `bug`, `suggestion`, and `other` — each appears in the `feedback` table with correct category
- [ ] Submit without email → row has NULL `contact_email`; submit with valid email → email stored and used as Resend `reply_to`; submit with invalid email → blocked with inline error
- [ ] Submit while signed in → `user_id` matches `user_profiles.id`; submit signed out → `user_id` is NULL
- [ ] Submit in FR then switch to EN → all strings translate
- [ ] Verify admin inbox receives the Resend notification with the correct subject (`[FilmVault feedback / <category>] …`)
- [ ] Cut network → toast shows error, modal stays open with content preserved
- [ ] Settings layout: legal notices and inventory list still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)