### PR TITLE
fix(layout): cover top safe-area via root container padding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -478,7 +478,7 @@ function AppContent({
 	const showTabBar = !SUB_SCREENS.has(screen);
 
 	return (
-		<div className="h-[100dvh] bg-bg text-text-primary font-body flex flex-col md:flex-row relative">
+		<div className="h-[100dvh] bg-bg text-text-primary font-body flex flex-col md:flex-row relative pt-[env(safe-area-inset-top)]">
 			{/* Sidebar — desktop only, always visible */}
 			<TabBar screen={screen} setScreen={resetScreen} variant="sidebar" className="hidden md:flex" />
 
@@ -495,7 +495,7 @@ function AppContent({
 				{screen === "map" ? (
 					<div className="flex-1 min-h-0">{renderScreen()}</div>
 				) : (
-					<div className="flex-1 overflow-y-auto px-4 md:px-8 pt-5 pb-5 md:pt-[max(1.25rem,env(safe-area-inset-top))]">
+					<div className="flex-1 overflow-y-auto px-4 md:px-8 pt-5 pb-5">
 						<div className="max-w-3xl mx-auto">
 							<div
 								key={`${screen}-${selectedFilm || ""}`}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -28,29 +28,29 @@ export function AppHeader({ screen, goBack, onEditFilm, filmTitle, cameraTitle, 
 
 	// Sub-screens: back button + title (+ optional contextual action on the
 	// right, e.g. edit on filmDetail). Root screens render their own header
-	// via PageHeader, nothing here.
-	if (isSubScreen) {
-		return (
-			<div
-				className={cn(
-					"shrink-0 flex items-center justify-between gap-2 px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-2 bg-paper border-b border-ink-faded/40",
-					className,
-				)}
-			>
-				<div className="flex items-center gap-2 min-w-0 flex-1">
-					<Button variant="ghost" size="icon" onClick={goBack} className="-ml-2" aria-label={t("aria.back")}>
-						<ArrowLeft size={20} className="text-ink-soft" />
-					</Button>
-					<h1 className="font-caveat text-2xl text-ink m-0 truncate">{subScreenTitles[screen]}</h1>
-				</div>
-				{screen === "filmDetail" && onEditFilm && (
-					<Button variant="ghost" size="icon" onClick={onEditFilm} aria-label={t("aria.editFilm")}>
-						<Pencil size={18} className="text-ink-soft" />
-					</Button>
-				)}
-			</div>
-		);
-	}
+	// via PageHeader inside the scroll container — nothing to render here.
+	// The safe-area-inset-top is handled by the root container's padding,
+	// so this header just uses a fixed pt-3.
+	if (!isSubScreen) return null;
 
-	return null;
+	return (
+		<div
+			className={cn(
+				"shrink-0 flex items-center justify-between gap-2 px-4 pt-3 pb-2 bg-paper border-b border-ink-faded/40",
+				className,
+			)}
+		>
+			<div className="flex items-center gap-2 min-w-0 flex-1">
+				<Button variant="ghost" size="icon" onClick={goBack} className="-ml-2" aria-label={t("aria.back")}>
+					<ArrowLeft size={20} className="text-ink-soft" />
+				</Button>
+				<h1 className="font-caveat text-2xl text-ink m-0 truncate">{subScreenTitles[screen]}</h1>
+			</div>
+			{screen === "filmDetail" && onEditFilm && (
+				<Button variant="ghost" size="icon" onClick={onEditFilm} aria-label={t("aria.editFilm")}>
+					<Pencil size={18} className="text-ink-soft" />
+				</Button>
+			)}
+		</div>
+	);
 }

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -65,7 +65,7 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 	}, [datedFilms, selectedYear]);
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5 md:-mt-[max(1.25rem,env(safe-area-inset-top))]">
+		<div className="-mx-4 md:-mx-8 -mt-5">
 			<PageHeader
 				title={t("dashboard.title")}
 				count={visible.length}

--- a/src/screens/EquipmentScreen.tsx
+++ b/src/screens/EquipmentScreen.tsx
@@ -36,7 +36,7 @@ export function EquipmentScreen({ data, setData, onCameraClick }: EquipmentScree
 	}) as string;
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5 md:-mt-[max(1.25rem,env(safe-area-inset-top))]">
+		<div className="-mx-4 md:-mx-8 -mt-5">
 			<PageHeader title={headerTitle} count={counts[activeTab]}>
 				<div className="px-[18px] pb-3">
 					<nav

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -171,7 +171,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 	}
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5 md:-mt-[max(1.25rem,env(safe-area-inset-top))]">
+		<div className="-mx-4 md:-mx-8 -mt-5">
 			<PageHeader title={t("stats.title")} count={films.length}>
 				<div className="px-[18px] pb-2.5">
 					<PeriodSwitch value={period} onChange={setPeriod} yearLabel={yearLabel} />

--- a/src/screens/stock/StockScreen.tsx
+++ b/src/screens/stock/StockScreen.tsx
@@ -58,7 +58,7 @@ export function StockScreen({ data, onOpenFilm, initialStateFilter }: StockScree
 	const searchActive = stockFilters.search.trim() !== "" || stockFilters.hasActiveFilters;
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5 md:-mt-[max(1.25rem,env(safe-area-inset-top))]">
+		<div className="-mx-4 md:-mx-8 -mt-5">
 			<PageHeader
 				title={t("stock.title")}
 				count={totalCount}


### PR DESCRIPTION
## Summary
- Move `env(safe-area-inset-top)` handling from sticky/per-screen elements onto the root `h-[100dvh]` container as plain `padding-top`
- The root already has `bg-bg` (paper), so the band under the Dynamic Island is filled by the root's own background — no sibling element to lag, no sticky quirks, and no child can ever extend into the parent's padding box
- Drop the redundant safe-area overrides: `md:pt-[max(1.25rem,env)]` on the scroll container, `md:-mt-[max(1.25rem,env)]` on the four screen wrappers, and `pt-[max(0.75rem,env)]` on the sub-screen AppHeader

## Why
On iOS Safari with `viewport-fit=cover`, web content is rendered edge-to-edge behind the Dynamic Island. On root screens the only thing covering that band was the sticky PageHeader's bg, and iOS sticky lags during momentum scroll — so list content briefly flashed through the safe-area zone as it scrolled past.

A previous attempt ([commit](https://github.com/benji07/film-vault/commit/9241c1e)) added an opaque sibling strip in `<main>`, which still let content pass through visually. Moving the inset to the root container's padding makes the safe-area band part of the layout box itself: there is no longer any element that *could* render content there.

## Test plan
- [ ] Open the app on an iPhone with Dynamic Island and reload (PWA + Safari)
- [ ] Scroll fast on Carnet, Stock, Stats, Equipment, Map — no content should appear behind the Island
- [ ] Open a film detail (sub-screen) — back button + title should sit cleanly below the Island, no double padding
- [ ] Verify Android / desktop are unchanged (env=0 → root pt collapses to 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)