### PR TITLE
fix(layout): drop pt-5/-mt-5 cancel pattern on root screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { PwaUpdateBanner } from "@/components/PwaUpdateBanner";
 import { QuickShotDialog } from "@/components/QuickShotDialog";
 import { TabBar } from "@/components/TabBar";
 import { ToastProvider, useToast } from "@/components/Toast";
+import { cn } from "@/lib/utils";
 import { CameraDetailScreen } from "@/screens/CameraDetailScreen";
 import { DashboardScreen } from "@/screens/DashboardScreen";
 import { EquipmentScreen } from "@/screens/EquipmentScreen";
@@ -495,7 +496,7 @@ function AppContent({
 				{screen === "map" ? (
 					<div className="flex-1 min-h-0">{renderScreen()}</div>
 				) : (
-					<div className="flex-1 overflow-y-auto px-4 md:px-8 pt-5 pb-5">
+					<div className={cn("flex-1 overflow-y-auto px-4 md:px-8 pb-5", SUB_SCREENS.has(screen) && "pt-5")}>
 						<div className="max-w-3xl mx-auto">
 							<div
 								key={`${screen}-${selectedFilm || ""}`}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -30,13 +30,13 @@ export function AppHeader({ screen, goBack, onEditFilm, filmTitle, cameraTitle, 
 	// right, e.g. edit on filmDetail). Root screens render their own header
 	// via PageHeader inside the scroll container — nothing to render here.
 	// The safe-area-inset-top is handled by the root container's padding,
-	// so this header just uses a fixed pt-3.
+	// so this header sits flush below it with no extra pt.
 	if (!isSubScreen) return null;
 
 	return (
 		<div
 			className={cn(
-				"shrink-0 flex items-center justify-between gap-2 px-4 pt-3 pb-2 bg-paper border-b border-ink-faded/40",
+				"shrink-0 flex items-center justify-between gap-2 px-4 pt-2 pb-2 bg-paper border-b border-ink-faded/40",
 				className,
 			)}
 		>

--- a/src/components/ui/page-header.tsx
+++ b/src/components/ui/page-header.tsx
@@ -20,7 +20,7 @@ interface PageHeaderProps {
 export function PageHeader({ title, count, right, children, className }: PageHeaderProps) {
 	return (
 		<header className={cn("sticky top-0 z-30 bg-paper", "shadow-[0_2px_0_var(--color-ink-faded)]", className)}>
-			<div className="flex items-center gap-2.5 px-4 pt-4 pb-2.5 pl-[18px] pr-3.5">
+			<div className="flex items-center gap-2.5 px-4 pt-2 md:pt-4 pb-2.5 pl-[18px] pr-3.5">
 				<h1 className="font-caveat font-bold text-[28px] leading-none text-ink tracking-[-0.5px] flex-shrink-0">
 					{title}
 					{count != null && (

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -65,7 +65,7 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 	}, [datedFilms, selectedYear]);
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5">
+		<div className="-mx-4 md:-mx-8">
 			<PageHeader
 				title={t("dashboard.title")}
 				count={visible.length}

--- a/src/screens/EquipmentScreen.tsx
+++ b/src/screens/EquipmentScreen.tsx
@@ -36,7 +36,7 @@ export function EquipmentScreen({ data, setData, onCameraClick }: EquipmentScree
 	}) as string;
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5">
+		<div className="-mx-4 md:-mx-8">
 			<PageHeader title={headerTitle} count={counts[activeTab]}>
 				<div className="px-[18px] pb-3">
 					<nav

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -171,7 +171,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 	}
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5">
+		<div className="-mx-4 md:-mx-8">
 			<PageHeader title={t("stats.title")} count={films.length}>
 				<div className="px-[18px] pb-2.5">
 					<PeriodSwitch value={period} onChange={setPeriod} yearLabel={yearLabel} />

--- a/src/screens/stock/StockScreen.tsx
+++ b/src/screens/stock/StockScreen.tsx
@@ -58,7 +58,7 @@ export function StockScreen({ data, onOpenFilm, initialStateFilter }: StockScree
 	const searchActive = stockFilters.search.trim() !== "" || stockFilters.hasActiveFilters;
 
 	return (
-		<div className="-mx-4 md:-mx-8 -mt-5">
+		<div className="-mx-4 md:-mx-8">
 			<PageHeader
 				title={t("stock.title")}
 				count={totalCount}


### PR DESCRIPTION
## Summary

Suite du fix safe-area mobile (#135). Le pattern d'annulation `scroll-container pt-5` + `screen-root -mt-5` ne collapsait pas correctement en émulation mobile DevTools, laissant un ruban papier d'environ 20 px entre le bandeau safe-area et le titre du `PageHeader` sur les écrans racine (Dashboard / Stock / Stats / Équipement).

- `pt-5` du scroll container dans `App.tsx` rendu conditionnel : appliqué uniquement aux sous-écrans, où il donne la respiration sous l'`AppHeader`.
- Suppression du `-mt-5` sur les 4 écrans racine — devenu inutile sans `pt-5` à compenser.
- `PageHeader` sticky maintenant flush au top du scroll port (= `viewport.y = env(safe-area-inset-top)`), avec son propre `pt-2 md:pt-4` pour la respiration.
- `AppHeader` aligné sur `pt-2` (8 px de breathing compact sous la safe-area).

## Test plan

- [ ] Mobile iOS / DevTools mobile : Dashboard / Stock / Stats / Équipement — titre Caveat collé sous le bandeau safe-area, plus de ruban papier vide.
- [ ] Mobile sous-écrans (FilmDetail / Settings) : back-arrow + titre toujours collés sous le bandeau safe-area, contenu sous l'`AppHeader` garde ses 20 px de respiration.
- [ ] Desktop : titres conservent leur breathing standard (`md:pt-4` = 16 px).
- [ ] Scroll : `PageHeader` sticky reste pinned au top, shadow `0_2px_0` sous le bloc.
- [ ] Rebond / overscroll iOS : bandeau au-dessus du `PageHeader` reste papier (couvert par le root pt safe-area).

🤖 Generated with [Claude Code](https://claude.com/claude-code)