### PR TITLE
refactor(theme): finalize bespoke components in monochrome (PR 2/4)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import { test } from "@playwright/test";
 import { seedDemoData, seedEmpty } from "./fixtures/seed";
 
-const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-1");
+const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-2");
 
 function shotPath(project: string, name: string) {
 	return path.join(OUT_DIR, project, `${name}.png`);
 }
 
-test.describe("Theme screenshots — PR 1 (token swap + decorations off)", () => {
+test.describe("Theme screenshots — PR 2 (bespoke components refonte)", () => {
 	test("welcome (empty storage)", async ({ page }, testInfo) => {
 		await seedEmpty(page);
 		await page.goto("/");
@@ -45,6 +45,19 @@ test.describe("Theme screenshots — PR 1 (token swap + decorations off)", () =>
 			await page.waitForTimeout(300);
 			await page.screenshot({
 				path: shotPath(testInfo.project.name, "stock"),
+				fullPage: true,
+			});
+		});
+
+		test("film detail (developed)", async ({ page }, testInfo) => {
+			await page.getByRole("button", { name: /pellicules|films/i }).first().click();
+			await page.waitForTimeout(300);
+			// Click the first FilmRow to open the detail screen.
+			const firstFilm = page.locator("button").filter({ hasText: /Portra|Tri-X|HP5|Delta|Superia/i }).first();
+			await firstFilm.click();
+			await page.waitForTimeout(400);
+			await page.screenshot({
+				path: shotPath(testInfo.project.name, "film-detail"),
 				fullPage: true,
 			});
 		});

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -36,19 +36,19 @@ export function AppHeader({ screen, goBack, onEditFilm, filmTitle, cameraTitle, 
 	return (
 		<div
 			className={cn(
-				"shrink-0 flex items-center justify-between gap-2 px-4 pt-2 pb-2 bg-paper border-b border-ink-faded/40",
+				"shrink-0 flex items-center justify-between gap-2 px-4 pt-2 pb-3 bg-bg/85 backdrop-blur-md",
 				className,
 			)}
 		>
 			<div className="flex items-center gap-2 min-w-0 flex-1">
 				<Button variant="ghost" size="icon" onClick={goBack} className="-ml-2" aria-label={t("aria.back")}>
-					<ArrowLeft size={20} className="text-ink-soft" />
+					<ArrowLeft size={20} className="text-text-2" />
 				</Button>
-				<h1 className="font-caveat text-2xl text-ink m-0 truncate">{subScreenTitles[screen]}</h1>
+				<h1 className="text-lg font-semibold text-text m-0 truncate tracking-tight">{subScreenTitles[screen]}</h1>
 			</div>
 			{screen === "filmDetail" && onEditFilm && (
 				<Button variant="ghost" size="icon" onClick={onEditFilm} aria-label={t("aria.editFilm")}>
-					<Pencil size={18} className="text-ink-soft" />
+					<Pencil size={18} className="text-text-2" />
 				</Button>
 			)}
 		</div>

--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { T } from "@/constants/theme";
 
 interface BarChartProps {
 	data: Record<string, number>;
@@ -9,41 +8,26 @@ interface BarChartProps {
 	formatValue?: (v: number) => string;
 }
 
-export function BarChart({ data: chartData, color = T.yellow, sort = true, limit, formatValue }: BarChartProps) {
+export function BarChart({ data: chartData, color, sort = true, limit, formatValue }: BarChartProps) {
 	const visible = useMemo(() => {
 		const entries = Object.entries(chartData);
 		const sorted = sort ? entries.sort((a, b) => b[1] - a[1]) : entries;
 		return typeof limit === "number" ? sorted.slice(0, limit) : sorted;
 	}, [chartData, sort, limit]);
-	// Scale bars against the highest value among the visible rows so the
-	// top entry still spans the full track when limit truncates the list.
 	const max = Math.max(...visible.map(([, v]) => v), 1);
+	const barColor = color ?? "var(--color-text)";
 	return (
 		<div className="flex flex-col">
-			{visible.map(([k, v], i) => (
-				<div
-					key={k}
-					className="grid items-center gap-2.5 py-1.5"
-					style={{
-						gridTemplateColumns: "80px 1fr 36px",
-						borderBottom: i < visible.length - 1 ? "1px dashed rgba(60,40,20,0.18)" : undefined,
-					}}
-				>
-					<span className="font-archivo-black text-[10px] uppercase tracking-[0.05em] text-ink leading-tight">{k}</span>
-					<div className="h-4 bg-ink relative overflow-hidden">
+			{visible.map(([k, v]) => (
+				<div key={k} className="grid items-center gap-2.5 py-2" style={{ gridTemplateColumns: "80px 1fr 36px" }}>
+					<span className="text-xs font-medium text-text-2 leading-tight truncate">{k}</span>
+					<div className="h-2 bg-fill-1 rounded-full relative overflow-hidden">
 						<div
-							className="h-full transition-[width] duration-500 ease-out"
-							style={{ width: `${(v / max) * 100}%`, background: color }}
-						>
-							<div
-								className="absolute inset-0"
-								style={{
-									backgroundImage: "repeating-linear-gradient(90deg, transparent 0 6px, rgba(0,0,0,0.2) 6px 7px)",
-								}}
-							/>
-						</div>
+							className="h-full rounded-full transition-[width] duration-500 ease-out"
+							style={{ width: `${(v / max) * 100}%`, background: barColor }}
+						/>
 					</div>
-					<span className="font-archivo-black text-[12px] text-ink text-right leading-none">
+					<span className="text-sm font-medium text-text text-right leading-none">
 						{formatValue ? formatValue(v) : v}
 					</span>
 				</div>

--- a/src/components/CarnetFilmCard.tsx
+++ b/src/components/CarnetFilmCard.tsx
@@ -1,13 +1,9 @@
 import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { FilmLabel } from "@/components/ui/film-label";
-import { KodakBadge } from "@/components/ui/kodak-badge";
-import { WashiTape } from "@/components/ui/washi-tape";
-import { filmTypeToVariant } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 import type { Camera, Film } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
-import { pickRotation, pickWashiColor, pickWashiPosition } from "@/utils/card-decorations";
 import { filmLastActionDate } from "@/utils/film-helpers";
 
 interface CarnetFilmCardProps {
@@ -18,17 +14,19 @@ interface CarnetFilmCardProps {
 	className?: string;
 }
 
-const STATE_BG: Record<string, string> = {
-	loaded: "bg-kodak-red text-paper",
-	partial: "bg-kodak-yellow-deep text-ink",
-	exposed: "bg-ink text-kodak-yellow",
-	atLab: "bg-kodak-teal text-paper",
-	developed: "bg-kodak-gold text-ink",
-	scanned: "bg-paper-dark text-ink-soft border border-ink-faded/60",
+type StateKey = "loaded" | "partial" | "exposed" | "atLab" | "developed" | "scanned";
+
+const STATE_BADGE: Record<StateKey, { className: string; dot: "accent" | "none" }> = {
+	loaded: { className: "bg-text text-bg", dot: "none" },
+	partial: { className: "bg-fill-2 text-text", dot: "none" },
+	exposed: { className: "bg-text text-bg", dot: "accent" },
+	atLab: { className: "bg-surface ring-1 ring-text-2 text-text", dot: "accent" },
+	developed: { className: "bg-fill-1 text-text", dot: "none" },
+	scanned: { className: "bg-transparent text-text-2 ring-1 ring-line", dot: "none" },
 };
 
 interface StateInfo {
-	key: keyof typeof STATE_BG;
+	key: StateKey;
 	label: string;
 }
 
@@ -57,7 +55,6 @@ function describeState(
 		};
 	}
 	if (film.state === "exposed") {
-		// Detect "au labo" via last sent_dev actionCode without subsequent developed entry
 		const sentDev = [...(film.history || [])].reverse().find((h) => h.actionCode === "sent_dev");
 		const labName = film.lab || (sentDev?.params?.lab as string | undefined);
 		if (labName || sentDev) {
@@ -89,12 +86,8 @@ function describeState(
 	};
 }
 
-export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: CarnetFilmCardProps) {
+export function CarnetFilmCard({ film, camera, onClick, className }: CarnetFilmCardProps) {
 	const { t, i18n } = useTranslation();
-	const variant = filmTypeToVariant(film.type);
-	const rotation = pickRotation(index);
-	const washiPos = pickWashiPosition(index);
-	const washiColor = pickWashiColor(index);
 	const { state, description } = describeState(film, camera, t);
 
 	const total = film.posesTotal ?? 36;
@@ -113,86 +106,59 @@ export function CarnetFilmCard({ film, camera, onClick, index = 0, className }: 
 			})
 		: null;
 
+	const badge = STATE_BADGE[state.key];
+
 	return (
 		<button
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"relative grid bg-paper-card overflow-hidden cursor-pointer transition-transform text-left w-full",
-				"shadow-[0_1px_0_rgba(60,40,20,0.05),0_8px_16px_-8px_rgba(50,35,15,0.18),0_2px_4px_-2px_rgba(50,35,15,0.18)]",
-				"min-h-[128px]",
-				"grid-cols-[88px_1fr]",
-				"active:scale-[.98]",
-				rotation,
+				"relative grid bg-surface rounded-[14px] overflow-hidden cursor-pointer text-left w-full",
+				"min-h-[128px] grid-cols-[88px_1fr] transition-colors hover:bg-surface-2",
 				className,
 			)}
 		>
-			<WashiTape
-				color={washiColor}
-				rotate={washiPos.rotate}
-				width={64}
-				className={cn("-top-[7px]", washiPos.left)}
-				style={washiPos.left.includes("right") ? { right: 30, left: "auto" } : undefined}
-			/>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} variant={variant} typeLabel={sub} />
+			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} typeLabel={sub} />
 
 			<div className="px-4 py-3.5 flex flex-col justify-between min-w-0">
 				<div className="flex items-start justify-between gap-2.5">
-					<div className="font-cormorant text-[20px] font-semibold leading-[1.05] text-ink tracking-[-0.2px] min-w-0">
-						{displayName}
-						{sub && (
-							<em className="block italic font-normal text-[13px] text-ink-faded mt-0.5">
-								{sub} · {t("dashboard.typeSuffix")}
-							</em>
-						)}
+					<div className="text-base font-semibold leading-tight text-text min-w-0">
+						<div className="truncate">{displayName}</div>
+						{sub && <div className="text-xs font-normal text-text-3 mt-0.5">{sub}</div>}
 					</div>
 					{labRef && (
-						<div className="font-typewriter text-[9px] tracking-[0.12em] text-ink-faded text-right leading-tight flex-shrink-0">
-							REF
-							<KodakBadge size="xs" className="block mt-0.5">
-								{labRef}
-							</KodakBadge>
+						<div className="text-[10px] text-text-3 text-right leading-tight flex-shrink-0">
+							<div className="uppercase tracking-wider">REF</div>
+							<div className="font-medium text-text-2">{labRef}</div>
 						</div>
 					)}
 				</div>
 
 				{(description || lastActionLabel) && (
 					<div className="mt-2">
-						{description && <div className="font-caveat text-[17px] leading-[1.3] text-ink-soft">{description}</div>}
-						{lastActionLabel && (
-							<div className="font-typewriter text-[9px] tracking-[0.12em] uppercase text-ink-faded mt-1">
-								{lastActionLabel}
-							</div>
-						)}
+						{description && <div className="text-sm leading-snug text-text-2">{description}</div>}
+						{lastActionLabel && <div className="text-[11px] text-text-3 mt-1">{lastActionLabel}</div>}
 					</div>
 				)}
 
-				<div className="flex items-center gap-2.5 mt-2.5 pt-2.5 border-t border-dashed border-ink-faded/35">
+				<div className="flex items-center gap-2.5 mt-2.5">
 					<span
 						className={cn(
-							"inline-flex items-center font-archivo font-extrabold text-[9px] uppercase tracking-[0.15em] px-2 py-1 leading-none flex-shrink-0",
-							STATE_BG[state.key],
+							"inline-flex items-center gap-1 text-[11px] font-medium px-2 py-1 leading-none rounded-full flex-shrink-0",
+							badge.className,
 						)}
 					>
-						● {state.label}
+						{badge.dot === "accent" && <span className="w-1.5 h-1.5 rounded-full bg-accent" />}
+						{state.label}
 					</span>
-					<div className="flex-1 h-2 bg-ink relative overflow-hidden">
+					<div className="flex-1 h-1.5 bg-fill-1 rounded-full relative overflow-hidden">
 						{shot > 0 && (
-							<div className="absolute left-0 top-0 bottom-0 bg-kodak-yellow" style={{ width: `${pct}%` }}>
-								<div
-									className="absolute inset-0"
-									style={{
-										backgroundImage: "repeating-linear-gradient(90deg, transparent 0 8px, rgba(0,0,0,0.18) 8px 9px)",
-									}}
-								/>
-							</div>
+							<div className="absolute left-0 top-0 bottom-0 bg-text rounded-full" style={{ width: `${pct}%` }} />
 						)}
 					</div>
-					<span className="font-archivo-black text-[13px] text-ink tracking-[-0.3px] flex-shrink-0">
+					<span className="text-sm font-medium text-text flex-shrink-0">
 						{shot > 0 ? shot : total}
-						<span className="font-archivo font-normal text-[11px] text-ink-faded">
-							{shot > 0 ? `/${total}` : ` ${t("dashboard.posesUnit")}`}
-						</span>
+						<span className="text-text-3 font-normal">{shot > 0 ? `/${total}` : ` ${t("dashboard.posesUnit")}`}</span>
 					</span>
 				</div>
 			</div>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -11,13 +11,11 @@ interface EmptyStateProps {
 export function EmptyState({ icon: Icon, title, subtitle, action }: EmptyStateProps) {
 	return (
 		<div className="flex flex-col items-center py-12 px-6 gap-3">
-			<div className="w-14 h-14 bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] -rotate-2 flex items-center justify-center">
-				<Icon size={22} className="text-ink-soft" />
+			<div className="w-16 h-16 bg-surface-2 rounded-full flex items-center justify-center">
+				<Icon size={24} className="text-text-3" />
 			</div>
-			<span className="font-caveat text-[22px] text-ink leading-tight">{title}</span>
-			{subtitle && (
-				<span className="font-cormorant text-[14px] text-ink-faded text-center italic max-w-[280px]">{subtitle}</span>
-			)}
+			<span className="text-lg font-semibold text-text leading-tight mt-1">{title}</span>
+			{subtitle && <span className="text-sm text-text-3 text-center max-w-[280px] leading-snug">{subtitle}</span>}
 			{action}
 		</div>
 	);

--- a/src/components/FilmRow.tsx
+++ b/src/components/FilmRow.tsx
@@ -1,12 +1,10 @@
 import { useTranslation } from "react-i18next";
 import { FilmLabel } from "@/components/ui/film-label";
-import { filmTypeToVariant } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 import type { Back, Camera, Film } from "@/types";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
-import { pickRotation } from "@/utils/card-decorations";
 import { fmtExpDate, getExpirationStatus } from "@/utils/expiration";
-import { filmName, filmType } from "@/utils/film-helpers";
+import { filmName } from "@/utils/film-helpers";
 import { fmtPrice } from "@/utils/helpers";
 
 interface FilmRowProps {
@@ -18,24 +16,22 @@ interface FilmRowProps {
 	index?: number;
 }
 
-const STATE_TONE: Record<Film["state"], { bg: string; fg: string }> = {
-	stock: { bg: "bg-transparent border-ink-faded", fg: "text-ink-faded" },
-	loaded: { bg: "bg-kodak-red border-ink", fg: "text-paper" },
-	partial: { bg: "bg-kodak-yellow-deep border-ink", fg: "text-ink" },
-	exposed: { bg: "bg-ink border-ink", fg: "text-kodak-yellow" },
-	developed: { bg: "bg-kodak-gold border-ink", fg: "text-ink" },
-	scanned: { bg: "bg-kodak-teal border-ink", fg: "text-paper" },
+const STATE_TONE: Record<Film["state"], { className: string; dot: "accent" | "none" }> = {
+	stock: { className: "bg-transparent text-text-3 ring-1 ring-line", dot: "none" },
+	loaded: { className: "bg-text text-bg", dot: "none" },
+	partial: { className: "bg-fill-2 text-text", dot: "none" },
+	exposed: { className: "bg-text text-bg", dot: "accent" },
+	developed: { className: "bg-fill-1 text-text", dot: "none" },
+	scanned: { className: "bg-transparent text-text-2 ring-1 ring-line", dot: "none" },
 };
 
-export function FilmRow({ film, onClick, cameras, backs, groupCount, index = 0 }: FilmRowProps) {
+export function FilmRow({ film, onClick, cameras, backs, groupCount }: FilmRowProps) {
 	const { t } = useTranslation();
-	const variant = filmTypeToVariant(filmType(film));
 	const cam = film.cameraId ? cameras.find((c) => c.id === film.cameraId) : null;
 	const back = film.backId ? backs.find((b) => b.id === film.backId) : null;
 	const expInfo = getExpirationStatus(film.expDate, t);
 	const isExpiring = expInfo && (expInfo.status === "expiring" || expInfo.status === "expired");
 	const stateLabel = t(`states.${film.state}`);
-	const rotation = pickRotation(index, "subtle");
 	const tone = STATE_TONE[film.state];
 
 	const sub = film.type ? film.type.toLowerCase() : "";
@@ -52,28 +48,25 @@ export function FilmRow({ film, onClick, cameras, backs, groupCount, index = 0 }
 			type="button"
 			onClick={onClick}
 			className={cn(
-				"relative grid bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)]",
+				"relative grid bg-surface rounded-[12px]",
 				"grid-cols-[64px_1fr_auto] items-stretch overflow-hidden text-left w-full cursor-pointer",
-				"transition-transform active:scale-[.99]",
-				rotation,
+				"transition-colors hover:bg-surface-2",
 			)}
 		>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} variant={variant} size="sm" />
+			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} size="sm" />
 
 			<div className="px-3 py-2.5 min-w-0">
-				<div className="font-cormorant text-[16px] font-semibold text-ink leading-[1.1]">
+				<div className="text-[15px] font-semibold text-text leading-tight">
 					{filmName(film)}
-					{sub && <em className="font-normal italic text-[13px] text-ink-faded ml-1.5">{sub}</em>}
+					{sub && <span className="font-normal text-[12px] text-text-3 ml-1.5">{sub}</span>}
 				</div>
-				<div className="font-typewriter text-[9px] tracking-[0.1em] uppercase text-ink-faded mt-1.5 leading-tight">
-					{metaParts.join(" · ")}
-				</div>
+				<div className="text-[11px] text-text-3 mt-1 leading-snug">{metaParts.join(" · ")}</div>
 				{film.tags && film.tags.length > 0 && (
 					<div className="flex flex-wrap gap-1 mt-1.5">
 						{film.tags.map((tag) => (
 							<span
 								key={tag}
-								className="inline-flex items-center font-archivo font-extrabold text-[9px] uppercase tracking-[0.15em] px-1.5 py-px border-[1.5px] border-ink-faded text-ink-faded"
+								className="inline-flex items-center text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-surface-2 text-text-2"
 							>
 								{tag}
 							</span>
@@ -82,25 +75,25 @@ export function FilmRow({ film, onClick, cameras, backs, groupCount, index = 0 }
 				)}
 			</div>
 
-			<div className="flex flex-col items-end justify-between px-3 py-2 border-l border-dashed border-ink-faded/40 bg-white/15 min-w-[64px]">
-				<div className="font-archivo-black text-[26px] text-ink leading-[0.9] tracking-[-0.5px] text-right">
+			<div className="flex flex-col items-end justify-between px-3 py-2 min-w-[64px]">
+				<div className="text-xl font-semibold text-text leading-none tracking-tight text-right">
 					{groupCount && groupCount > 1 ? groupCount : (film.quantity ?? 1)}
-					<span className="block font-archivo font-bold text-[9px] text-ink-faded mt-0.5 tracking-[0.18em] uppercase text-right">
+					<span className="block text-[10px] text-text-3 font-normal mt-1 text-right">
 						{groupCount && groupCount > 1 ? t("stock.resultCount", { count: groupCount }) : stateLabel.toLowerCase()}
 					</span>
 				</div>
 				{isExpiring ? (
-					<span className="inline-flex items-center font-archivo font-extrabold text-[9px] uppercase tracking-[0.15em] px-1.5 py-1 border-[1.5px] border-ink bg-kodak-yellow text-ink leading-none -rotate-3 mt-2">
+					<span className="inline-flex items-center text-[10px] font-medium px-2 py-1 leading-none rounded-full mt-2 bg-accent-soft text-accent ring-1 ring-accent">
 						{expInfo.label}
 					</span>
 				) : (
 					<span
 						className={cn(
-							"inline-flex items-center font-archivo font-extrabold text-[9px] uppercase tracking-[0.15em] px-1.5 py-1 border-[1.5px] leading-none mt-2",
-							tone.bg,
-							tone.fg,
+							"inline-flex items-center gap-1 text-[10px] font-medium px-2 py-1 leading-none rounded-full mt-2",
+							tone.className,
 						)}
 					>
+						{tone.dot === "accent" && <span className="w-1.5 h-1.5 rounded-full bg-accent" />}
 						{stateLabel}
 					</span>
 				)}

--- a/src/components/FloatingActionMenu.tsx
+++ b/src/components/FloatingActionMenu.tsx
@@ -30,52 +30,14 @@ interface ActionDef {
 	id: ActionId;
 	icon: LucideIcon;
 	labelKey: string;
-	bg: string;
-	fg: string;
-	dark: boolean;
 }
 
 const ACTION_DEFS: Record<ActionId, ActionDef> = {
-	roll: {
-		id: "roll",
-		icon: FilmIcon,
-		labelKey: "fab.film",
-		bg: "bg-kodak-yellow",
-		fg: "text-ink",
-		dark: false,
-	},
-	shot: {
-		id: "shot",
-		icon: NotebookPen,
-		labelKey: "fab.quickShot",
-		bg: "bg-kodak-red",
-		fg: "text-paper",
-		dark: true,
-	},
-	camera: {
-		id: "camera",
-		icon: Camera,
-		labelKey: "fab.camera",
-		bg: "bg-kodak-teal",
-		fg: "text-paper",
-		dark: true,
-	},
-	lens: {
-		id: "lens",
-		icon: Focus,
-		labelKey: "fab.lens",
-		bg: "bg-washi-1",
-		fg: "text-ink",
-		dark: false,
-	},
-	back: {
-		id: "back",
-		icon: Package,
-		labelKey: "fab.back",
-		bg: "bg-washi-2",
-		fg: "text-ink",
-		dark: false,
-	},
+	roll: { id: "roll", icon: FilmIcon, labelKey: "fab.film" },
+	shot: { id: "shot", icon: NotebookPen, labelKey: "fab.quickShot" },
+	camera: { id: "camera", icon: Camera, labelKey: "fab.camera" },
+	lens: { id: "lens", icon: Focus, labelKey: "fab.lens" },
+	back: { id: "back", icon: Package, labelKey: "fab.back" },
 };
 
 const PRIORITY: Record<FabContext, ActionId[]> = {
@@ -134,8 +96,6 @@ export function FloatingActionMenu({
 		handlerFor(id)();
 	};
 
-	const primary = ACTION_DEFS[order[0] as ActionId];
-
 	return (
 		<>
 			{open && (
@@ -143,7 +103,7 @@ export function FloatingActionMenu({
 					type="button"
 					aria-label={t("aria.close")}
 					onClick={() => setOpen(false)}
-					className="fixed inset-0 z-30 bg-ink/55 backdrop-blur-sm animate-backdrop-fade-in cursor-default"
+					className="fixed inset-0 z-30 bg-text/35 backdrop-blur-sm animate-backdrop-fade-in cursor-default"
 				/>
 			)}
 
@@ -175,17 +135,12 @@ export function FloatingActionMenu({
 				aria-expanded={open}
 				className={cn(
 					"fixed bottom-[calc(7rem+env(safe-area-inset-bottom))] right-5 md:bottom-8 md:right-8 z-40",
-					"w-16 h-16 border-[3px] border-ink flex flex-col items-center justify-center cursor-pointer",
-					"shadow-[4px_4px_0_var(--color-ink),0_8px_20px_rgba(0,0,0,0.3)] transition-transform duration-200 ease-out",
-					open ? `bg-ink text-kodak-yellow rotate-45` : cn(primary.bg, primary.dark ? "text-paper" : "text-ink"),
+					"w-14 h-14 rounded-full flex items-center justify-center cursor-pointer",
+					"shadow-lg transition-transform duration-200 ease-out",
+					open ? "bg-surface-2 text-text rotate-45" : "bg-accent text-bg hover:bg-accent-hover",
 				)}
 			>
-				<Plus size={open ? 30 : 26} strokeWidth={2.6} />
-				{!open && (
-					<span className="font-archivo-black text-[8px] tracking-[0.15em] mt-0.5 uppercase">
-						{t("fab.add", { defaultValue: "Ajouter" })}
-					</span>
-				)}
+				<Plus size={26} strokeWidth={2.4} />
 			</button>
 		</>
 	);
@@ -202,8 +157,8 @@ interface SpeedDialItemProps {
 
 function SpeedDialItem({ action, label, onClick, primary, delayMs, extraMargin }: SpeedDialItemProps) {
 	const Icon = action.icon;
-	const btnSize = primary ? "w-14 h-14" : "w-11 h-11";
-	const iconSize = primary ? 22 : 18;
+	const btnSize = primary ? "w-12 h-12" : "w-10 h-10";
+	const iconSize = primary ? 20 : 16;
 	return (
 		<button
 			type="button"
@@ -216,15 +171,8 @@ function SpeedDialItem({ action, label, onClick, primary, delayMs, extraMargin }
 		>
 			<span
 				className={cn(
-					"font-archivo-black uppercase tracking-[0.12em] leading-none text-right border-2 border-ink",
-					primary
-						? cn(
-								"px-3 py-2 text-[12px]",
-								action.bg,
-								action.dark ? "text-paper" : "text-ink",
-								"shadow-[3px_3px_0_var(--color-ink)]",
-							)
-						: "px-2.5 py-1.5 text-[10px] bg-paper-card text-ink shadow-[2px_2px_0_var(--color-ink)]",
+					"text-xs font-medium leading-none rounded-full px-3 py-1.5 shadow-sm",
+					primary ? "bg-text text-bg" : "bg-surface text-text",
 				)}
 			>
 				{label}
@@ -232,12 +180,8 @@ function SpeedDialItem({ action, label, onClick, primary, delayMs, extraMargin }
 			<span
 				className={cn(
 					btnSize,
-					action.bg,
-					action.dark ? "text-paper" : "text-ink",
-					"flex items-center justify-center flex-shrink-0",
-					primary
-						? "border-[3px] border-ink shadow-[4px_4px_0_var(--color-ink)]"
-						: "border-2 border-ink shadow-[3px_3px_0_var(--color-ink)]",
+					"flex items-center justify-center flex-shrink-0 rounded-full shadow-sm",
+					primary ? "bg-text text-bg" : "bg-surface text-text",
 				)}
 			>
 				<Icon size={iconSize} />

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -11,41 +11,23 @@ interface StatCardProps {
 	className?: string;
 }
 
-/**
- * Big stat tile : ink panel with a colored top stripe and shadow,
- * archivo-black big number, archivo uppercase label, caveat hint.
- */
-export function StatCard({
-	icon: Icon,
-	label,
-	value,
-	hint,
-	color = "var(--color-kodak-yellow)",
-	className,
-}: StatCardProps) {
+export function StatCard({ icon: Icon, label, value, hint, color, className }: StatCardProps) {
 	const numericValue = typeof value === "number" ? value : Number.parseInt(String(value), 10);
 	const isNumeric = !Number.isNaN(numericValue) && /^\d/.test(String(value));
 	const animated = useCountUp(isNumeric ? numericValue : 0);
 	const suffix = isNumeric && typeof value === "string" ? value.replace(/^\d+/, "") : "";
+	const valueColor = color ?? "var(--color-text)";
 
 	return (
-		<div
-			className={cn("relative bg-ink text-paper border-2 border-ink overflow-hidden px-3.5 py-3", className)}
-			style={{ boxShadow: `4px 4px 0 ${color}` }}
-		>
-			<div className="absolute top-0 left-0 right-0 h-1" style={{ background: color }} />
-			<div className="flex items-center gap-2 mb-1">
-				{Icon && <Icon size={12} color={color} className="opacity-70" />}
-				<div className="font-archivo font-extrabold text-[9px] uppercase tracking-[0.18em] text-paper/65">{label}</div>
+		<div className={cn("bg-surface rounded-[14px] px-4 py-3.5", className)}>
+			<div className="flex items-center gap-2 mb-1.5">
+				{Icon && <Icon size={14} className="text-text-3" />}
+				<div className="text-[11px] uppercase tracking-wider text-text-3 font-medium">{label}</div>
 			</div>
-			<div className="font-archivo-black text-[28px] leading-none tracking-[-0.5px] tabular-nums" style={{ color }}>
+			<div className="text-[28px] font-semibold leading-none tracking-tight tabular-nums" style={{ color: valueColor }}>
 				{isNumeric ? `${animated}${suffix}` : value}
 			</div>
-			{hint && (
-				<div className="font-caveat text-[14px] mt-1.5 leading-tight" style={{ color }}>
-					{hint}
-				</div>
-			)}
+			{hint && <div className="text-sm mt-1.5 leading-tight text-text-2">{hint}</div>}
 		</div>
 	);
 }

--- a/src/components/StockFilterDialog.tsx
+++ b/src/components/StockFilterDialog.tsx
@@ -76,8 +76,8 @@ export function StockFilterDialog({
 
 				<div className="flex flex-col gap-5">
 					<FormField label={t("stock.scope", { defaultValue: "Lot" })}>
-						<nav className="grid grid-cols-2 border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] bg-paper-card">
-							{scopeItems.map((item, i) => {
+						<nav className="grid grid-cols-2 rounded-[10px] bg-surface-2 p-1 gap-1">
+							{scopeItems.map((item) => {
 								const active = scope === item.key;
 								return (
 									<button
@@ -86,16 +86,13 @@ export function StockFilterDialog({
 										onClick={() => onScopeChange(item.key)}
 										aria-pressed={active}
 										className={cn(
-											"font-archivo-black text-[10px] uppercase tracking-[0.15em] py-2 px-2 cursor-pointer leading-none",
-											"flex items-center justify-center gap-1.5",
-											active ? "bg-kodak-yellow text-ink" : "bg-transparent text-ink-faded hover:bg-paper-dark/30",
-											i === 0 && "border-r-2 border-ink",
+											"text-xs font-medium py-2 px-2 cursor-pointer leading-none rounded-[8px]",
+											"flex items-center justify-center gap-1.5 transition-colors",
+											active ? "bg-surface text-text shadow-sm" : "bg-transparent text-text-3 hover:text-text",
 										)}
 									>
 										{item.label}
-										<span className="font-archivo font-bold text-[9px] tracking-[0.15em] opacity-70">
-											{String(item.count).padStart(2, "0")}
-										</span>
+										<span className="text-[11px] font-normal opacity-70">{String(item.count).padStart(2, "0")}</span>
 									</button>
 								);
 							})}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -32,13 +32,14 @@ export function TabBar({ screen, setScreen, variant = "bar", className }: TabBar
 	if (variant === "sidebar") {
 		return (
 			<nav
-				className={cn("w-[220px] shrink-0 bg-ink text-paper border-r-2 border-ink flex flex-col pt-8 pb-6", className)}
+				className={cn(
+					"w-[220px] shrink-0 bg-surface ring-1 ring-line flex flex-col pt-8 pb-6 rounded-r-[14px]",
+					className,
+				)}
 			>
 				<div className="px-6 mb-8">
-					<h1 className="font-caveat text-2xl text-kodak-yellow m-0">My Film Vault</h1>
-					<p className="font-typewriter text-[10px] tracking-[0.18em] uppercase text-paper/60 mt-1">
-						{t("nav.subtitle")}
-					</p>
+					<h1 className="text-2xl font-semibold text-text leading-none m-0 tracking-tight">My Film Vault</h1>
+					<p className="text-xs text-text-3 mt-1.5">{t("nav.subtitle")}</p>
 				</div>
 				<div className="flex flex-col gap-1 px-3 flex-1">
 					{tabs.map((tab) => {
@@ -49,14 +50,12 @@ export function TabBar({ screen, setScreen, variant = "bar", className }: TabBar
 								key={tab.key}
 								onClick={() => setScreen(tab.key)}
 								className={cn(
-									"w-full flex items-center gap-3 px-3 py-2.5 cursor-pointer transition-colors text-left",
-									"font-archivo font-extrabold text-[11px] uppercase tracking-[0.15em]",
-									active
-										? "bg-kodak-yellow text-ink"
-										: "bg-transparent text-paper/70 hover:bg-paper/10 hover:text-paper",
+									"w-full flex items-center gap-3 px-3 py-2.5 rounded-[10px] cursor-pointer transition-colors text-left",
+									"text-sm font-medium",
+									active ? "bg-surface-2 text-text" : "bg-transparent text-text-3 hover:bg-surface-2 hover:text-text",
 								)}
 							>
-								<tab.icon size={18} strokeWidth={active ? 2.4 : 1.6} />
+								<tab.icon size={18} strokeWidth={active ? 2.2 : 1.6} />
 								{tab.label}
 							</button>
 						);
@@ -69,9 +68,9 @@ export function TabBar({ screen, setScreen, variant = "bar", className }: TabBar
 	return (
 		<nav
 			className={cn(
-				"shrink-0 relative w-full bg-ink flex justify-around items-stretch",
-				"pt-3 pb-[max(0.625rem,env(safe-area-inset-bottom))]",
-				"border-t-2 border-kodak-yellow",
+				"shrink-0 relative w-full bg-surface flex justify-around items-stretch",
+				"pt-2 pb-[max(0.625rem,env(safe-area-inset-bottom))]",
+				"border-t border-line",
 				className,
 			)}
 		>
@@ -84,21 +83,15 @@ export function TabBar({ screen, setScreen, variant = "bar", className }: TabBar
 						onClick={() => setScreen(tab.key)}
 						aria-pressed={active}
 						className={cn(
-							"flex-1 flex flex-col items-center gap-1 px-2 py-1.5 cursor-pointer",
-							"font-archivo font-bold text-[9px] uppercase tracking-[0.18em] leading-none",
+							"flex-1 flex flex-col items-center gap-1 px-2 py-1.5 cursor-pointer relative",
+							"text-[10px] font-medium leading-none",
 							"transition-colors",
-							active ? "text-kodak-yellow" : "text-paper/55 hover:text-paper",
+							active ? "text-text" : "text-text-3 hover:text-text-2",
 						)}
 					>
-						<span
-							className={cn(
-								"w-7 h-7 flex items-center justify-center transition-colors",
-								active ? "bg-kodak-yellow text-ink" : "bg-transparent",
-							)}
-						>
-							<tab.icon size={16} strokeWidth={active ? 2.4 : 1.8} />
-						</span>
+						<tab.icon size={20} strokeWidth={active ? 2.2 : 1.7} />
 						{tab.label}
+						{active && <span className="absolute bottom-[-2px] h-0.5 w-6 rounded-full bg-accent" aria-hidden="true" />}
 					</button>
 				);
 			})}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -10,11 +10,27 @@ interface ToastItem {
 	exiting: boolean;
 }
 
-const TOAST_COLORS: Record<ToastType, string> = {
-	success: "var(--color-kodak-teal)",
-	info: "var(--color-ink)",
-	warning: "var(--color-kodak-yellow-deep)",
-	error: "var(--color-kodak-red)",
+const TOAST_STYLES: Record<ToastType, { background: string; color: string; border: string }> = {
+	success: {
+		background: "var(--color-text)",
+		color: "var(--color-bg)",
+		border: "transparent",
+	},
+	info: {
+		background: "var(--color-text)",
+		color: "var(--color-bg)",
+		border: "transparent",
+	},
+	warning: {
+		background: "var(--color-fill-2)",
+		color: "var(--color-text)",
+		border: "transparent",
+	},
+	error: {
+		background: "var(--color-accent)",
+		color: "var(--color-bg)",
+		border: "transparent",
+	},
 };
 
 interface ToastContextValue {
@@ -50,27 +66,27 @@ export function ToastProvider({ children }: { children: ReactNode }) {
 				className="fixed left-1/2 z-[300] pointer-events-none flex flex-col gap-2"
 				style={{ top: "max(0.75rem, env(safe-area-inset-top))" }}
 			>
-				{toasts.map((t) => (
-					<div
-						key={t.id}
-						className={t.exiting ? "animate-toast-exit" : "animate-toast-enter"}
-						style={{
-							background: TOAST_COLORS[t.type],
-							color: t.type === "warning" ? "var(--color-ink)" : "var(--color-paper)",
-							padding: "8px 16px",
-							fontSize: "11px",
-							fontFamily: "var(--font-archivo-black)",
-							fontWeight: 900,
-							letterSpacing: "0.12em",
-							textTransform: "uppercase",
-							whiteSpace: "nowrap",
-							border: "2px solid var(--color-ink)",
-							boxShadow: "3px 3px 0 var(--color-ink)",
-						}}
-					>
-						{t.message}
-					</div>
-				))}
+				{toasts.map((t) => {
+					const style = TOAST_STYLES[t.type];
+					return (
+						<div
+							key={t.id}
+							className={t.exiting ? "animate-toast-exit" : "animate-toast-enter"}
+							style={{
+								background: style.background,
+								color: style.color,
+								padding: "10px 16px",
+								fontSize: "13px",
+								fontWeight: 500,
+								whiteSpace: "nowrap",
+								borderRadius: "10px",
+								boxShadow: "0 4px 16px -4px rgba(0,0,0,0.18)",
+							}}
+						>
+							{t.message}
+						</div>
+					);
+				})}
 			</div>
 		</ToastContext>
 	);

--- a/src/components/equipment/EquipmentItemCard.tsx
+++ b/src/components/equipment/EquipmentItemCard.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from "react";
 import { PhotoImg } from "@/components/ui/photo-img";
-import { WashiTape } from "@/components/ui/washi-tape";
 import { cn } from "@/lib/utils";
-import { pickRotation, pickWashiColor, pickWashiPosition, type WashiColor } from "@/utils/card-decorations";
+import type { WashiColor } from "@/utils/card-decorations";
 
 export type EquipmentVignette = "default" | "silver" | "red" | "lens" | "back";
 
@@ -22,34 +21,13 @@ interface EquipmentItemCardProps {
 	className?: string;
 }
 
-type VignetteStyle = { background: string; boxShadow: string };
-
-const VIGNETTE_STYLES: Record<EquipmentVignette, VignetteStyle> = (() => {
-	const bg: Record<EquipmentVignette, string> = {
-		default: "linear-gradient(180deg, #4a3f30 0%, #2a221a 100%)",
-		silver: "linear-gradient(180deg, #c4b8a0 0%, #8a7e6a 100%)",
-		red: "linear-gradient(180deg, #8a3024 0%, #5a1810 100%)",
-		lens: "linear-gradient(180deg, #2d3a44 0%, #16202a 100%)",
-		back: "linear-gradient(180deg, #5e4e3a 0%, #312618 100%)",
-	};
-	const ring: Record<EquipmentVignette, string> = {
-		default: "#2a2520",
-		silver: "#1a1612",
-		red: "#1a1612",
-		lens: "#0a0a12",
-		back: "#1a1410",
-	};
-	const boxShadow = "inset 0 -8px 12px rgba(0,0,0,0.5), inset 0 2px 4px rgba(255,200,100,0.15)";
-	return Object.fromEntries(
-		(Object.keys(bg) as EquipmentVignette[]).map((k) => [
-			k,
-			{
-				background: `radial-gradient(circle at 50% 60%, ${ring[k]} 0 16px, var(--color-ink) 16px 18px, transparent 18px), ${bg[k]}`,
-				boxShadow,
-			},
-		]),
-	) as Record<EquipmentVignette, VignetteStyle>;
-})();
+const VIGNETTE_BG: Record<EquipmentVignette, string> = {
+	default: "linear-gradient(180deg, #4a4845 0%, #2a2825 100%)",
+	silver: "linear-gradient(180deg, #d8d6d2 0%, #9c9a96 100%)",
+	red: "linear-gradient(180deg, #4a4845 0%, #2a2825 100%)",
+	lens: "linear-gradient(180deg, #3a3a38 0%, #18181a 100%)",
+	back: "linear-gradient(180deg, #524f4a 0%, #2c2a26 100%)",
+};
 
 export function EquipmentItemCard({
 	name,
@@ -59,103 +37,61 @@ export function EquipmentItemCard({
 	loadedSummary,
 	photo,
 	vignette = "default",
-	washi,
-	washiOffset = 0,
-	index = 0,
 	actions,
 	onClick,
 	className,
 }: EquipmentItemCardProps) {
-	const rotation = pickRotation(index);
-	const washiPos = pickWashiPosition(index);
-	const washiColor = washi ?? pickWashiColor(index, washiOffset);
-
 	const innerClasses = cn(
-		"grid w-full text-left grid-cols-[110px_1fr] overflow-hidden",
-		onClick && "cursor-pointer transition-transform active:scale-[.99]",
+		"grid w-full text-left grid-cols-[110px_1fr] overflow-hidden rounded-[14px]",
+		onClick && "cursor-pointer transition-colors hover:bg-surface-2",
 	);
 
 	const inner = (
 		<>
-			{/* Vignette / photo */}
-			<div className="bg-ink relative overflow-hidden flex items-center justify-center min-h-[124px]">
+			<div className="relative overflow-hidden flex items-center justify-center min-h-[124px]">
 				{photo ? (
 					<PhotoImg src={photo} alt="" aria-hidden="true" className="absolute inset-0 w-full h-full object-cover" />
 				) : (
-					<div className="w-[70px] h-[50px] rounded-[4px] relative" style={VIGNETTE_STYLES[vignette]}>
-						<span
-							className="absolute top-1.5 left-1/2 w-6 h-1.5 bg-ink rounded-sm"
-							style={{ transform: "translateX(-50%)" }}
-						/>
-					</div>
+					<div className="absolute inset-2 rounded-[10px]" style={{ background: VIGNETTE_BG[vignette] }} />
 				)}
 				{formatLabel && (
-					<div className="absolute bottom-2 left-2 right-2 bg-kodak-yellow border border-ink text-ink font-archivo-black text-[9px] tracking-[0.15em] text-center px-1 py-0.5 uppercase">
+					<div className="absolute bottom-2 left-2 right-2 bg-text/85 text-bg text-[10px] font-medium text-center px-2 py-0.5 uppercase tracking-wider rounded-full backdrop-blur-sm">
 						{formatLabel}
 					</div>
 				)}
 			</div>
 
-			{/* Body */}
-			<div className="px-3.5 py-3 flex flex-col gap-1.5 min-w-0">
-				<div className="font-archivo-black text-[16px] tracking-[-0.3px] uppercase leading-[0.95] text-ink">
-					{name}
-					{year && (
-						<em className="block font-cormorant not-italic-fix italic text-[12px] text-ink-faded mt-1 font-normal normal-case tracking-normal">
-							{year}
-						</em>
-					)}
+			<div className="px-4 py-3 flex flex-col gap-1.5 min-w-0">
+				<div className="text-[15px] font-semibold text-text leading-tight">
+					<div className="truncate">{name}</div>
+					{year && <div className="text-xs font-normal text-text-3 mt-0.5">{year}</div>}
 				</div>
 
 				{stats.length > 0 && (
-					<div className="flex border border-ink-faded mt-1.5">
-						{stats.map((s, i) => (
-							<div
-								key={s.label}
-								className={cn("flex-1 px-1.5 py-1 text-center", i < stats.length - 1 && "border-r border-ink-faded")}
-							>
-								<div className="font-archivo-black text-[13px] text-ink leading-none">{s.value}</div>
-								<div className="font-archivo font-bold text-[8px] tracking-[0.15em] uppercase text-ink-faded mt-1">
-									{s.label}
-								</div>
+					<div className="flex gap-3 mt-1">
+						{stats.map((s) => (
+							<div key={s.label} className="flex flex-col">
+								<div className="text-sm font-semibold text-text leading-none">{s.value}</div>
+								<div className="text-[10px] tracking-wider uppercase text-text-3 mt-1">{s.label}</div>
 							</div>
 						))}
 					</div>
 				)}
 
 				{loadedSummary ? (
-					<div className="flex items-center gap-2 mt-1.5 px-2 py-1.5 bg-kodak-red border-[1.5px] border-ink text-paper">
-						<span className="font-archivo-black text-[9px] tracking-[0.15em] bg-paper text-kodak-red px-1.5 py-0.5">
-							●
-						</span>
-						<span className="font-caveat text-[15px] leading-none flex-1 truncate">{loadedSummary}</span>
+					<div className="flex items-center gap-2 mt-1.5 px-2 py-1.5 rounded-[8px] bg-accent-soft text-accent ring-1 ring-accent">
+						<span className="w-1.5 h-1.5 rounded-full bg-accent" />
+						<span className="text-xs font-medium leading-none flex-1 truncate">{loadedSummary}</span>
 					</div>
 				) : (
-					<div className="flex items-center gap-1.5 mt-1.5 font-caveat text-[14px] text-ink-faded italic">
-						<span className="w-2 h-2 bg-ink-faded inline-block" />
-						<span>—</span>
-					</div>
+					<div className="flex items-center gap-1.5 mt-1.5 text-xs text-text-3">—</div>
 				)}
 			</div>
 		</>
 	);
 
 	return (
-		<article
-			className={cn(
-				"relative bg-paper-card border-2 border-ink shadow-[4px_4px_0_var(--color-ink)]",
-				rotation,
-				className,
-			)}
-		>
-			<WashiTape
-				color={washiColor}
-				rotate={washiPos.rotate}
-				width={54}
-				className={cn("-top-[7px]", washiPos.left)}
-				style={washiPos.left.includes("right") ? { right: 30, left: "auto" } : undefined}
-			/>
-
+		<article className={cn("relative bg-surface rounded-[14px] overflow-hidden", className)}>
 			{onClick ? (
 				<button type="button" onClick={onClick} className={innerClasses}>
 					{inner}
@@ -164,7 +100,6 @@ export function EquipmentItemCard({
 				<div className={innerClasses}>{inner}</div>
 			)}
 
-			{/* Actions floated top-right so they live outside the main button. */}
 			{actions && (
 				// biome-ignore lint/a11y/useKeyWithClickEvents: wrapper only stops propagation; inner buttons handle keyboard.
 				<div className="absolute top-2 right-2 flex gap-1.5 z-10" onClick={(e) => e.stopPropagation()}>

--- a/src/components/map/MapFilterBar.tsx
+++ b/src/components/map/MapFilterBar.tsx
@@ -112,7 +112,7 @@ export function MapFilterBar({
 						onFilterFilm(null);
 						onClearFilter();
 					}}
-					className="self-start flex items-center gap-1 font-archivo font-extrabold text-[10px] uppercase tracking-[0.12em] text-kodak-red bg-paper-card border-2 border-ink shadow-[2px_2px_0_var(--color-ink)] px-2.5 py-1.5 mt-1"
+					className="self-start flex items-center gap-1 text-xs font-medium text-accent bg-accent-soft rounded-full ring-1 ring-accent px-3 py-1.5 mt-1"
 				>
 					<X size={12} />
 					{t("map.allFilms")}

--- a/src/components/stats/FormatStack.tsx
+++ b/src/components/stats/FormatStack.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { T } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
 interface FormatStackProps {
@@ -7,8 +6,17 @@ interface FormatStackProps {
 	className?: string;
 }
 
-const SEGMENT_COLORS = [T.yellow, T.red, T.w2, T.ink, T.gold, T.teal] as const;
-const SEGMENT_FG = ["text-ink", "text-paper", "text-ink", "text-paper", "text-ink", "text-paper"] as const;
+// Ramp neutre dérivée de la palette monochrome — du plus foncé au plus clair.
+const SEGMENT_COLORS = [
+	"var(--color-text)",
+	"var(--color-text-2)",
+	"var(--color-text-3)",
+	"var(--color-fill-2)",
+	"var(--color-fill-1)",
+	"var(--color-line)",
+] as const;
+
+const SEGMENT_FG = ["text-bg", "text-bg", "text-bg", "text-text", "text-text", "text-text"] as const;
 
 interface Segment {
 	key: string;
@@ -26,8 +34,8 @@ export function FormatStack({ data, className }: FormatStackProps) {
 			key: k,
 			value: v,
 			pct: (v / total) * 100,
-			color: SEGMENT_COLORS[i % SEGMENT_COLORS.length] ?? T.yellow,
-			fg: SEGMENT_FG[i % SEGMENT_FG.length] ?? "text-ink",
+			color: SEGMENT_COLORS[i % SEGMENT_COLORS.length] ?? SEGMENT_COLORS[0],
+			fg: SEGMENT_FG[i % SEGMENT_FG.length] ?? "text-text",
 		}));
 	}, [data]);
 
@@ -35,31 +43,23 @@ export function FormatStack({ data, className }: FormatStackProps) {
 
 	return (
 		<div className={className}>
-			{/* Stack horizontal */}
-			<div className="flex h-[50px] border-2 border-ink overflow-hidden mb-3">
-				{segments.map((s, i) => (
-					<div
-						key={s.key}
-						className={cn(
-							"flex items-center justify-center relative",
-							i < segments.length - 1 && "border-r-2 border-ink",
-						)}
-						style={{ width: `${s.pct}%`, background: s.color }}
-					>
-						{s.pct > 8 && <span className={cn("font-archivo-black text-[14px]", s.fg)}>{Math.round(s.pct)}%</span>}
-					</div>
-				))}
-			</div>
-			{/* Légende grille 2 colonnes */}
-			<div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+			<div className="flex h-10 rounded-full overflow-hidden mb-3 gap-0.5">
 				{segments.map((s) => (
 					<div
 						key={s.key}
-						className="flex items-center gap-2 font-archivo font-bold text-[10px] uppercase tracking-[0.1em] text-ink-soft"
+						className="flex items-center justify-center relative"
+						style={{ width: `${s.pct}%`, background: s.color }}
 					>
-						<span className="w-2.5 h-2.5 border-[1.5px] border-ink shrink-0" style={{ background: s.color }} />
+						{s.pct > 8 && <span className={cn("text-xs font-medium tabular-nums", s.fg)}>{Math.round(s.pct)}%</span>}
+					</div>
+				))}
+			</div>
+			<div className="grid grid-cols-2 gap-x-3 gap-y-1.5">
+				{segments.map((s) => (
+					<div key={s.key} className="flex items-center gap-2 text-xs text-text-2">
+						<span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ background: s.color }} />
 						<span className="truncate">{s.key}</span>
-						<span className="font-archivo-black text-[11px] text-ink ml-auto">{s.value}</span>
+						<span className="text-sm font-medium text-text ml-auto tabular-nums">{s.value}</span>
 					</div>
 				))}
 			</div>

--- a/src/components/stats/PeriodSwitch.tsx
+++ b/src/components/stats/PeriodSwitch.tsx
@@ -18,8 +18,8 @@ const ITEMS: { id: StatsPeriod; label: (year: string) => string }[] = [
 
 export function PeriodSwitch({ value, onChange, yearLabel, className }: PeriodSwitchProps) {
 	return (
-		<nav className={cn("flex border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] bg-paper-card", className)}>
-			{ITEMS.map((item, i) => {
+		<nav className={cn("flex bg-surface-2 rounded-[10px] p-1 gap-1", className)}>
+			{ITEMS.map((item) => {
 				const active = value === item.id;
 				return (
 					<button
@@ -28,10 +28,9 @@ export function PeriodSwitch({ value, onChange, yearLabel, className }: PeriodSw
 						onClick={() => onChange(item.id)}
 						aria-pressed={active}
 						className={cn(
-							"flex-1 px-2 py-2 cursor-pointer leading-none",
-							"font-archivo-black text-[10px] uppercase tracking-[0.15em]",
-							active ? "bg-kodak-yellow text-ink" : "bg-transparent text-ink-faded hover:bg-paper-dark/30",
-							i < ITEMS.length - 1 && "border-r-2 border-ink",
+							"flex-1 px-2 py-1.5 cursor-pointer leading-none rounded-[8px] transition-colors",
+							"text-xs font-medium",
+							active ? "bg-surface text-text shadow-sm" : "bg-transparent text-text-3 hover:text-text",
 						)}
 					>
 						{item.label(yearLabel)}

--- a/src/components/ui/film-label.tsx
+++ b/src/components/ui/film-label.tsx
@@ -1,3 +1,4 @@
+import { monogram, tileColor } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
 export type FilmLabelVariant = "color" | "bw" | "slide" | "tungsten";
@@ -5,78 +6,39 @@ export type FilmLabelVariant = "color" | "bw" | "slide" | "tungsten";
 interface FilmLabelProps {
 	iso: number | string;
 	format: string;
+	brand?: string;
 	variant?: FilmLabelVariant;
 	size?: "sm" | "md";
 	typeLabel?: string;
 	className?: string;
 }
 
-const VARIANT_BG: Record<FilmLabelVariant, string> = {
-	color: "bg-kodak-yellow",
-	bw: "bg-paper-dark",
-	slide: "bg-kodak-teal",
-	tungsten: "bg-kodak-red",
-};
-
-const VARIANT_FG: Record<FilmLabelVariant, string> = {
-	color: "text-ink",
-	bw: "text-ink",
-	slide: "text-paper",
-	tungsten: "text-paper",
-};
-
-const VARIANT_STRIPE: Record<FilmLabelVariant, string> = {
-	color: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_6px,var(--color-kodak-yellow)_6px_9px)]",
-	bw: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_6px,var(--color-paper-dark)_6px_9px)]",
-	slide: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_6px,var(--color-kodak-teal)_6px_9px)]",
-	tungsten: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_6px,var(--color-kodak-red)_6px_9px)]",
-};
-
 /**
- * Étiquette de pellicule façon packaging Kodak.
- * Couleur de fond selon `variant`, rayures noires top/bot (perforations
- * stylisées), ISO en gros chiffre Archivo Black, format en bandeau séparé.
+ * Vignette monogramme dérivée de la marque. Le carré est teinté d'un gris
+ * neutre déterministe via `tileColor(brand)`. ISO et format sont affichés
+ * en métadonnée discrète sous le monogramme. `variant` est conservé pour
+ * compat ascendante mais n'a plus d'effet visuel.
  */
-export function FilmLabel({ iso, format, variant = "color", size = "md", typeLabel, className }: FilmLabelProps) {
+export function FilmLabel({ iso, format, brand, size = "md", className }: FilmLabelProps) {
 	const isSm = size === "sm";
+	const bg = tileColor(brand);
+	const initials = monogram(brand);
 
 	return (
 		<div
 			className={cn(
-				"relative flex flex-col items-center justify-center text-center overflow-hidden",
-				"border-r-2 border-ink",
-				isSm ? "py-2 px-1" : "pt-3.5 pb-3 px-1.5 border-r-[3px]",
-				VARIANT_BG[variant],
-				VARIANT_FG[variant],
+				"relative flex flex-col items-center justify-center text-center text-white",
+				isSm ? "py-2 px-1 gap-0.5" : "py-3 px-1.5 gap-1",
 				className,
 			)}
+			style={{ backgroundColor: bg }}
 		>
-			{/* Bandes rayées top/bot */}
-			<div className={cn("absolute left-0 right-0 top-0 h-2", VARIANT_STRIPE[variant])} />
-			<div className={cn("absolute left-0 right-0 bottom-0 h-2", VARIANT_STRIPE[variant])} />
-
-			{/* ISO */}
-			<div className={cn("font-archivo-black leading-[0.9] tracking-tight", isSm ? "text-[22px]" : "text-[32px] mt-1")}>
-				{iso}
+			<div className={cn("font-semibold leading-none tracking-tight", isSm ? "text-[20px]" : "text-[26px]")}>
+				{initials}
 			</div>
-
-			{/* ISO suffix */}
-			{!isSm && <div className="font-archivo text-[10px] font-extrabold tracking-[0.15em] mt-0.5">ISO</div>}
-
-			{/* Format separator + label */}
-			<div
-				className={cn(
-					"font-archivo font-extrabold tracking-[0.15em] uppercase border-t-[1.5px] border-current",
-					isSm ? "text-[9px] mt-1.5 pt-[3px]" : "text-[11px] mt-2 pt-1.5",
-				)}
-			>
-				{format}
+			<div className={cn("font-medium leading-none text-white/75", isSm ? "text-[10px]" : "text-[11px]")}>
+				{iso} · {format}
 			</div>
-
-			{/* Type label (only md) */}
-			{!isSm && typeLabel && (
-				<div className="font-typewriter text-[8px] tracking-[0.18em] mt-1 opacity-75">{typeLabel}</div>
-			)}
 		</div>
 	);
 }

--- a/src/components/ui/film-packaging-header.tsx
+++ b/src/components/ui/film-packaging-header.tsx
@@ -1,6 +1,6 @@
-import { useTranslation } from "react-i18next";
+import { Badge } from "@/components/ui/badge";
 import type { FilmLabelVariant } from "@/components/ui/film-label";
-import { KodakBadge } from "@/components/ui/kodak-badge";
+import { monogram, tileColor } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
 interface FilmPackagingHeaderProps {
@@ -9,39 +9,17 @@ interface FilmPackagingHeaderProps {
 	iso: number | string;
 	format: string;
 	type?: string;
-	variant: FilmLabelVariant;
+	variant?: FilmLabelVariant;
 	refCode?: string;
 	exposures?: number | string;
 	className?: string;
 	rotate?: number;
 }
 
-const VARIANT_BG: Record<FilmLabelVariant, string> = {
-	color: "bg-kodak-yellow",
-	bw: "bg-paper-dark",
-	slide: "bg-kodak-teal",
-	tungsten: "bg-kodak-red",
-};
-
-const VARIANT_FG: Record<FilmLabelVariant, string> = {
-	color: "text-ink",
-	bw: "text-ink",
-	slide: "text-paper",
-	tungsten: "text-paper",
-};
-
-const VARIANT_STRIPE: Record<FilmLabelVariant, string> = {
-	color: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_8px,var(--color-kodak-yellow)_8px_11px)]",
-	bw: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_8px,var(--color-paper-dark)_8px_11px)]",
-	slide: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_8px,var(--color-kodak-teal)_8px_11px)]",
-	tungsten: "bg-[repeating-linear-gradient(90deg,var(--color-ink)_0_8px,var(--color-kodak-red)_8px_11px)]",
-};
-
 /**
- * Bandeau d'en-tête façon packaging Kodak (utilisé dans le détail d'une
- * pellicule et la modal d'ajout). Bandes noires top/bot, code marque
- * abrégé en KodakBadge, modèle en gros chiffres archivo-black, ISO
- * proéminent sur la droite.
+ * En-tête de pellicule épuré : tile monogramme déterministe (gris dérivé
+ * de la marque) + métadonnées en typo claire. Le packaging Kodak Gold a
+ * été retiré au profit d'une mise en page minimaliste.
  */
 export function FilmPackagingHeader({
 	brand,
@@ -49,79 +27,39 @@ export function FilmPackagingHeader({
 	iso,
 	format,
 	type,
-	variant,
 	refCode,
 	exposures,
 	className,
-	rotate = -0.5,
 }: FilmPackagingHeaderProps) {
-	const { t } = useTranslation();
-	const negativeLabel = t("filmPackaging.subline");
-	const brandCode = brand.slice(0, 2).toUpperCase();
-	const subline = type ? type.toLowerCase() : negativeLabel;
-	const modelLine = model.split(" ")[0]?.toUpperCase() || model.toUpperCase();
+	const initials = monogram(brand);
+	const bg = tileColor(brand);
 
 	return (
-		<section
-			className={cn(
-				"relative overflow-hidden border-[3px] border-ink shadow-[5px_5px_0_var(--color-ink)]",
-				VARIANT_BG[variant],
-				VARIANT_FG[variant],
-				className,
-			)}
-			style={{ transform: `rotate(${rotate}deg)` }}
-		>
-			{/* Bandes top/bot */}
-			<div className={cn("absolute left-0 right-0 top-0 h-2.5", VARIANT_STRIPE[variant])} />
-			<div className={cn("absolute left-0 right-0 bottom-0 h-2.5", VARIANT_STRIPE[variant])} />
+		<section className={cn("flex items-stretch gap-4 bg-surface rounded-[14px] p-4", className)}>
+			<div
+				className="flex flex-col items-center justify-center text-white shrink-0 rounded-[10px] w-[88px] h-[88px]"
+				style={{ backgroundColor: bg }}
+			>
+				<div className="text-3xl font-semibold leading-none tracking-tight">{initials}</div>
+				<div className="text-[10px] font-medium text-white/75 leading-none mt-1.5">{format}</div>
+			</div>
 
-			<div className="px-4 pt-5 pb-1 flex items-start justify-between">
-				<div className="font-archivo-black text-[11px] tracking-[0.22em] uppercase">
-					<KodakBadge size="sm" className="mr-1.5">
-						{brandCode}
-					</KodakBadge>
-					{brand}
-				</div>
-				{refCode && (
-					<div className="font-typewriter text-[9px] tracking-[0.12em] text-right leading-tight">
-						REF
-						<KodakBadge size="sm" className="block mt-0.5">
-							{refCode}
-						</KodakBadge>
+			<div className="flex-1 min-w-0 flex flex-col justify-between gap-2">
+				<div className="flex items-start justify-between gap-3 min-w-0">
+					<div className="min-w-0">
+						<div className="text-xs uppercase tracking-wider text-text-3 leading-none">{brand}</div>
+						<div className="text-xl font-semibold text-text leading-tight mt-1 truncate">{model}</div>
+						{type && <div className="text-sm text-text-2 mt-0.5">{type.toLowerCase()}</div>}
 					</div>
-				)}
-			</div>
+					<div className="text-right leading-none shrink-0">
+						<div className="text-3xl font-semibold text-text tracking-tight">{iso}</div>
+						<div className="text-[10px] text-text-3 mt-1 tracking-wider">ISO</div>
+					</div>
+				</div>
 
-			<div className="px-4 pt-2 pb-1 grid grid-cols-[1fr_auto] gap-3 items-end">
-				<div className="font-archivo-black text-[28px] leading-[0.92] tracking-[-1px] uppercase">
-					{modelLine}
-					<em className="block font-archivo not-italic font-bold text-[12px] tracking-[0.15em] mt-1.5 normal-case">
-						{subline} · {negativeLabel}
-					</em>
-				</div>
-				<div className="text-right leading-[0.85]">
-					<span className="font-archivo-black text-[52px] tracking-[-3px] block">{iso}</span>
-					<span className="font-archivo font-black text-[10px] tracking-[0.2em]">ISO / ASA</span>
-				</div>
-			</div>
-
-			<div className="px-4 pt-2.5 pb-4 mt-2 border-t-2 border-ink flex items-center justify-between gap-3">
-				<div className="font-archivo font-extrabold text-[10px] tracking-[0.18em] uppercase flex gap-2">
-					<KodakBadge>{format}</KodakBadge>
-					{exposures != null && <KodakBadge>{exposures} EXP</KodakBadge>}
-				</div>
-				{/* Frise jaune décorative (motif "barcode") */}
-				<div className="h-5 flex items-center bg-ink px-1.5 py-1">
-					{[1, 3, 1, 2, 1, 4, 2, 1, 3, 1].map((w, i) => (
-						<i
-							key={`bar-${
-								// biome-ignore lint/suspicious/noArrayIndexKey: static decorative pattern
-								i
-							}`}
-							className="inline-block h-full bg-kodak-yellow"
-							style={{ width: w * 1.5, marginRight: i < 9 ? 2 : 0 }}
-						/>
-					))}
+				<div className="flex items-center gap-2 flex-wrap">
+					{exposures != null && <Badge variant="default">{exposures} poses</Badge>}
+					{refCode && <Badge variant="outline">{refCode}</Badge>}
 				</div>
 			</div>
 		</section>

--- a/src/components/ui/kodak-badge.tsx
+++ b/src/components/ui/kodak-badge.tsx
@@ -5,12 +5,13 @@ interface KodakBadgeProps extends HTMLAttributes<HTMLSpanElement> {
 	size?: "xs" | "sm";
 }
 
+/** Pill neutre — l'identité Kodak Gold a été retirée du thème. */
 export function KodakBadge({ children, size = "sm", className, ...props }: KodakBadgeProps) {
 	return (
 		<span
 			className={cn(
-				"inline-flex items-center font-archivo-black bg-ink text-kodak-yellow tracking-[0.05em]",
-				size === "xs" ? "text-[9px] px-1 py-px" : "text-[11px] px-1.5 py-0.5",
+				"inline-flex items-center bg-surface-2 text-text font-medium rounded-full",
+				size === "xs" ? "text-[10px] px-1.5 py-px" : "text-xs px-2 py-0.5",
 				className,
 			)}
 			{...props}

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -88,9 +88,9 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 							type="button"
 							onClick={onOpenSettings}
 							aria-label={t("nav.settings")}
-							className="flex items-center justify-center bg-paper-card border-2 border-ink shadow-[2px_2px_0_var(--color-ink)] w-9 h-9 cursor-pointer hover:-translate-x-px hover:-translate-y-px hover:shadow-[3px_3px_0_var(--color-ink)] transition-all"
+							className="flex items-center justify-center bg-surface-2 hover:bg-line w-9 h-9 rounded-full cursor-pointer transition-colors"
 						>
-							<Settings size={15} className="text-ink-faded" />
+							<Settings size={16} className="text-text-2" />
 						</button>
 					) : undefined
 				}

--- a/src/screens/EquipmentScreen.tsx
+++ b/src/screens/EquipmentScreen.tsx
@@ -39,11 +39,8 @@ export function EquipmentScreen({ data, setData, onCameraClick }: EquipmentScree
 		<div className="-mx-4 md:-mx-8">
 			<PageHeader title={headerTitle} count={counts[activeTab]}>
 				<div className="px-[18px] pb-3">
-					<nav
-						className="grid grid-cols-3 border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] bg-paper-card"
-						data-tour="equipment-tabs"
-					>
-						{tabs.map((tab, i) => {
+					<nav className="grid grid-cols-3 bg-surface-2 rounded-[10px] p-1 gap-1" data-tour="equipment-tabs">
+						{tabs.map((tab) => {
 							const active = activeTab === tab.key;
 							return (
 								<button
@@ -52,16 +49,13 @@ export function EquipmentScreen({ data, setData, onCameraClick }: EquipmentScree
 									onClick={() => setActiveTab(tab.key)}
 									aria-pressed={active}
 									className={cn(
-										"font-archivo-black text-[10px] uppercase tracking-[0.15em] py-2 px-2 cursor-pointer leading-none",
-										"flex items-center justify-center gap-1.5",
-										active ? "bg-kodak-yellow text-ink" : "bg-transparent text-ink-faded hover:bg-paper-dark/30",
-										i < 2 && "border-r-2 border-ink",
+										"text-xs font-medium py-2 px-2 cursor-pointer leading-none rounded-[8px]",
+										"flex items-center justify-center gap-1.5 transition-colors",
+										active ? "bg-surface text-text shadow-sm" : "bg-transparent text-text-3 hover:text-text",
 									)}
 								>
 									{tab.label}
-									<span className="font-archivo font-bold text-[9px] tracking-[0.15em] opacity-70">
-										{String(tab.count).padStart(2, "0")}
-									</span>
+									<span className="text-[11px] font-normal opacity-70">{String(tab.count).padStart(2, "0")}</span>
 								</button>
 							);
 						})}

--- a/src/screens/FilmDetailScreen.tsx
+++ b/src/screens/FilmDetailScreen.tsx
@@ -11,7 +11,6 @@ import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { FilmPackagingHeader } from "@/components/ui/film-packaging-header";
-import { WashiTape } from "@/components/ui/washi-tape";
 import { filmTypeToVariant, T } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 import type { AppData, FilmState, Film as FilmType } from "@/types";
@@ -238,41 +237,32 @@ export function FilmDetailScreen({
 				exposures={film.posesTotal ?? undefined}
 			/>
 
-			{/* État banner — coloré, légère rotation */}
+			{/* État banner */}
 			<div
 				className={cn(
-					"relative border-2 border-ink shadow-[4px_4px_0_var(--color-ink)] flex items-center justify-between px-4 py-3 rotate-[0.6deg]",
+					"relative rounded-[14px] flex items-center justify-between px-4 py-3.5",
 					stateBanner.bg,
 					stateBanner.fg,
 				)}
 			>
-				<div className="font-archivo-black text-[22px] tracking-[0.05em] leading-none uppercase">
-					{stateBanner.label}
-					<small className="block font-archivo not-italic font-bold text-[10px] tracking-[0.18em] mt-1.5 opacity-85">
-						{stateBanner.sub}
-					</small>
+				<div>
+					<div className="text-base font-semibold leading-tight">{stateBanner.label}</div>
+					<div className="text-xs opacity-75 mt-1">{stateBanner.sub}</div>
 				</div>
-				<div className="text-right font-archivo-black">
-					<div className="text-[28px] leading-[0.85] tracking-[-1px]">
+				<div className="text-right">
+					<div className="text-2xl font-semibold tabular-nums leading-none tracking-tight">
 						{film.posesShot && film.posesShot > 0 ? film.posesShot : (film.posesTotal ?? "—")}
 						{film.posesShot && film.posesShot > 0 && film.posesTotal && (
-							<span className="text-[16px] opacity-55">/{film.posesTotal}</span>
+							<span className="text-sm font-normal opacity-60">/{film.posesTotal}</span>
 						)}
 					</div>
-					<div className="font-typewriter font-normal text-[8px] tracking-[0.18em] mt-1 opacity-75 uppercase">
-						poses
-					</div>
+					<div className="text-[10px] uppercase tracking-wider mt-1 opacity-70">poses</div>
 				</div>
 			</div>
 
-			{/* Lifecycle stepper — 6 étapes */}
-			<section
-				data-tour="film-lifecycle"
-				className="relative bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] px-4 pt-5 pb-4 -rotate-[0.3deg]"
-			>
-				<WashiTape color="w2" rotate={-2} width={50} className="-top-[9px] left-6" />
-				<div className="font-archivo-black text-[11px] tracking-[0.2em] uppercase mb-3.5 flex items-center gap-2">
-					<span className="w-2.5 h-2.5 bg-kodak-yellow border-[1.5px] border-ink" />
+			{/* Lifecycle stepper */}
+			<section data-tour="film-lifecycle" className="relative bg-surface rounded-[14px] px-4 pt-4 pb-4">
+				<div className="text-sm font-medium text-text-2 mb-3">
 					{t("filmDetail.lifecycleTitle", { defaultValue: "Parcours de la pellicule" })}
 				</div>
 				<FilmLifecycleStepper currentState={film.state} history={film.history} />

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -9,7 +9,6 @@ import { FormatStack } from "@/components/stats/FormatStack";
 import { PeriodSwitch, type StatsPeriod } from "@/components/stats/PeriodSwitch";
 import { Card } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
-import { WashiTape } from "@/components/ui/washi-tape";
 import { T } from "@/constants/theme";
 import type { AppData, Film as FilmType } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
@@ -208,54 +207,42 @@ export function StatsScreen({ data }: StatsScreenProps) {
 				</section>
 
 				{Object.keys(aggregates.byBrand).length > 0 && (
-					<section className="relative bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] px-4 py-4 -rotate-[0.2deg]">
-						<WashiTape color="w1" rotate={-2} width={60} className="-top-[8px] left-10" />
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">
+					<section className="relative bg-surface rounded-[14px] px-4 py-4">
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">
 							{t("stats.byBrand")}
-							<span className="font-typewriter text-[10px] tracking-[0.12em] text-ink-faded font-normal ml-2">
-								— top
-							</span>
+							<span className="text-xs text-text-3 font-normal ml-2">— top</span>
 						</h2>
 						<BarChart data={aggregates.byBrand} color={T.yellow} limit={5} />
 					</section>
 				)}
 
 				{Object.keys(aggregates.byFormat).length > 0 && (
-					<section className="relative bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] px-4 py-4 rotate-[0.2deg]">
-						<WashiTape color="w3" rotate={2} width={60} className="-top-[8px] right-10" />
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">
+					<section className="relative bg-surface rounded-[14px] px-4 py-4">
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">
 							{t("stats.byFormat")}
-							<span className="font-typewriter text-[10px] tracking-[0.12em] text-ink-faded font-normal ml-2">
-								— stack
-							</span>
+							<span className="text-xs text-text-3 font-normal ml-2">— stack</span>
 						</h2>
 						<FormatStack data={aggregates.byFormat} />
 					</section>
 				)}
 
 				{Object.keys(aggregates.byType).length > 0 && (
-					<section className="relative bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] px-4 py-4">
-						<WashiTape color="w2" rotate={-2} width={60} className="-top-[8px] left-10" />
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">
+					<section className="relative bg-surface rounded-[14px] px-4 py-4">
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">
 							{t("stats.byType")}
-							<span className="font-typewriter text-[10px] tracking-[0.12em] text-ink-faded font-normal ml-2">
-								— rolls par type
-							</span>
+							<span className="text-xs text-text-3 font-normal ml-2">— rolls par type</span>
 						</h2>
 						<BarChart data={aggregates.byType} color={T.teal} />
 					</section>
 				)}
 
 				{/* Cadence — courbe SVG */}
-				<section className="relative bg-paper-card border-2 border-ink shadow-[3px_3px_0_var(--color-ink)] px-4 py-4 -rotate-[0.2deg]">
-					<WashiTape color="w1" rotate={-2} width={60} className="-top-[8px] left-10" />
-					<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-1">
+				<section className="relative bg-surface rounded-[14px] px-4 py-4">
+					<h2 className="text-base font-semibold text-text leading-tight mb-1">
 						{t("stats.monthlyConsumption")}
-						<span className="font-typewriter text-[10px] tracking-[0.12em] text-ink-faded font-normal ml-2">
-							— rolls par mois
-						</span>
+						<span className="text-xs text-text-3 font-normal ml-2">— rolls par mois</span>
 					</h2>
-					<div className="font-archivo flex justify-between font-extrabold text-[8px] tracking-[0.18em] uppercase text-ink-faded mb-1.5 mt-2">
+					<div className="flex justify-between text-[10px] uppercase tracking-wider text-text-3 mb-1.5 mt-2">
 						<span>nb. rolls</span>
 						<span>{yearLabel} · ytd</span>
 					</div>
@@ -263,42 +250,39 @@ export function StatsScreen({ data }: StatsScreenProps) {
 				</section>
 
 				{Object.keys(aggregates.byCamera).length > 0 && (
-					<Card className="-rotate-[0.15deg]">
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">{t("stats.byCamera")}</h2>
-						<BarChart data={aggregates.byCamera} color={T.gold} limit={5} />
+					<Card>
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byCamera")}</h2>
+						<BarChart data={aggregates.byCamera} color={T.text} limit={5} />
 					</Card>
 				)}
 
 				{Object.keys(aggregates.byLens).length > 0 && (
 					<Card>
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">{t("stats.byLens")}</h2>
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byLens")}</h2>
 						<BarChart data={aggregates.byLens} color={T.teal} limit={5} />
 					</Card>
 				)}
 
 				{Object.keys(aggregates.byTag).length > 0 && (
 					<Card>
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">{t("stats.byTag")}</h2>
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byTag")}</h2>
 						<BarChart data={aggregates.byTag} color={T.red} limit={5} />
 					</Card>
 				)}
 
 				{topFilmsSorted.length > 0 && (
-					<Card className="rotate-[0.15deg]">
-						<h2 className="font-caveat text-[24px] font-bold text-ink leading-none mb-3">{t("stats.favoriteFilms")}</h2>
+					<Card>
+						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.favoriteFilms")}</h2>
 						<div className="flex flex-col gap-2">
 							{topFilmsSorted.map(([name, count], i) => (
-								<div
-									key={name}
-									className="flex items-center gap-3 py-1 border-b border-dashed border-ink-faded/30 last:border-0"
-								>
+								<div key={name} className="flex items-center gap-3 py-1.5">
 									<span
-										className={`font-archivo-black text-[16px] min-w-[28px] ${i === 0 ? "text-kodak-red" : "text-ink-faded"}`}
+										className={`text-sm font-semibold tabular-nums min-w-[24px] ${i === 0 ? "text-accent" : "text-text-3"}`}
 									>
 										#{i + 1}
 									</span>
-									<span className="font-cormorant text-[15px] text-ink flex-1">{name}</span>
-									<span className="font-archivo-black text-[14px] text-ink">{count}</span>
+									<span className="text-sm text-text flex-1 truncate">{name}</span>
+									<span className="text-sm font-semibold text-text tabular-nums">{count}</span>
 								</div>
 							))}
 						</div>
@@ -307,15 +291,12 @@ export function StatsScreen({ data }: StatsScreenProps) {
 
 				{/* Insight final — fond ink + washi jaune */}
 				{topCamera && (
-					<section className="relative bg-ink text-paper border-2 border-ink shadow-[4px_4px_0_var(--color-kodak-yellow)] px-4 py-4 rotate-[0.3deg]">
-						<WashiTape color="yellow" rotate={-2} width={60} className="-top-[8px] left-6" />
-						<div className="font-archivo font-extrabold text-[9px] uppercase tracking-[0.2em] text-kodak-yellow">
+					<section className="relative bg-text text-bg rounded-[14px] px-4 py-4">
+						<div className="text-[10px] uppercase tracking-wider text-bg/60 font-medium">
 							{t("stats.insight.favoriteCamera", { defaultValue: "★ ton boîtier favori" })}
 						</div>
-						<div className="font-archivo-black text-[20px] uppercase tracking-[-0.3px] leading-[1.1] mt-1.5">
-							{topCamera[0]}
-						</div>
-						<div className="font-caveat text-[18px] text-kodak-yellow mt-1.5 leading-[1.2]">
+						<div className="text-xl font-semibold leading-tight mt-1.5">{topCamera[0]}</div>
+						<div className="text-sm text-bg/70 mt-1.5">
 							{t("stats.insight.rollCount", { count: topCamera[1], defaultValue: "{{count}} rolls" })}
 						</div>
 					</section>
@@ -323,7 +304,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 
 				{costs.totalSpent > 0 && (
 					<>
-						<h3 className="font-caveat text-[26px] font-bold text-ink leading-none mt-2">{t("stats.expenses")}</h3>
+						<h3 className="text-lg font-semibold text-text leading-tight mt-2 tracking-tight">{t("stats.expenses")}</h3>
 						<div className="grid grid-cols-3 gap-2.5">
 							<StatCard
 								icon={Coins}
@@ -341,10 +322,8 @@ export function StatsScreen({ data }: StatsScreenProps) {
 						</div>
 						{Object.keys(costs.costByCategory).length > 1 && (
 							<Card>
-								<h2 className="font-caveat text-[22px] font-bold text-ink leading-none mb-3">
-									{t("stats.costByCategory")}
-								</h2>
-								<BarChart data={costs.costByCategory} color={T.gold} formatValue={(v) => fmtPrice(v)} />
+								<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.costByCategory")}</h2>
+								<BarChart data={costs.costByCategory} color={T.text} formatValue={(v) => fmtPrice(v)} />
 							</Card>
 						)}
 					</>


### PR DESCRIPTION
## Summary

Deuxième étape de la refonte minimaliste. Refonte des composants bespoke qui portaient l'identité Kodak Gold. Les états des films restent visuellement distinguables en monochrome via densité de fill + point rouge sur les deux états critiques.

## Changes

### Composants bespoke
- **`FilmLabel` → vignette monogramme** : 1-2 lettres dérivées de `film.brand` (`Kodak`→`KO`, `Cinestill`→`CI`) sur tile gris déterministe via `tileColor(brand)`. Plus de packaging Kodak Gold, plus de bandes rayées.
- **`FilmRow` + `CarnetFilmCard`** : nouvelle table `STATE_TONE` / `STATE_BADGE` monochrome (filled noir, gris moyen/clair, ghost, outlined). Point rouge uniquement sur `exposed` et `atLab`. Retrait des rotations + ombres dures.
- **`Toast`** : success/info → `bg-text`, warning → `bg-fill-2`, error → `bg-accent`. Border + ombre dure remplacés par `rounded-[10px]` + ombre douce.
- **`TabBar`** : retrait perforations 35mm + bordure jaune. Active state = `text-text` + indicateur 2px `bg-accent` sous l'icône.
- **`BarChart`** : barres `bg-text`, track `bg-fill-1`, retrait du diagonal stripe.
- **`film-packaging-header`** : refonte en card épurée avec tile monogramme à gauche.
- **`kodak-badge`** : pill neutre (`bg-surface-2` / `text-text`).

### Sweep secondaire
- `StatCard`, `EmptyState`, `FloatingActionMenu`, `AppHeader`, `StockFilterDialog`, `EquipmentItemCard`, `PeriodSwitch`, `MapFilterBar`, `FormatStack` : retrait borders/shadows hardcodés, fonts neutralisés, segmented controls remplacés par des nav rounded sur `bg-surface-2`.
- `StatsScreen` : sections en `bg-surface rounded-[14px]`, typo cleanée, washi tapes supprimés, charts en monochrome (`T.text`), insight final en fond noir/texte clair, ranking #1 en accent rouge.
- `FilmDetailScreen` : state banner et lifecycle stepper simplifiés.
- `DashboardScreen` : settings button en pill rond `bg-surface-2`.
- `EquipmentItemCard` : gradients de boîtiers désaturés en gris neutre.

### Screenshots
`e2e/screenshots.spec.ts` cible désormais `docs/screenshots/pr-2/` et capture en plus le FilmDetail (état exposed) pour valider le point rouge.

## Test plan

- [x] `npm run build` (tsc --noEmit + vite build)
- [x] `npm run lint` (biome)
- [ ] `npm run screenshots` localement → joindre les PNG de `docs/screenshots/pr-2/{desktop,mobile}/*.png` au descriptif
- [ ] Parcours manuel : Dashboard, Stock (liste + groupé), FilmDetail (toutes transitions), CameraDetail, Stats, Settings, toasts (success/error/warning)
- [ ] Vérifier que les 6 états du film restent distinguables (loaded vs exposed via le point rouge ; developed vs partial via la densité de fill ; stock vs scanned via la présence/absence de ring)

## Notes

- 22 fichiers, +331 / -647 (le code se densifie en s'épurant).
- Les alias legacy (`bg-paper-card`, `text-ink-faded`, `font-caveat`, etc.) restent en place et sont toujours re-aimés vers la palette monochrome — la PR 4 fera le ménage final mécanique.
- Reste à venir :
  - **PR 3** — Hex hardcodés cross-cutting + un peu de couleur réintroduite (par état ou par marque, à définir)
  - **PR 4** — Suppression mécanique des alias `font-cormorant` / `font-archivo` / etc.

https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX

---
_Generated by [Claude Code](https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX)_