### PR TITLE
refactor(theme): reintroduce semantic earth-tone palette (PR 3/4)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import { test } from "@playwright/test";
 import { seedDemoData, seedEmpty } from "./fixtures/seed";
 
-const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-2");
+const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-3");
 
 function shotPath(project: string, name: string) {
 	return path.join(OUT_DIR, project, `${name}.png`);
 }
 
-test.describe("Theme screenshots — PR 2 (bespoke components refonte)", () => {
+test.describe("Theme screenshots — PR 3 (earth tones + semantic color)", () => {
 	test("welcome (empty storage)", async ({ page }, testInfo) => {
 		await seedEmpty(page);
 		await page.goto("/");

--- a/src/components/CarnetFilmCard.tsx
+++ b/src/components/CarnetFilmCard.tsx
@@ -16,13 +16,13 @@ interface CarnetFilmCardProps {
 
 type StateKey = "loaded" | "partial" | "exposed" | "atLab" | "developed" | "scanned";
 
-const STATE_BADGE: Record<StateKey, { className: string; dot: "accent" | "none" }> = {
+const STATE_BADGE: Record<StateKey, { className: string; dot: "accent" | "terracotta" | "none" }> = {
 	loaded: { className: "bg-text text-bg", dot: "none" },
-	partial: { className: "bg-fill-2 text-text", dot: "none" },
+	partial: { className: "bg-amber-soft text-amber", dot: "none" },
 	exposed: { className: "bg-text text-bg", dot: "accent" },
-	atLab: { className: "bg-surface ring-1 ring-text-2 text-text", dot: "accent" },
-	developed: { className: "bg-fill-1 text-text", dot: "none" },
-	scanned: { className: "bg-transparent text-text-2 ring-1 ring-line", dot: "none" },
+	atLab: { className: "bg-terracotta-soft text-terracotta", dot: "terracotta" },
+	developed: { className: "bg-sage-soft text-sage", dot: "none" },
+	scanned: { className: "bg-smoke-soft text-smoke", dot: "none" },
 };
 
 interface StateInfo {
@@ -118,7 +118,7 @@ export function CarnetFilmCard({ film, camera, onClick, className }: CarnetFilmC
 				className,
 			)}
 		>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} typeLabel={sub} />
+			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} type={film.type} typeLabel={sub} />
 
 			<div className="px-4 py-3.5 flex flex-col justify-between min-w-0">
 				<div className="flex items-start justify-between gap-2.5">
@@ -149,6 +149,7 @@ export function CarnetFilmCard({ film, camera, onClick, className }: CarnetFilmC
 						)}
 					>
 						{badge.dot === "accent" && <span className="w-1.5 h-1.5 rounded-full bg-accent" />}
+						{badge.dot === "terracotta" && <span className="w-1.5 h-1.5 rounded-full bg-terracotta" />}
 						{state.label}
 					</span>
 					<div className="flex-1 h-1.5 bg-fill-1 rounded-full relative overflow-hidden">

--- a/src/components/FilmRow.tsx
+++ b/src/components/FilmRow.tsx
@@ -19,10 +19,10 @@ interface FilmRowProps {
 const STATE_TONE: Record<Film["state"], { className: string; dot: "accent" | "none" }> = {
 	stock: { className: "bg-transparent text-text-3 ring-1 ring-line", dot: "none" },
 	loaded: { className: "bg-text text-bg", dot: "none" },
-	partial: { className: "bg-fill-2 text-text", dot: "none" },
+	partial: { className: "bg-amber-soft text-amber", dot: "none" },
 	exposed: { className: "bg-text text-bg", dot: "accent" },
-	developed: { className: "bg-fill-1 text-text", dot: "none" },
-	scanned: { className: "bg-transparent text-text-2 ring-1 ring-line", dot: "none" },
+	developed: { className: "bg-sage-soft text-sage", dot: "none" },
+	scanned: { className: "bg-smoke-soft text-smoke", dot: "none" },
 };
 
 export function FilmRow({ film, onClick, cameras, backs, groupCount }: FilmRowProps) {
@@ -53,7 +53,7 @@ export function FilmRow({ film, onClick, cameras, backs, groupCount }: FilmRowPr
 				"transition-colors hover:bg-surface-2",
 			)}
 		>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} size="sm" />
+			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} type={film.type} size="sm" />
 
 			<div className="px-3 py-2.5 min-w-0">
 				<div className="text-[15px] font-semibold text-text leading-tight">

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -12,18 +12,18 @@ interface ToastItem {
 
 const TOAST_STYLES: Record<ToastType, { background: string; color: string; border: string }> = {
 	success: {
-		background: "var(--color-text)",
+		background: "var(--color-sage)",
 		color: "var(--color-bg)",
 		border: "transparent",
 	},
 	info: {
-		background: "var(--color-text)",
+		background: "var(--color-smoke)",
 		color: "var(--color-bg)",
 		border: "transparent",
 	},
 	warning: {
-		background: "var(--color-fill-2)",
-		color: "var(--color-text)",
+		background: "var(--color-amber)",
+		color: "var(--color-bg)",
 		border: "transparent",
 	},
 	error: {

--- a/src/components/equipment/EquipmentItemCard.tsx
+++ b/src/components/equipment/EquipmentItemCard.tsx
@@ -24,9 +24,9 @@ interface EquipmentItemCardProps {
 const VIGNETTE_BG: Record<EquipmentVignette, string> = {
 	default: "linear-gradient(180deg, #4a4845 0%, #2a2825 100%)",
 	silver: "linear-gradient(180deg, #d8d6d2 0%, #9c9a96 100%)",
-	red: "linear-gradient(180deg, #4a4845 0%, #2a2825 100%)",
-	lens: "linear-gradient(180deg, #3a3a38 0%, #18181a 100%)",
-	back: "linear-gradient(180deg, #524f4a 0%, #2c2a26 100%)",
+	red: "linear-gradient(180deg, #8a3a2d 0%, #4a1a14 100%)",
+	lens: "linear-gradient(180deg, #4a5a68 0%, #1c2630 100%)",
+	back: "linear-gradient(180deg, #6e5a35 0%, #2c2418 100%)",
 };
 
 export function EquipmentItemCard({

--- a/src/components/stats/FormatStack.tsx
+++ b/src/components/stats/FormatStack.tsx
@@ -6,17 +6,19 @@ interface FormatStackProps {
 	className?: string;
 }
 
-// Ramp neutre dérivée de la palette monochrome — du plus foncé au plus clair.
+// Palette qualitative earth-tone — chaque segment d'un format doit être
+// distinguable d'un coup d'œil. L'accent rouge est volontairement absent
+// pour ne pas être confondu avec un état d'erreur.
 const SEGMENT_COLORS = [
-	"var(--color-text)",
+	"var(--color-amber)",
+	"var(--color-sage)",
+	"var(--color-smoke)",
+	"var(--color-terracotta)",
 	"var(--color-text-2)",
 	"var(--color-text-3)",
-	"var(--color-fill-2)",
-	"var(--color-fill-1)",
-	"var(--color-line)",
 ] as const;
 
-const SEGMENT_FG = ["text-bg", "text-bg", "text-bg", "text-text", "text-text", "text-text"] as const;
+const SEGMENT_FG = ["text-bg", "text-bg", "text-bg", "text-bg", "text-bg", "text-bg"] as const;
 
 interface Segment {
 	key: string;

--- a/src/components/ui/film-label.tsx
+++ b/src/components/ui/film-label.tsx
@@ -1,4 +1,4 @@
-import { monogram, tileColor } from "@/constants/theme";
+import { monogram, tileColor, typeColor } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
 export type FilmLabelVariant = "color" | "bw" | "slide" | "tungsten";
@@ -7,6 +7,7 @@ interface FilmLabelProps {
 	iso: number | string;
 	format: string;
 	brand?: string;
+	type?: string;
 	variant?: FilmLabelVariant;
 	size?: "sm" | "md";
 	typeLabel?: string;
@@ -14,14 +15,14 @@ interface FilmLabelProps {
 }
 
 /**
- * Vignette monogramme dérivée de la marque. Le carré est teinté d'un gris
- * neutre déterministe via `tileColor(brand)`. ISO et format sont affichés
- * en métadonnée discrète sous le monogramme. `variant` est conservé pour
- * compat ascendante mais n'a plus d'effet visuel.
+ * Vignette monogramme dérivée de la marque. Le carré prend la teinte
+ * earth-tone du type de pellicule (`typeColor(type)`) ou retombe sur un
+ * gris déterministe via `tileColor(brand)` quand le type est inconnu.
+ * Le monogramme reste basé sur la marque pour identifier d'un coup d'œil.
  */
-export function FilmLabel({ iso, format, brand, size = "md", className }: FilmLabelProps) {
+export function FilmLabel({ iso, format, brand, type, size = "md", className }: FilmLabelProps) {
 	const isSm = size === "sm";
-	const bg = tileColor(brand);
+	const bg = type ? typeColor(type) : tileColor(brand);
 	const initials = monogram(brand);
 
 	return (

--- a/src/components/ui/film-packaging-header.tsx
+++ b/src/components/ui/film-packaging-header.tsx
@@ -1,6 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import type { FilmLabelVariant } from "@/components/ui/film-label";
-import { monogram, tileColor } from "@/constants/theme";
+import { monogram, tileColor, typeColor } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
 interface FilmPackagingHeaderProps {
@@ -17,9 +17,9 @@ interface FilmPackagingHeaderProps {
 }
 
 /**
- * En-tête de pellicule épuré : tile monogramme déterministe (gris dérivé
- * de la marque) + métadonnées en typo claire. Le packaging Kodak Gold a
- * été retiré au profit d'une mise en page minimaliste.
+ * En-tête de pellicule épuré : tile monogramme + métadonnées en typo
+ * claire. Le tile prend la teinte earth-tone du type quand il est connu,
+ * et retombe sur un gris déterministe via `tileColor(brand)` sinon.
  */
 export function FilmPackagingHeader({
 	brand,
@@ -32,7 +32,7 @@ export function FilmPackagingHeader({
 	className,
 }: FilmPackagingHeaderProps) {
 	const initials = monogram(brand);
-	const bg = tileColor(brand);
+	const bg = type ? typeColor(type) : tileColor(brand);
 
 	return (
 		<section className={cn("flex items-stretch gap-4 bg-surface rounded-[14px] p-4", className)}>

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -15,6 +15,16 @@ export const T = {
 	accentHover: "var(--color-accent-hover)",
 	accentSoft: "var(--color-accent-soft)",
 
+	// Earth tones — palette sémantique désaturée
+	sage: "var(--color-sage)",
+	sageSoft: "var(--color-sage-soft)",
+	amber: "var(--color-amber)",
+	amberSoft: "var(--color-amber-soft)",
+	smoke: "var(--color-smoke)",
+	smokeSoft: "var(--color-smoke-soft)",
+	terracotta: "var(--color-terracotta)",
+	terracottaSoft: "var(--color-terracotta-soft)",
+
 	// Ramp gris pour fills d'états
 	fill1: "var(--color-fill-1)",
 	fill2: "var(--color-fill-2)",
@@ -27,22 +37,21 @@ export const T = {
 	ink: "var(--color-text)",
 	inkSoft: "var(--color-text-2)",
 	inkFaded: "var(--color-text-3)",
-	yellow: "var(--color-fill-2)",
-	yellowDeep: "var(--color-fill-2)",
-	gold: "var(--color-fill-1)",
+	yellow: "var(--color-amber)",
+	yellowDeep: "var(--color-amber)",
+	gold: "var(--color-amber)",
 	red: "var(--color-accent)",
-	teal: "var(--color-text-2)",
+	teal: "var(--color-sage)",
 	black: "var(--color-text)",
-	w1: "var(--color-fill-2)",
-	w2: "var(--color-fill-2)",
-	w3: "var(--color-fill-2)",
-	w4: "var(--color-fill-2)",
+	w1: "var(--color-amber)",
+	w2: "var(--color-sage)",
+	w3: "var(--color-terracotta)",
+	w4: "var(--color-smoke)",
 	textSec: "var(--color-text-2)",
 	textMuted: "var(--color-text-3)",
-	orange: "var(--color-fill-2)",
-	amber: "var(--color-fill-2)",
-	green: "var(--color-text-2)",
-	blue: "var(--color-text-3)",
+	orange: "var(--color-terracotta)",
+	green: "var(--color-sage)",
+	blue: "var(--color-smoke)",
 } as const;
 
 /** Returns a CSS color-mix() expression for a CSS variable with the given opacity (0–1). */
@@ -61,6 +70,41 @@ export function tileColor(brand?: string): string {
 	return TILE_RAMP[Math.abs(h) % TILE_RAMP.length] ?? TILE_FALLBACK;
 }
 
+/** Returns the earth-tone CSS variable for a film type (used for state badges,
+ *  type chips, BrandTile background). Falls back to a neutral text-2 when the
+ *  type is unknown so the result is always a valid CSS color. */
+export function typeColor(type?: string): string {
+	switch (type) {
+		case "Couleur":
+			return "var(--color-amber)";
+		case "N&B":
+			return "var(--color-text-2)";
+		case "Diapo":
+			return "var(--color-smoke)";
+		case "ECN-2":
+			return "var(--color-terracotta)";
+		default:
+			return "var(--color-text-2)";
+	}
+}
+
+/** Soft variant of {@link typeColor} for fills/backgrounds that need to stay
+ *  on a light surface without overwhelming the rest of the UI. */
+export function typeColorSoft(type?: string): string {
+	switch (type) {
+		case "Couleur":
+			return "var(--color-amber-soft)";
+		case "N&B":
+			return "var(--color-fill-2)";
+		case "Diapo":
+			return "var(--color-smoke-soft)";
+		case "ECN-2":
+			return "var(--color-terracotta-soft)";
+		default:
+			return "var(--color-fill-2)";
+	}
+}
+
 /** 1-2 letter monogram extracted from a brand name (e.g., "Kodak" → "KO", "Cinestill" → "CI"). */
 export function monogram(brand?: string): string {
 	if (!brand) return "·";
@@ -75,13 +119,13 @@ export function monogram(brand?: string): string {
 	return cleaned.slice(0, cleaned.length === 1 ? 1 : 2).toUpperCase();
 }
 
-/** DEPRECATED — kept for backward-compat with callers that haven't migrated yet.
- *  Maps every Film type to a single muted gray; there is no longer a per-type color. */
+/** Per-type color used for badges, chips and `ActiveRollCard` accents.
+ *  Earth-tone palette aligned with {@link typeColor}. */
 export const FILM_TYPE_COLORS: Record<string, string> = {
-	Couleur: T.fill2,
-	"N&B": T.fill2,
-	Diapo: T.fill2,
-	"ECN-2": T.fill2,
+	Couleur: T.amber,
+	"N&B": T.text2,
+	Diapo: T.smoke,
+	"ECN-2": T.terracotta,
 };
 
 /** DEPRECATED — variants no longer drive distinct visuals. Kept as a typed alias

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,18 @@
 	--color-accent-hover: #a02e23;
 	--color-accent-soft: color-mix(in srgb, #c4392d 12%, transparent);
 
+	/* Earth tones — palette désaturée pour la sémantique colorée
+	   (états des films, types, charts, toasts). Pensée pour cohabiter
+	   avec le rouge accent sans le concurrencer. */
+	--color-sage: #6b8068;
+	--color-sage-soft: color-mix(in srgb, #6b8068 14%, transparent);
+	--color-amber: #b88a3a;
+	--color-amber-soft: color-mix(in srgb, #b88a3a 14%, transparent);
+	--color-smoke: #6b7c8a;
+	--color-smoke-soft: color-mix(in srgb, #6b7c8a 14%, transparent);
+	--color-terracotta: #b8674d;
+	--color-terracotta-soft: color-mix(in srgb, #b8674d 14%, transparent);
+
 	/* Ramp neutre pour fills d'états */
 	--color-fill-1: #ededea;
 	--color-fill-2: #cfcfcb;
@@ -52,14 +64,12 @@
 	--color-text-primary: var(--color-text);
 	--color-text-sec: var(--color-text-2);
 	--color-text-muted: var(--color-text-3);
-	--color-orange: var(--color-fill-2);
-	--color-orange-soft: color-mix(in srgb, var(--color-text-3) 18%, transparent);
-	--color-amber: var(--color-fill-2);
-	--color-amber-soft: color-mix(in srgb, var(--color-text-3) 14%, transparent);
-	--color-green: var(--color-text-2);
-	--color-green-soft: color-mix(in srgb, var(--color-text-2) 14%, transparent);
-	--color-blue: var(--color-text-3);
-	--color-blue-soft: color-mix(in srgb, var(--color-text-3) 18%, transparent);
+	--color-orange: var(--color-terracotta);
+	--color-orange-soft: var(--color-terracotta-soft);
+	--color-green: var(--color-sage);
+	--color-green-soft: var(--color-sage-soft);
+	--color-blue: var(--color-smoke);
+	--color-blue-soft: var(--color-smoke-soft);
 
 	/* Font alias re-aimés vers la sans-serif unique. */
 	--font-caveat: var(--font-sans);

--- a/src/screens/StatsScreen.tsx
+++ b/src/screens/StatsScreen.tsx
@@ -184,25 +184,25 @@ export function StatsScreen({ data }: StatsScreenProps) {
 						icon={Film}
 						label={t("stats.bigStats.collected", { defaultValue: "Rolls collectés" })}
 						value={filtered.length}
-						color={T.yellow}
+						color={T.amber}
 					/>
 					<StatCard
 						icon={Archive}
 						label={t("stats.bigStats.toDev", { defaultValue: "À développer" })}
 						value={aggregates.exposedCount}
-						color={T.red}
+						color={T.accent}
 					/>
 					<StatCard
 						icon={Snowflake}
 						label={t("stats.bigStats.inStock", { defaultValue: "En stock" })}
 						value={aggregates.stockCount}
-						color={T.teal}
+						color={T.smoke}
 					/>
 					<StatCard
 						icon={Sparkles}
 						label={t("stats.bigStats.brands", { defaultValue: "Marques essayées" })}
 						value={aggregates.uniqueBrandsCount}
-						color={T.gold}
+						color={T.sage}
 					/>
 				</section>
 
@@ -212,7 +212,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 							{t("stats.byBrand")}
 							<span className="text-xs text-text-3 font-normal ml-2">— top</span>
 						</h2>
-						<BarChart data={aggregates.byBrand} color={T.yellow} limit={5} />
+						<BarChart data={aggregates.byBrand} color={T.amber} limit={5} />
 					</section>
 				)}
 
@@ -232,7 +232,7 @@ export function StatsScreen({ data }: StatsScreenProps) {
 							{t("stats.byType")}
 							<span className="text-xs text-text-3 font-normal ml-2">— rolls par type</span>
 						</h2>
-						<BarChart data={aggregates.byType} color={T.teal} />
+						<BarChart data={aggregates.byType} color={T.sage} />
 					</section>
 				)}
 
@@ -252,21 +252,21 @@ export function StatsScreen({ data }: StatsScreenProps) {
 				{Object.keys(aggregates.byCamera).length > 0 && (
 					<Card>
 						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byCamera")}</h2>
-						<BarChart data={aggregates.byCamera} color={T.text} limit={5} />
+						<BarChart data={aggregates.byCamera} color={T.smoke} limit={5} />
 					</Card>
 				)}
 
 				{Object.keys(aggregates.byLens).length > 0 && (
 					<Card>
 						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byLens")}</h2>
-						<BarChart data={aggregates.byLens} color={T.teal} limit={5} />
+						<BarChart data={aggregates.byLens} color={T.terracotta} limit={5} />
 					</Card>
 				)}
 
 				{Object.keys(aggregates.byTag).length > 0 && (
 					<Card>
 						<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.byTag")}</h2>
-						<BarChart data={aggregates.byTag} color={T.red} limit={5} />
+						<BarChart data={aggregates.byTag} color={T.accent} limit={5} />
 					</Card>
 				)}
 
@@ -306,24 +306,24 @@ export function StatsScreen({ data }: StatsScreenProps) {
 					<>
 						<h3 className="text-lg font-semibold text-text leading-tight mt-2 tracking-tight">{t("stats.expenses")}</h3>
 						<div className="grid grid-cols-3 gap-2.5">
+							<StatCard icon={Coins} label={t("stats.totalSpent")} value={fmtPrice(costs.totalSpent)} color={T.amber} />
 							<StatCard
 								icon={Coins}
-								label={t("stats.totalSpent")}
-								value={fmtPrice(costs.totalSpent)}
-								color={T.yellow}
+								label={t("stats.avgPerFilm")}
+								value={fmtPrice(costs.avgPerFilm)}
+								color={T.terracotta}
 							/>
-							<StatCard icon={Coins} label={t("stats.avgPerFilm")} value={fmtPrice(costs.avgPerFilm)} color={T.red} />
 							<StatCard
 								icon={Coins}
 								label={t("stats.avgPerFrame")}
 								value={fmtPrice(costs.avgPerFrame)}
-								color={T.teal}
+								color={T.sage}
 							/>
 						</div>
 						{Object.keys(costs.costByCategory).length > 1 && (
 							<Card>
 								<h2 className="text-base font-semibold text-text leading-tight mb-3">{t("stats.costByCategory")}</h2>
-								<BarChart data={costs.costByCategory} color={T.text} formatValue={(v) => fmtPrice(v)} />
+								<BarChart data={costs.costByCategory} color={T.amber} formatValue={(v) => fmtPrice(v)} />
 							</Card>
 						)}
 					</>


### PR DESCRIPTION
## Context

Le monochrome strict de PR 1+2 manquait de hiérarchie visuelle quand on balaye le stock ou les stats — tout se ressemblait, on perdait du temps à lire les badges. PR 3 réintroduit une palette **désaturée earth tones** à côté du rouge accent, **réservée à des usages sémantiques précis**. La base reste monochrome ; la couleur signale plutôt qu'elle décore.

> ⚠️ Cette PR est branchée sur `claude/modernize-theme-design-ISkzx` (PR #139) et la cible. À merger dans l'ordre PR #139 → cette PR.

## Nouvelle palette

| Token | Hex | Usage |
|---|---|---|
| `--color-sage` | `#6b8068` | `developed`, success toast |
| `--color-amber` | `#b88a3a` | `partial`, warning toast, type Couleur |
| `--color-smoke` | `#6b7c8a` | `scanned`, info toast, type Diapo |
| `--color-terracotta` | `#b8674d` | `atLab`, type ECN-2 |
| `--color-accent` | `#c4392d` (inchangé) | `exposed` dot, error toast, expiring |

Chaque teinte a une variante `-soft` (color-mix 14%) pour les fills clairs.

## Application

### Vignette monogramme (BrandTile + FilmPackagingHeader)
La teinte vient désormais de `typeColor(film.type)` quand le type est connu (Couleur → amber, N&B → text-2, Diapo → smoke, ECN-2 → terracotta). Sinon retombe sur `tileColor(brand)` (gris déterministe). Le monogramme reste basé sur la marque pour conserver l'identité.

### Badges d'états (FilmRow + CarnetFilmCard)
| État | PR 2 (monochrome) | PR 3 (earth tones) |
|---|---|---|
| stock | ring gris | ring gris (no change) |
| loaded | bg-text + bg | bg-text + bg (no change — état primaire) |
| partial | bg-fill-2 | **bg-amber-soft + text-amber** |
| exposed | bg-text + dot rouge | bg-text + dot rouge (no change) |
| atLab | ring gris + dot rouge | **bg-terracotta-soft + dot terracotta** |
| developed | bg-fill-1 | **bg-sage-soft + text-sage** |
| scanned | ghost | **bg-smoke-soft + text-smoke** |

### Toasts
- `success` → sage
- `warning` → amber
- `info` → smoke
- `error` → accent (inchangé)

### Stats
- 4 StatCards principaux : amber / accent / smoke / sage (4 couleurs distinctes)
- BarCharts : amber / sage / smoke / terracotta / accent selon la dimension
- FormatStack : palette qualitative earth tones (5 couleurs)

### Equipment & ActiveRollCard
- Vignettes de boîtiers : presets `red`/`lens`/`back` retrouvent un caractère désaturé (pas du Kodak Gold mais une teinte).
- `FILM_TYPE_COLORS` consommé par `ActiveRollCard` repointé vers les earth tones → les rolls actifs sur le Dashboard ont à nouveau un code couleur par type.

## Aliases legacy

`T.yellow`, `T.gold`, `T.green`, `T.blue`, `T.orange`, `T.teal` sont re-aimés vers les nouveaux earth tones — les composants secondaires qui les consomment encore récupèrent la couleur sans modification.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [ ] `npm run screenshots` localement → `docs/screenshots/pr-3/{desktop,mobile}/*.png`
- [ ] Vérifier que les 6 états du film restent immédiatement distinguables
- [ ] Vérifier que les types (Couleur / N&B / Diapo / ECN-2) sont reconnaissables au premier coup d'œil dans la liste Stock
- [ ] Vérifier que la nouvelle palette ne crie pas — l'ensemble doit rester sobre, le rouge réservé aux signaux critiques

## Notes

- 11 fichiers, +136 / -78
- PR 4 (suppression mécanique des alias `font-cormorant`/`font-archivo`/etc.) reste à venir, indépendante du sujet couleur.

https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX

---
_Generated by [Claude Code](https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX)_