### PR TITLE
refactor(theme): remove font alias shims (PR 4/4)

### DIFF
--- a/e2e/screenshots.spec.ts
+++ b/e2e/screenshots.spec.ts
@@ -2,13 +2,13 @@ import path from "node:path";
 import { test } from "@playwright/test";
 import { seedDemoData, seedEmpty } from "./fixtures/seed";
 
-const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-3");
+const OUT_DIR = path.join(process.cwd(), "docs", "screenshots", "pr-4");
 
 function shotPath(project: string, name: string) {
 	return path.join(OUT_DIR, project, `${name}.png`);
 }
 
-test.describe("Theme screenshots — PR 3 (earth tones + semantic color)", () => {
+test.describe("Theme screenshots — PR 4 (font alias cleanup)", () => {
 	test("welcome (empty storage)", async ({ page }, testInfo) => {
 		await seedEmpty(page);
 		await page.goto("/");

--- a/src/components/FilmLifecycleStepper.tsx
+++ b/src/components/FilmLifecycleStepper.tsx
@@ -8,7 +8,6 @@ interface FilmLifecycleStepperProps {
 	className?: string;
 }
 
-/** 6 étapes visuelles du parcours d'une pellicule. */
 const STEPS = [
 	{ key: "stock", labelKey: "lifecycle.stock", fallback: "Stock" },
 	{ key: "loaded", labelKey: "lifecycle.loaded", fallback: "Chargée" },
@@ -44,13 +43,7 @@ export function FilmLifecycleStepper({ currentState, history, className }: FilmL
 
 	return (
 		<div className={cn("relative flex items-center justify-between px-1", className)}>
-			{/* Ligne de connexion en pointillés */}
-			<div
-				className="absolute left-4 right-4 top-3.5 h-[2px] z-0"
-				style={{
-					backgroundImage: "repeating-linear-gradient(90deg, var(--color-ink-faded) 0 4px, transparent 4px 8px)",
-				}}
-			/>
+			<div className="absolute left-4 right-4 top-3.5 h-[2px] bg-line z-0" />
 			{STEPS.map((step, i) => {
 				const done = i < currentIdx;
 				const current = i === currentIdx;
@@ -59,22 +52,18 @@ export function FilmLifecycleStepper({ currentState, history, className }: FilmL
 					<div key={step.key} className="relative z-10 flex flex-col items-center gap-1.5">
 						<div
 							className={cn(
-								"w-7 h-7 flex items-center justify-center font-archivo-black text-[11px] border-2 transition-all",
-								current && "bg-kodak-red text-paper border-ink scale-[1.15] animate-timeline-pulse",
-								done && "bg-ink text-kodak-yellow border-ink",
-								!current && !done && "bg-paper text-ink-faded border-ink-faded",
+								"w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold transition-all",
+								current && "bg-accent text-bg scale-[1.15] animate-timeline-pulse",
+								done && "bg-text text-bg",
+								!current && !done && "bg-surface-2 text-text-3",
 							)}
 						>
 							{done ? "✓" : current ? "●" : "·"}
 						</div>
 						<div
 							className={cn(
-								"font-archivo text-[9px] tracking-[0.12em] uppercase text-center leading-none whitespace-nowrap",
-								current
-									? "font-black text-kodak-red"
-									: done
-										? "font-extrabold text-ink-soft"
-										: "font-bold text-ink-faded",
+								"text-[10px] font-medium text-center leading-none whitespace-nowrap",
+								current ? "text-accent font-semibold" : done ? "text-text-2" : "text-text-3",
 							)}
 						>
 							{label}

--- a/src/components/stats/CadenceCurve.tsx
+++ b/src/components/stats/CadenceCurve.tsx
@@ -10,8 +10,8 @@ interface CadenceCurveProps {
 }
 
 /**
- * Vintage cadence curve : polyline noire avec area jaune translucide,
- * points rouges + point fort jaune (max). Grille fine en pointillés.
+ * Cadence curve : polyline noire avec aire ambrée translucide. Points
+ * fumés (smoke) + point fort ambré (max). Grille discrète, axes neutres.
  */
 export function CadenceCurve({ data, yTicks, className }: CadenceCurveProps) {
 	const entries = Object.entries(data);
@@ -51,16 +51,16 @@ export function CadenceCurve({ data, yTicks, className }: CadenceCurveProps) {
 		<div className={className}>
 			<div className="relative pl-6">
 				{/* Y axis ticks */}
-				<div className="absolute -left-1 top-0 bottom-6 w-5 flex flex-col justify-between font-archivo font-bold text-[8px] text-ink-faded text-right">
+				<div className="absolute -left-1 top-0 bottom-6 w-5 flex flex-col justify-between text-[10px] font-medium text-text-3 text-right">
 					{ticks.map((v) => (
 						<span key={v}>{v}</span>
 					))}
 				</div>
 				<div
-					className="relative h-[130px] border-l-[1.5px] border-b-[1.5px] border-ink"
+					className="relative h-[130px] border-l border-b border-line"
 					style={{
 						backgroundImage:
-							"linear-gradient(to right, rgba(60,40,20,0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(60,40,20,0.08) 1px, transparent 1px)",
+							"linear-gradient(to right, var(--color-line) 1px, transparent 1px), linear-gradient(to bottom, var(--color-line) 1px, transparent 1px)",
 						backgroundSize: "calc(100%/12) 100%, 100% 25%",
 					}}
 				>
@@ -73,12 +73,12 @@ export function CadenceCurve({ data, yTicks, className }: CadenceCurveProps) {
 						<title>Cadence</title>
 						{points.length >= 2 && (
 							<>
-								<polygon points={area} fill="rgba(232,168,24,0.35)" />
+								<polygon points={area} fill="var(--color-amber-soft)" />
 								<polyline
 									points={polyline}
 									fill="none"
-									stroke="var(--color-ink)"
-									strokeWidth="2.5"
+									stroke="var(--color-text)"
+									strokeWidth="2"
 									strokeLinejoin="round"
 									strokeLinecap="round"
 								/>
@@ -88,9 +88,9 @@ export function CadenceCurve({ data, yTicks, className }: CadenceCurveProps) {
 										key={i}
 										cx={p.x}
 										cy={p.y}
-										r={i === maxIndex ? 4.5 : 3.5}
-										fill={i === maxIndex ? "var(--color-kodak-yellow)" : "var(--color-kodak-red)"}
-										stroke="var(--color-ink)"
+										r={i === maxIndex ? 4 : 3}
+										fill={i === maxIndex ? "var(--color-amber)" : "var(--color-smoke)"}
+										stroke="var(--color-bg)"
 										strokeWidth="1.5"
 									/>
 								))}
@@ -99,7 +99,7 @@ export function CadenceCurve({ data, yTicks, className }: CadenceCurveProps) {
 					</svg>
 				</div>
 				{/* X axis labels (month initials) */}
-				<div className="flex justify-between mt-1 font-archivo font-bold text-[8px] uppercase text-ink-faded">
+				<div className="flex justify-between mt-1.5 text-[10px] font-medium text-text-3">
 					{months.map((m, i) => (
 						// biome-ignore lint/suspicious/noArrayIndexKey: positional month label
 						<span key={i}>{m}</span>

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -146,10 +146,5 @@ export function filmTypeToVariant(type: string | undefined): FilmLabelVariant {
 }
 
 export const FONT = {
-	caveat: "var(--font-sans)",
-	cormorant: "var(--font-sans)",
-	typewriter: "var(--font-sans)",
-	archivo: "var(--font-sans)",
-	archivoBlack: "var(--font-sans)",
 	sans: "var(--font-sans)",
 } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -70,16 +70,6 @@
 	--color-green-soft: var(--color-sage-soft);
 	--color-blue: var(--color-smoke);
 	--color-blue-soft: var(--color-smoke-soft);
-
-	/* Font alias re-aimés vers la sans-serif unique. */
-	--font-caveat: var(--font-sans);
-	--font-cormorant: var(--font-sans);
-	--font-typewriter: var(--font-sans);
-	--font-archivo: var(--font-sans);
-	--font-archivo-black: var(--font-sans);
-	--font-display: var(--font-sans);
-	--font-body: var(--font-sans);
-	--font-mono: var(--font-sans);
 }
 
 @layer base {

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -111,8 +111,8 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 								{year}
 								<span
 									className={cn(
-										"font-archivo-black text-[9px] px-1.5 py-px",
-										selectedYear === year ? "bg-ink/20 text-ink" : "bg-ink/10 text-ink",
+										"text-[10px] font-medium px-1.5 py-px rounded-full",
+										selectedYear === year ? "bg-text/15 text-text" : "bg-surface-2 text-text-2",
 									)}
 								>
 									{count}
@@ -127,11 +127,11 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 				{activeFilms.length > 0 && (
 					<section className="flex flex-col gap-[18px]" aria-label={t("dashboard.activeRolls")}>
 						<header className="flex items-center justify-between">
-							<h2 className="font-archivo-black text-[11px] tracking-[0.2em] uppercase flex items-center gap-2 text-ink">
-								<span className="w-2.5 h-2.5 bg-kodak-red border-[1.5px] border-ink" />
+							<h2 className="text-sm font-semibold flex items-center gap-2 text-text">
+								<span className="w-1.5 h-1.5 rounded-full bg-accent" />
 								{t("dashboard.activeRolls")}
 							</h2>
-							<span className="font-archivo-black text-[11px] text-ink-faded">{activeFilms.length}</span>
+							<span className="text-sm font-medium text-text-3">{activeFilms.length}</span>
 						</header>
 						{activeFilms.map((f, idx) => {
 							const cam = f.cameraId ? cameras.find((c) => c.id === f.cameraId) : null;

--- a/src/screens/stock/StockTab.tsx
+++ b/src/screens/stock/StockTab.tsx
@@ -78,12 +78,12 @@ export function StockTab({ films, filteredFilms, cameras, backs, onOpenFilm, sea
 		<div className="flex flex-col gap-2" data-tour="stock-list">
 			{groups.map((group) => (
 				<section key={group.brand} className="flex flex-col gap-2">
-					<header className="flex items-center justify-between border-b-2 border-ink pt-3 pb-1.5">
-						<span className="font-archivo-black text-[13px] tracking-[0.15em] uppercase text-ink">★ {group.brand}</span>
-						<em className="not-italic font-typewriter text-[10px] tracking-[0.12em] text-ink-faded">
+					<header className="flex items-center justify-between border-b border-line pt-3 pb-1.5">
+						<span className="text-sm font-semibold text-text">{group.brand}</span>
+						<span className="text-xs text-text-3">
 							{t("stock.resultCount", { count: group.totalQty })}
 							{group.totalCost > 0 && ` · ${group.totalCost.toFixed(0)} €`}
-						</em>
+						</span>
 					</header>
 					{group.identicals.map((g, i) => (
 						<FilmRow


### PR DESCRIPTION
## Context

Dernière étape de la refonte. La PR 1 avait re-aimé les alias `--font-caveat` / `--font-cormorant` / `--font-typewriter` / `--font-archivo` / `--font-archivo-black` vers `--font-sans` (system stack) pour permettre une migration progressive des callers. Maintenant que les composants bespoke (PR 2) et les écrans secondaires (PR 3) consomment tous des classes Tailwind sans-serif, on peut supprimer ces alias.

## Changes

### Sweep des 4 fichiers qui utilisaient encore `font-*`

- **`FilmLifecycleStepper`** : `font-archivo-black`/`font-archivo` → `text-xs font-semibold` + simplification de la signalétique. Les pastilles deviennent des cercles ronds (`bg-text` pour les étapes faites, `bg-accent` pour l'étape courante avec animation timeline-pulse) au lieu de carrés `border-2 border-ink`. La ligne pointillée jaune devient un trait neutre `bg-line`.
- **`CadenceCurve`** : `font-archivo` → `text-[10px] font-medium`. Le SVG passe des `var(--color-kodak-yellow/red)` aux `var(--color-amber/smoke)` earth tones de PR 3, area en `color-mix amber-soft`.
- **`DashboardScreen`** : header "active rolls" et count badge en typo claire (`text-sm font-semibold`), point rouge accent au lieu d'un carré `bg-kodak-red border-ink`.
- **`StockTab`** : header de groupe par marque allégé (`text-sm font-semibold`, séparateur `border-line`).

### Cleanup tokens

- **`src/index.css`** : suppression des 8 alias `--font-*` (caveat, cormorant, typewriter, archivo, archivo-black, display, body, mono). Seul `--font-sans` subsiste.
- **`src/constants/theme.ts`** : `FONT` map réduit à `{ sans: "var(--font-sans)" }` (les 5 alias pointaient tous vers la même valeur).

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `grep -rn "font-(caveat|cormorant|typewriter|archivo|archivo-black)" src/` → zéro résultat
- [ ] `npm run screenshots` → `docs/screenshots/pr-4/{desktop,mobile}/*.png`
- [ ] Smoke test visuel : Dashboard (active rolls header), Stock (groupes par marque), FilmDetail (lifecycle stepper), Stats (cadence curve)

## Notes

- Les **alias de couleur legacy** (`--color-paper`, `--color-ink`, `--color-kodak-*`, `--color-washi-*`, `--color-text-primary`, etc.) **restent en place** dans `index.css` — un nettoyage indépendant pourra les retirer une fois tous les écrans confirmés migrés. Le scope de PR 4 reste les fonts uniquement.
- `FilmLabelVariant` et `filmTypeToVariant` sont **toujours exportés** (consommés par `AddFilmDialog` + `FilmDetailScreen` + `FilmPackagingHeader`). Le prop `variant` est désormais no-op visuellement et pourra être supprimé en suivi quand on retravaillera ces écrans.
- 7 fichiers, +30 / -56 — la refonte se conclut en allégeant les tokens.

https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX

---
_Generated by [Claude Code](https://claude.ai/code/session_013UuoK5epsByBSgdh6iRRYX)_