### PR TITLE
feat(catalog): box images in stock list + credits, smarter enrichment workflow

### DIFF
--- a/.github/workflows/enrich-catalog.yml
+++ b/.github/workflows/enrich-catalog.yml
@@ -23,7 +23,14 @@ jobs:
 
       - run: npx tsx scripts/enrich-catalog.ts
 
-      - uses: peter-evans/create-pull-request@v6
+      # Always surface what the script found in the run page, even when
+      # nothing changed and no PR is created.
+      - name: Publish report to job summary
+        if: always()
+        run: cat enrichment-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - id: cpr
+        uses: peter-evans/create-pull-request@v6
         with:
           branch: chore/enrich-catalog
           title: "chore: refresh film catalog enrichment"
@@ -32,3 +39,7 @@ jobs:
           add-paths: |
             src/constants/film-catalog-enrichment.json
             src/constants/film-catalog-discoveries.json
+
+      - name: Note when no changes
+        if: steps.cpr.outputs.pull-request-number == ''
+        run: echo "::notice::No catalog changes vs main — no PR opened. See the job summary above for current stats."

--- a/src/components/CarnetFilmCard.tsx
+++ b/src/components/CarnetFilmCard.tsx
@@ -4,6 +4,7 @@ import { FilmLabel } from "@/components/ui/film-label";
 import { cn } from "@/lib/utils";
 import type { Camera, Film } from "@/types";
 import { cameraDisplayName } from "@/utils/camera-helpers";
+import { findCatalogEntry } from "@/utils/catalog";
 import { filmLastActionDate } from "@/utils/film-helpers";
 
 interface CarnetFilmCardProps {
@@ -118,7 +119,14 @@ export function CarnetFilmCard({ film, camera, onClick, className }: CarnetFilmC
 				className,
 			)}
 		>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} type={film.type} typeLabel={sub} />
+			<FilmLabel
+				iso={film.iso ?? "—"}
+				format={film.format ?? ""}
+				brand={film.brand}
+				type={film.type}
+				typeLabel={sub}
+				imageUrl={findCatalogEntry(film.brand, film.model, film.format)?.imageUrl}
+			/>
 
 			<div className="px-4 py-3.5 flex flex-col justify-between min-w-0">
 				<div className="flex items-start justify-between gap-2.5">

--- a/src/components/FilmRow.tsx
+++ b/src/components/FilmRow.tsx
@@ -3,6 +3,7 @@ import { FilmLabel } from "@/components/ui/film-label";
 import { cn } from "@/lib/utils";
 import type { Back, Camera, Film } from "@/types";
 import { backDisplayName, cameraDisplayName } from "@/utils/camera-helpers";
+import { findCatalogEntry } from "@/utils/catalog";
 import { fmtExpDate, getExpirationStatus } from "@/utils/expiration";
 import { filmName } from "@/utils/film-helpers";
 import { fmtPrice } from "@/utils/helpers";
@@ -53,7 +54,14 @@ export function FilmRow({ film, onClick, cameras, backs, groupCount }: FilmRowPr
 				"transition-colors hover:bg-surface-2",
 			)}
 		>
-			<FilmLabel iso={film.iso ?? "—"} format={film.format ?? ""} brand={film.brand} type={film.type} size="sm" />
+			<FilmLabel
+				iso={film.iso ?? "—"}
+				format={film.format ?? ""}
+				brand={film.brand}
+				type={film.type}
+				size="sm"
+				imageUrl={findCatalogEntry(film.brand, film.model, film.format)?.imageUrl}
+			/>
 
 			<div className="px-3 py-2.5 min-w-0">
 				<div className="text-[15px] font-semibold text-text leading-tight">

--- a/src/components/ui/film-label.tsx
+++ b/src/components/ui/film-label.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { monogram, tileColor, typeColor } from "@/constants/theme";
 import { cn } from "@/lib/utils";
 
@@ -11,6 +12,7 @@ interface FilmLabelProps {
 	variant?: FilmLabelVariant;
 	size?: "sm" | "md";
 	typeLabel?: string;
+	imageUrl?: string;
 	className?: string;
 }
 
@@ -19,11 +21,42 @@ interface FilmLabelProps {
  * earth-tone du type de pellicule (`typeColor(type)`) ou retombe sur un
  * gris déterministe via `tileColor(brand)` quand le type est inconnu.
  * Le monogramme reste basé sur la marque pour identifier d'un coup d'œil.
+ *
+ * Quand `imageUrl` est fourni et chargeable, l'image de boîte remplace le
+ * monogramme et l'ISO/format s'affiche en surimpression sur un dégradé
+ * sombre en bas pour rester lisible. Tombe sur le monogramme si l'image
+ * échoue (onError) — utile pour les URL externes (raw GitHub) qui peuvent
+ * 404 ou être bloquées.
  */
-export function FilmLabel({ iso, format, brand, type, size = "md", className }: FilmLabelProps) {
+export function FilmLabel({ iso, format, brand, type, size = "md", imageUrl, className }: FilmLabelProps) {
 	const isSm = size === "sm";
 	const bg = type ? typeColor(type) : tileColor(brand);
 	const initials = monogram(brand);
+
+	const [failedUrl, setFailedUrl] = useState<string | null>(null);
+	const showImage = Boolean(imageUrl) && imageUrl !== failedUrl;
+
+	if (showImage) {
+		return (
+			<div className={cn("relative w-full h-full overflow-hidden bg-surface-2", className)}>
+				<img
+					src={imageUrl}
+					alt={brand ?? ""}
+					onError={() => setFailedUrl(imageUrl ?? null)}
+					className="w-full h-full object-cover"
+				/>
+				<div
+					className={cn(
+						"absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent",
+						"text-white text-center font-medium leading-none",
+						isSm ? "text-[9px] pt-3 pb-1" : "text-[10px] pt-4 pb-1.5",
+					)}
+				>
+					{iso} · {format}
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -767,6 +767,9 @@ export const en = {
 		contactTitle: "Contact",
 		contactContent:
 			"For any questions about your data or to exercise your rights, you can contact the publisher via GitHub: github.com/benji07/film-vault/issues.",
+		imageCreditsTitle: "Film box image credits",
+		imageCreditsContent:
+			"Box photos shown in the catalog come from two open-source databases:\n• dekuNukem/Film-Packaging (github.com/dekuNukem/Film-Packaging) — MIT-licensed code, fair-use images\n• dxdatabase/Open-source-film-database (github.com/dxdatabase/Open-source-film-database) — fair-use images\n\nImage rights belong to the respective manufacturers (Kodak, Ilford, Fujifilm, Lomography, etc.). They are used as a visual reference for film identification. No image is redistributed or stored by FilmVault — they are loaded directly from the source repositories via raw.githubusercontent.com.",
 	},
 
 	// Tour / Guide

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -767,6 +767,9 @@ export const fr = {
 		contactTitle: "Contact",
 		contactContent:
 			"Pour toute question relative à vos données ou pour exercer vos droits, vous pouvez contacter l'éditeur via GitHub : github.com/benji07/film-vault/issues.",
+		imageCreditsTitle: "Crédits images de pellicules",
+		imageCreditsContent:
+			"Les photos de boîtes affichées dans le catalogue proviennent de deux bases de données ouvertes :\n• dekuNukem/Film-Packaging (github.com/dekuNukem/Film-Packaging) — code MIT, photos sous fair-use\n• dxdatabase/Open-source-film-database (github.com/dxdatabase/Open-source-film-database) — photos sous fair-use\n\nLes droits sur les images appartiennent aux fabricants respectifs (Kodak, Ilford, Fujifilm, Lomography, etc.). Elles sont utilisées à titre de référence visuelle pour l'identification des pellicules. Aucune image n'est redistribuée ni stockée par FilmVault — elles sont chargées directement depuis les dépôts sources via raw.githubusercontent.com.",
 	},
 
 	// Tour / Guide

--- a/src/screens/LegalScreen.tsx
+++ b/src/screens/LegalScreen.tsx
@@ -63,6 +63,13 @@ export function LegalScreen({ onBack }: LegalScreenProps) {
 				<h2 className="text-sm font-bold text-text-primary font-body">{t("legal.contactTitle")}</h2>
 				<p className="text-xs text-text-sec font-body leading-relaxed">{t("legal.contactContent")}</p>
 			</Card>
+
+			<Card className="p-4 flex flex-col gap-3">
+				<h2 className="text-sm font-bold text-text-primary font-body">{t("legal.imageCreditsTitle")}</h2>
+				<p className="text-xs text-text-sec font-body leading-relaxed whitespace-pre-line">
+					{t("legal.imageCreditsContent")}
+				</p>
+			</Card>
 		</div>
 	);
 }


### PR DESCRIPTION
Suite de la PR #142. Deux apports indépendants depuis le merge :

## 1. Images de boîtes dans la liste

Le `imageUrl` du catalogue était wiré dans `AddFilmDialog` (preview) et `FilmDetailScreen` mais **pas dans la liste** (`FilmRow` / `CarnetFilmCard`), qui utilisent `FilmLabel` au lieu de `FilmPackagingHeader`. En parcourant son inventaire on voyait toujours le monogramme coloré.

- `FilmLabel` accepte une prop optionnelle `imageUrl`. Quand elle est fournie et chargeable, l'image remplit la tuile et l'ISO/format reste lisible en surimpression sur un dégradé noir en bas. `onError` retombe sur la tuile monogramme actuelle (URLs externes peuvent 404).
- `FilmRow` et `CarnetFilmCard` font un lookup `findCatalogEntry(brand, model, format)?.imageUrl` et le passent à `FilmLabel`. Pas de match catalogue → comportement inchangé.

## 2. Crédits images dans la page légale

Nouvelle carte « Crédits images de pellicules » dans `LegalScreen` (FR + EN) qui crédite explicitement :

- `dekuNukem/Film-Packaging` (MIT pour le code, fair-use pour les images)
- `dxdatabase/Open-source-film-database` (fair-use)

Avec mention que les droits appartiennent aux fabricants (Kodak, Ilford, Fujifilm, Lomography…) et que FilmVault ne redistribue pas les images — elles sont chargées en direct depuis `raw.githubusercontent.com`.

## 3. UX du workflow d'enrichissement (fixé en passant)

Le run hebdomadaire produisait zéro feedback visible quand le diff était vide vs `main` (juste un log enfoui). Désormais :

- Le rapport markdown est **toujours** publié dans `$GITHUB_STEP_SUMMARY` — visible en haut de la page du run, peu importe si une PR est ouverte.
- Un `::notice::` explicite signale « no PR opened, see job summary » pour distinguer « pas de nouveauté » de « ça a planté ».

## Test plan

- [ ] `npm run dev` → écran Stock : les pellicules avec image dans le catalogue (Kodak Portra 400, Ilford HP5+, Velvia 50, etc.) affichent la photo de boîte au lieu du monogramme. ISO/format restent lisibles en bas.
- [ ] Pellicule sans match catalogue → tuile monogramme inchangée.
- [ ] DevTools → bloquer `raw.githubusercontent.com` → fallback monogramme s'active après `onError`.
- [ ] Carnet : même comportement que Stock.
- [ ] Réglages → Mentions légales → carte « Crédits images » présente, lisible en FR + EN.
- [ ] Actions → déclencher manuellement « Enrich film catalog » via `workflow_dispatch` → la page du run affiche le rapport markdown en haut, et un notice « No catalog changes vs main » si pas de diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9yHkXFGj71maQ5QxLTNQN)_