### PR TITLE
feat(catalog): interface admin pour le référentiel des pellicules

### DIFF
--- a/supabase/migrations/20260509000000_catalog_admin.sql
+++ b/supabase/migrations/20260509000000_catalog_admin.sql
@@ -45,7 +45,12 @@ GRANT EXECUTE ON FUNCTION public.is_admin() TO anon;
 
 -- 3. Public catalog RPC (extended with new columns) -------------------------
 
-CREATE OR REPLACE FUNCTION public.get_film_catalog(p_since TIMESTAMPTZ DEFAULT NULL)
+-- DROP first: the original function returned SETOF catalog_film_stocks; we
+-- want a custom TABLE shape that excludes image_path. Postgres rejects the
+-- return-type change via CREATE OR REPLACE.
+DROP FUNCTION IF EXISTS public.get_film_catalog(TIMESTAMPTZ);
+
+CREATE FUNCTION public.get_film_catalog(p_since TIMESTAMPTZ DEFAULT NULL)
 RETURNS TABLE (
     id INTEGER,
     brand TEXT,


### PR DESCRIPTION
## Contexte

Les PR #142 / #143 ont introduit un pipeline d'auto-enrichment qui télécharge les images de pellicules depuis 2 dépôts GitHub externes (`dekuNukem/Film-Packaging` + `dxdatabase/Open-source-film-database`). Le rendu visuel est hétéroclite (styles, qualités et formats variables selon la source) et il n'y a aucun moyen de curer le catalogue. Cette PR remplace ce pipeline par une interface admin qui permet d'éditer directement la table `catalog_film_stocks` et d'uploader des images choisies.

## Changements

### Backend (`supabase/migrations/20260509000000_catalog_admin.sql`)
- Colonnes `image_url`, `image_path`, `development_process` sur `catalog_film_stocks`
- Flag `is_admin BOOLEAN` sur `user_profiles`, RPC helper `is_admin()`
- RPCs admin (gardés par `is_admin()`) : `get_film_catalog_admin`, `admin_upsert_film_stock`, `admin_archive_film_stock`
- `get_film_catalog` (DROP+CREATE) étendu avec les nouvelles colonnes
- Bucket Storage `catalog-images` (public read, admin-only write via RLS)
- Backfill du `development_process` depuis l'ancien sidecar (74 entrées)

### Frontend
- `src/screens/AdminCatalogScreen.tsx` — liste groupée par marque, recherche, toggle archivés, ajout/édition/archivage
- `src/components/AdminFilmDialog.tsx` — formulaire avec preview live `FilmLabel` + upload Supabase Storage
- `src/utils/admin-catalog.ts` — RPCs CRUD + upload + helpers
- `src/utils/use-is-admin.ts` — hook qui re-vérifie à chaque session
- `SettingsScreen` — nouvelle Card "Administration" visible uniquement si `is_admin = true`
- `App.tsx` + `AppHeader.tsx` + `types.ts` — nouvelle ScreenName `adminCatalog`
- `catalog.ts` — suppression de la logique enrichment/discoveries, lecture directe des nouvelles colonnes

### Suppressions
- `scripts/enrich-catalog.ts`
- `.github/workflows/enrich-catalog.yml`
- `src/constants/film-catalog-enrichment.json`
- `src/constants/film-catalog-discoveries.json`

## Bootstrap admin

Après application de la migration, exécuter une fois en SQL :

```sql
UPDATE user_profiles SET is_admin = true
WHERE auth_uid = (SELECT id FROM auth.users WHERE email = '<ton email>');
```

## Test plan

- [ ] La migration passe sur Supabase (DROP+CREATE de `get_film_catalog` ✓ déjà corrigé en commit 90b1ff5)
- [ ] Bootstrap admin appliqué sur ton compte
- [ ] Section "Administration" visible dans Settings une fois connecté
- [ ] Liste admin affiche tous les films (toggle archivés OK)
- [ ] Ajout d'une pellicule + upload image → visible dans Stock / Carnet / FilmDetail
- [ ] Édition d'une pellicule existante → autocomplete dans `AddFilmDialog` reflète la modif
- [ ] Archivage → disparition côté autocomplete utilisateur, restauration possible depuis l'admin
- [ ] Compte non-admin : section cachée + RPC `admin_*` rejeté côté serveur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aby3fPL5Dxe9yjf6Cz3zA3)_