### PR TITLE
feat(dashboard): sections repliables par statut (actives, labo, à numériser)

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Vérifier un changement FilmVault en pilotant l'app réelle (Vite + Playwright, données seedées dans localStorage).
+---
+
+# Vérifier FilmVault
+
+## Lancer l'app
+
+```bash
+npm ci                 # si node_modules absent
+npm run dev            # Vite sur http://localhost:5173 (laisser tourner en arrière-plan)
+```
+
+## Piloter avec Playwright
+
+Écrire un spec dans `e2e/` (le `playwright.config.ts` réutilise le dev server déjà lancé hors CI) :
+
+```bash
+npx playwright test e2e/mon-spec.spec.ts --project="Mobile Chrome" --reporter=list
+```
+
+- Seeder les données AVANT le boot via `page.addInitScript` sur la clé `localStorage["filmvault-data"]`.
+  Réutiliser `createDemoData()` (`src/tour/demo-data.ts`) ou `e2e/fixtures/seed.ts` (couvre les états loaded/partial/exposed/developed/scanned ; ajouter un film avec `actionCode: "sent_dev"` pour la variante « au labo »).
+- L'écran de bienvenue peut apparaître : cliquer le bouton `/continuer|locale|sans/i` s'il est visible.
+- Locale : `localStorage["filmvault-locale"]` = `"fr"` | `"en"`.
+
+## Pièges
+
+- **Navigateurs** : si le Playwright du repo est plus récent que les navigateurs préinstallés (`Executable doesn't exist at .../chromium_headless_shell-XXXX/...`), créer une structure compatible pointant sur le chromium préinstallé :
+  ```bash
+  mkdir -p ~/pw-compat/chromium_headless_shell-XXXX/chrome-headless-shell-linux64
+  ln -s /opt/pw-browsers/chromium ~/pw-compat/chromium_headless_shell-XXXX/chrome-headless-shell-linux64/chrome-headless-shell
+  touch ~/pw-compat/chromium_headless_shell-XXXX/{INSTALLATION_COMPLETE,DEPENDENCIES_VALIDATED}
+  PLAYWRIGHT_BROWSERS_PATH=~/pw-compat npx playwright test ...
+  ```
+- **`addInitScript` persiste à travers les `page.reload()`** : il re-seede les données à chaque navigation. Pour tester un autre jeu de données, ouvrir une nouvelle page (`page.context().newPage()`).
+- **Deux `<main>` imbriqués** sur l'accueil : utiliser `page.locator("main").last()`.
+- **`toBeVisible()` ignore le clipping `overflow-hidden`** des sections repliées : vérifier plutôt `clientHeight === 0` du panneau (`aria-controls`).
+- Les specs `e2e/select-in-dialog.spec.ts` peuvent échouer localement avec le chromium compat (préexistant, passent en CI).
+
+## Captures
+
+`page.screenshot({ path: ..., fullPage: true })` vers le scratchpad, puis les lire/envoyer. `npm run screenshots` régénère les captures officielles de `docs/screenshots/`.

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -11,7 +11,7 @@ Pour le routing et la propagation du state, voir `docs/architecture.md`.
 Accueil « Carnet » : trois sections repliables par statut (état de repli persisté dans `localStorage["filmvault-carnet-collapsed"]`, section masquée quand vide) suivies du journal chronologique filtré par année (chips dans le header) :
 
 1. **Pellicules actives** — films `loaded`/`partial` (chargées d'abord, puis date de dernière action décroissante)
-2. **Labo** — films `exposed` (le badge de `CarnetFilmCard` distingue « exposée » de « au labo » via l'historique `sent_dev`)
+2. **À développer** — films `exposed` (le badge de `CarnetFilmCard` distingue « exposée » de « au labo » via l'historique `sent_dev`)
 3. **À numériser** — films `developed`
 
 **Props**

--- a/docs/screens.md
+++ b/docs/screens.md
@@ -8,14 +8,18 @@ Pour le routing et la propagation du state, voir `docs/architecture.md`.
 
 `src/screens/DashboardScreen.tsx`
 
-Accueil : pellicules actives (chargées/partielles), équipement chargé, stats rapides, section « À faire » (dev/scan).
+Accueil « Carnet » : trois sections repliables par statut (état de repli persisté dans `localStorage["filmvault-carnet-collapsed"]`, section masquée quand vide) suivies du journal chronologique filtré par année (chips dans le header) :
+
+1. **Pellicules actives** — films `loaded`/`partial` (chargées d'abord, puis date de dernière action décroissante)
+2. **Labo** — films `exposed` (le badge de `CarnetFilmCard` distingue « exposée » de « au labo » via l'historique `sent_dev`)
+3. **À numériser** — films `developed`
 
 **Props**
 ```ts
-{ data, setScreen, setSelectedFilm, onAddFilm, setAutoOpenShotNote?, onNavigateToStock }
+{ data, onOpenFilm, onOpenSettings? }
 ```
 
-**Composants exploités** : `ActiveRollCard`, `EquipmentCard`, `StatCard`, `StatChip`, `TodoItem`, `EmptyState`.
+**Composants exploités** : `CarnetFilmCard`, `EmptyState`, `Chip`, `PageHeader`.
 
 ## `StockScreen` — `stock`
 

--- a/e2e/carnet-sections.spec.ts
+++ b/e2e/carnet-sections.spec.ts
@@ -61,16 +61,16 @@ test.describe("carnet status sections", () => {
 		await seedAndOpen(page);
 
 		const activeBtn = page.getByRole("button", { name: /^Pellicules actives/ }).first();
-		const labBtn = page.getByRole("button", { name: /^Labo/ }).first();
+		const devBtn = page.getByRole("button", { name: /^À développer/ }).first();
 		const scanBtn = page.getByRole("button", { name: /^À numériser/ }).first();
 		await expect(activeBtn).toBeVisible();
 		await expect(activeBtn).toContainText("2");
-		await expect(labBtn).toBeVisible();
-		await expect(labBtn).toContainText("2");
+		await expect(devBtn).toBeVisible();
+		await expect(devBtn).toContainText("2");
 		await expect(scanBtn).toBeVisible();
 		await expect(scanBtn).toContainText("1");
 
-		// The Labo section mixes both variants: exposed (to drop off) and at the lab (sent_dev).
+		// The "À développer" section mixes both variants: exposed (to drop off) and at the lab (sent_dev).
 		const mainText = (await page.locator("main").last().innerText()).toLowerCase();
 		expect(mainText).toContain("exposée");
 		expect(mainText).toContain("au labo");
@@ -83,26 +83,26 @@ test.describe("carnet status sections", () => {
 	test("collapses, persists across reload, and re-expands", async ({ page }) => {
 		await seedAndOpen(page);
 
-		const labBtn = page.getByRole("button", { name: /^Labo/ }).first();
-		await expect(labBtn).toHaveAttribute("aria-expanded", "true");
-		await labBtn.click();
-		await expect(labBtn).toHaveAttribute("aria-expanded", "false");
+		const devBtn = page.getByRole("button", { name: /^À développer/ }).first();
+		await expect(devBtn).toHaveAttribute("aria-expanded", "true");
+		await devBtn.click();
+		await expect(devBtn).toHaveAttribute("aria-expanded", "false");
 
 		// The collapsible panel actually closes (clipped to zero height).
-		const panelId = await labBtn.getAttribute("aria-controls");
+		const panelId = await devBtn.getAttribute("aria-controls");
 		await expect
 			.poll(async () => page.evaluate((id) => document.getElementById(id as string)?.clientHeight ?? -1, panelId))
 			.toBe(0);
 
 		await page.reload();
 		await page.waitForLoadState("networkidle");
-		const labBtn2 = page.getByRole("button", { name: /^Labo/ }).first();
-		await expect(labBtn2).toHaveAttribute("aria-expanded", "false");
+		const devBtn2 = page.getByRole("button", { name: /^À développer/ }).first();
+		await expect(devBtn2).toHaveAttribute("aria-expanded", "false");
 		const stored = await page.evaluate(() => window.localStorage.getItem("filmvault-carnet-collapsed"));
-		expect(stored).toBe('{"lab":true}');
+		expect(stored).toBe('{"dev":true}');
 
-		await labBtn2.click();
-		await expect(labBtn2).toHaveAttribute("aria-expanded", "true");
+		await devBtn2.click();
+		await expect(devBtn2).toHaveAttribute("aria-expanded", "true");
 	});
 
 	test("hides empty sections", async ({ page }) => {
@@ -114,6 +114,6 @@ test.describe("carnet status sections", () => {
 
 		await expect(page.getByRole("button", { name: /^À numériser/ }).first()).toBeVisible();
 		await expect(page.getByRole("button", { name: /^Pellicules actives/ })).toHaveCount(0);
-		await expect(page.getByRole("button", { name: /^Labo/ })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: /^À développer/ })).toHaveCount(0);
 	});
 });

--- a/e2e/carnet-sections.spec.ts
+++ b/e2e/carnet-sections.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+import type { Film } from "../src/types";
+import { createDemoData } from "../src/tour/demo-data";
+
+function daysAgoISO(n: number) {
+	const d = new Date();
+	d.setDate(d.getDate() - n);
+	return d.toISOString();
+}
+
+/** Demo data plus an exposed film already sent to the lab (sent_dev history + lab set). */
+function buildData() {
+	const data = createDemoData();
+	data.films.push({
+		id: "test-film-atlab",
+		brand: "Fujifilm",
+		model: "Velvia 50",
+		iso: 50,
+		type: "Diapo",
+		format: "120",
+		state: "exposed",
+		lab: "Nation Photo",
+		labRef: "NP-2214",
+		addedDate: daysAgoISO(40),
+		posesShot: 12,
+		posesTotal: 12,
+		history: [
+			{ date: daysAgoISO(40), action: "", actionCode: "added" },
+			{ date: daysAgoISO(20), action: "", actionCode: "exposed" },
+			{ date: daysAgoISO(10), action: "", actionCode: "sent_dev", params: { lab: "Nation Photo" } },
+		],
+	});
+	return data;
+}
+
+async function seedAndOpen(page: import("@playwright/test").Page, films?: Film[]) {
+	const data = buildData();
+	if (films) data.films = films;
+	await page.addInitScript(
+		([payload]) => {
+			window.localStorage.setItem("filmvault-data", payload as string);
+		},
+		[JSON.stringify(data)],
+	);
+	await page.goto("/");
+	const continueBtn = page.getByRole("button", { name: /continuer|locale|sans/i });
+	if (
+		await continueBtn
+			.first()
+			.isVisible({ timeout: 2500 })
+			.catch(() => false)
+	) {
+		await continueBtn.first().click();
+	}
+	await page.waitForLoadState("networkidle");
+	return data;
+}
+
+test.describe("carnet status sections", () => {
+	test("shows the three sections with counts and state badges", async ({ page }) => {
+		await seedAndOpen(page);
+
+		const activeBtn = page.getByRole("button", { name: /^Pellicules actives/ }).first();
+		const labBtn = page.getByRole("button", { name: /^Labo/ }).first();
+		const scanBtn = page.getByRole("button", { name: /^À numériser/ }).first();
+		await expect(activeBtn).toBeVisible();
+		await expect(activeBtn).toContainText("2");
+		await expect(labBtn).toBeVisible();
+		await expect(labBtn).toContainText("2");
+		await expect(scanBtn).toBeVisible();
+		await expect(scanBtn).toContainText("1");
+
+		// The Labo section mixes both variants: exposed (to drop off) and at the lab (sent_dev).
+		const mainText = (await page.locator("main").last().innerText()).toLowerCase();
+		expect(mainText).toContain("exposée");
+		expect(mainText).toContain("au labo");
+		expect(mainText).toContain("développée");
+
+		// Films still appear in the year journal below (chronological log keeps everything).
+		expect((mainText.match(/superia 400/g) || []).length).toBeGreaterThanOrEqual(2);
+	});
+
+	test("collapses, persists across reload, and re-expands", async ({ page }) => {
+		await seedAndOpen(page);
+
+		const labBtn = page.getByRole("button", { name: /^Labo/ }).first();
+		await expect(labBtn).toHaveAttribute("aria-expanded", "true");
+		await labBtn.click();
+		await expect(labBtn).toHaveAttribute("aria-expanded", "false");
+
+		// The collapsible panel actually closes (clipped to zero height).
+		const panelId = await labBtn.getAttribute("aria-controls");
+		await expect
+			.poll(async () => page.evaluate((id) => document.getElementById(id as string)?.clientHeight ?? -1, panelId))
+			.toBe(0);
+
+		await page.reload();
+		await page.waitForLoadState("networkidle");
+		const labBtn2 = page.getByRole("button", { name: /^Labo/ }).first();
+		await expect(labBtn2).toHaveAttribute("aria-expanded", "false");
+		const stored = await page.evaluate(() => window.localStorage.getItem("filmvault-carnet-collapsed"));
+		expect(stored).toBe('{"lab":true}');
+
+		await labBtn2.click();
+		await expect(labBtn2).toHaveAttribute("aria-expanded", "true");
+	});
+
+	test("hides empty sections", async ({ page }) => {
+		const data = buildData();
+		await seedAndOpen(
+			page,
+			data.films.filter((f) => f.state === "developed"),
+		);
+
+		await expect(page.getByRole("button", { name: /^À numériser/ }).first()).toBeVisible();
+		await expect(page.getByRole("button", { name: /^Pellicules actives/ })).toHaveCount(0);
+		await expect(page.getByRole("button", { name: /^Labo/ })).toHaveCount(0);
+	});
+});

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -71,6 +71,8 @@ export const en = {
 		partiallyExposed_other: "{{count}} partially exposed films",
 		myEquipment: "My equipment",
 		activeRolls: "Active rolls",
+		labSection: "Lab",
+		scanSection: "To scan",
 		todoSection: "To do",
 		awaitingDev_one: "{{count}} film to develop",
 		awaitingDev_other: "{{count}} films to develop",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -71,7 +71,7 @@ export const en = {
 		partiallyExposed_other: "{{count}} partially exposed films",
 		myEquipment: "My equipment",
 		activeRolls: "Active rolls",
-		labSection: "Lab",
+		devSection: "To develop",
 		scanSection: "To scan",
 		todoSection: "To do",
 		awaitingDev_one: "{{count}} film to develop",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -71,6 +71,8 @@ export const fr = {
 		partiallyExposed_other: "{{count}} pellicules partiellement exposées",
 		myEquipment: "Mon équipement",
 		activeRolls: "Pellicules actives",
+		labSection: "Labo",
+		scanSection: "À numériser",
 		todoSection: "À faire",
 		awaitingDev_one: "{{count}} pellicule à développer",
 		awaitingDev_other: "{{count}} pellicules à développer",

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -71,7 +71,7 @@ export const fr = {
 		partiallyExposed_other: "{{count}} pellicules partiellement exposées",
 		myEquipment: "Mon équipement",
 		activeRolls: "Pellicules actives",
-		labSection: "Labo",
+		devSection: "À développer",
 		scanSection: "À numériser",
 		todoSection: "À faire",
 		awaitingDev_one: "{{count}} pellicule à développer",

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -103,7 +103,7 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 			.map(({ film }) => film);
 	}, [films]);
 
-	const labFilms = useMemo(() => sortByLastActionDesc(films.filter((f) => f.state === "exposed")), [films]);
+	const devFilms = useMemo(() => sortByLastActionDesc(films.filter((f) => f.state === "exposed")), [films]);
 
 	const scanFilms = useMemo(() => sortByLastActionDesc(films.filter((f) => f.state === "developed")), [films]);
 
@@ -142,7 +142,7 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 
 	const statusSections: Array<{ id: string; title: string; films: Film[] }> = [
 		{ id: "active", title: t("dashboard.activeRolls"), films: activeFilms },
-		{ id: "lab", title: t("dashboard.labSection"), films: labFilms },
+		{ id: "dev", title: t("dashboard.devSection"), films: devFilms },
 		{ id: "scan", title: t("dashboard.scanSection"), films: scanFilms },
 	].filter((s) => s.films.length > 0);
 

--- a/src/screens/DashboardScreen.tsx
+++ b/src/screens/DashboardScreen.tsx
@@ -1,5 +1,5 @@
-import { Film as FilmIcon, Settings } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, Film as FilmIcon, Settings } from "lucide-react";
+import { type ReactNode, useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CarnetFilmCard } from "@/components/CarnetFilmCard";
 import { EmptyState } from "@/components/EmptyState";
@@ -8,6 +8,7 @@ import { PageHeader } from "@/components/ui/page-header";
 import { cn } from "@/lib/utils";
 import type { AppData, Film, FilmState } from "@/types";
 import { filmLastActionDate } from "@/utils/film-helpers";
+import { usePersistedState } from "@/utils/use-persisted-state";
 
 interface DashboardScreenProps {
 	data: AppData;
@@ -18,9 +19,67 @@ interface DashboardScreenProps {
 const CARNET_STATES: ReadonlySet<FilmState> = new Set(["loaded", "partial", "exposed", "developed", "scanned"]);
 const ACTIVE_STATE_ORDER: Record<string, number> = { loaded: 0, partial: 1 };
 
+interface CarnetSectionProps {
+	title: string;
+	count: number;
+	collapsed: boolean;
+	onToggle: () => void;
+	children: ReactNode;
+}
+
+function CarnetSection({ title, count, collapsed, onToggle, children }: CarnetSectionProps) {
+	const panelId = useId();
+
+	return (
+		<section className="flex flex-col" aria-label={title}>
+			<button
+				type="button"
+				onClick={onToggle}
+				aria-expanded={!collapsed}
+				aria-controls={panelId}
+				className="flex items-center gap-2 w-full cursor-pointer text-left"
+			>
+				<span className="w-1.5 h-1.5 rounded-full bg-accent flex-none" />
+				<h2 className="text-sm font-semibold text-text flex-1">{title}</h2>
+				<span className="text-sm font-medium text-text-3">{count}</span>
+				<ChevronDown
+					size={15}
+					className={cn("text-text-3 flex-none transition-transform duration-200", collapsed && "-rotate-90")}
+				/>
+			</button>
+			<div
+				id={panelId}
+				className={cn(
+					"grid transition-[grid-template-rows] duration-200 ease-out",
+					collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+				)}
+			>
+				<div className="overflow-hidden min-h-0">
+					<div className="flex flex-col gap-[18px] pt-[14px]">{children}</div>
+				</div>
+			</div>
+		</section>
+	);
+}
+
+function sortByLastActionDesc(films: Film[]): Film[] {
+	return films
+		.map((film) => ({ film, lastDate: filmLastActionDate(film) ?? "" }))
+		.sort((a, b) => b.lastDate.localeCompare(a.lastDate))
+		.map(({ film }) => film);
+}
+
 export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardScreenProps) {
 	const { t } = useTranslation();
 	const { films, cameras } = data;
+	const [collapsedSections, setCollapsedSections] = usePersistedState<Record<string, boolean>>(
+		"filmvault-carnet-collapsed",
+		{},
+	);
+
+	const toggleSection = (id: string) => {
+		setCollapsedSections((prev) => ({ ...prev, [id]: !prev[id] }));
+	};
 
 	const datedFilms = useMemo(() => {
 		const list: Array<{ film: Film; lastDate: string }> = [];
@@ -43,6 +102,10 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 			})
 			.map(({ film }) => film);
 	}, [films]);
+
+	const labFilms = useMemo(() => sortByLastActionDesc(films.filter((f) => f.state === "exposed")), [films]);
+
+	const scanFilms = useMemo(() => sortByLastActionDesc(films.filter((f) => f.state === "developed")), [films]);
 
 	const yearBuckets = useMemo(() => {
 		const map = new Map<string, number>();
@@ -76,6 +139,12 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 			.sort((a, b) => b.lastDate.localeCompare(a.lastDate))
 			.map(({ film }) => film);
 	}, [datedFilms, selectedYear]);
+
+	const statusSections: Array<{ id: string; title: string; films: Film[] }> = [
+		{ id: "active", title: t("dashboard.activeRolls"), films: activeFilms },
+		{ id: "lab", title: t("dashboard.labSection"), films: labFilms },
+		{ id: "scan", title: t("dashboard.scanSection"), films: scanFilms },
+	].filter((s) => s.films.length > 0);
 
 	return (
 		<div className="-mx-4 md:-mx-8">
@@ -124,22 +193,21 @@ export function DashboardScreen({ data, onOpenFilm, onOpenSettings }: DashboardS
 			</PageHeader>
 
 			<main className="px-[18px] pt-8 pb-32 flex flex-col gap-[18px]">
-				{activeFilms.length > 0 && (
-					<section className="flex flex-col gap-[18px]" aria-label={t("dashboard.activeRolls")}>
-						<header className="flex items-center justify-between">
-							<h2 className="text-sm font-semibold flex items-center gap-2 text-text">
-								<span className="w-1.5 h-1.5 rounded-full bg-accent" />
-								{t("dashboard.activeRolls")}
-							</h2>
-							<span className="text-sm font-medium text-text-3">{activeFilms.length}</span>
-						</header>
-						{activeFilms.map((f, idx) => {
+				{statusSections.map(({ id, title, films: sectionFilms }) => (
+					<CarnetSection
+						key={id}
+						title={title}
+						count={sectionFilms.length}
+						collapsed={collapsedSections[id] ?? false}
+						onToggle={() => toggleSection(id)}
+					>
+						{sectionFilms.map((f, idx) => {
 							const cam = f.cameraId ? cameras.find((c) => c.id === f.cameraId) : null;
 							return <CarnetFilmCard key={f.id} film={f} camera={cam} index={idx} onClick={() => onOpenFilm(f.id)} />;
 						})}
-						<hr className="border-0 border-t border-dashed border-ink-faded/35" />
-					</section>
-				)}
+					</CarnetSection>
+				))}
+				{statusSections.length > 0 && <hr className="border-0 border-t border-dashed border-ink-faded/35" />}
 				{visible.length === 0 ? (
 					<EmptyState
 						icon={FilmIcon}


### PR DESCRIPTION
Le Carnet affiche désormais trois sections repliables au-dessus du journal
annuel : Pellicules actives (loaded/partial), Labo (exposed — le badge de
chaque carte distingue « exposée » de « au labo ») et À numériser (developed).
Chaque section montre son compteur, se replie d'un tap (état persisté dans
localStorage "filmvault-carnet-collapsed") et est masquée quand elle est vide.

Ajout d'un spec e2e couvrant compteurs, badges, repli/persistance et sections
vides ; mise à jour de docs/screens.md (entrée Dashboard périmée).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RKwgQ7fAAuByYKzdENnihd