### PR TITLE
ci: add daily Supabase keep-alive workflow

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,24 @@
+name: Supabase keep-alive
+
+on:
+  schedule:
+    # Tous les jours à 06:00 UTC — garde le projet Supabase (offre gratuite)
+    # actif en évitant la pause après ~7 jours d'inactivité.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase (lecture publique du catalogue)
+        env:
+          SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: |
+          curl --fail --silent --show-error \
+            "${SUPABASE_URL}/rest/v1/catalog_cameras?select=id&limit=1" \
+            -H "apikey: ${SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}"


### PR DESCRIPTION
Prevents the free-tier Supabase project from pausing after ~7 days of
inactivity by making a lightweight public read (catalog_cameras) once a
day. Reuses the existing VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY
secrets; no data is modified.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015E48K6Mm8DcuhYnfKT3qrZ